### PR TITLE
fix bug with comments to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@
 ![Static Badge](https://img.shields.io/badge/Python-3.12-blue)
 ![Static Badge](https://img.shields.io/badge/ROS2-jazzy-blue)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-[comment]: # TODO: These will only work once the repo is public and CI and releases are configured on the public repo. Uncomment them then
-[comment]: # ![GitHub Release](https://img.shields.io/github/v/release/RobotecAI/rai)
-[comment]: # ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/RobotecAI/rai/poetry-test.yml)
+![GitHub Release](https://img.shields.io/github/v/release/RobotecAI/rai)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/RobotecAI/rai/poetry-test.yml)
 
 Welcome to the RAI Framework repository! We are dedicated to advancing robotics by integrating Generative AI to enable intelligent task fulfillment and enhance conventional algorithms.
 


### PR DESCRIPTION
Make the release and CI badges simply visible, in the private repo it's not an issue and they should start working immediatly once CI passes on the public repo and we publish the release.