### PR TITLE
remove build badge until jenkins is setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![GitHub Release](https://img.shields.io/github/v/release/RobotecAI/rai)
-![GitHub branch check runs](https://img.shields.io/github/check-runs/RobotecAI/rai/development)
 ![Contributors](https://img.shields.io/github/contributors/robotecai/rai)
 
 ![Static Badge](https://img.shields.io/badge/Ubuntu-24.04-orange)


### PR DESCRIPTION
## Purpose

remove build badge until jenkins is setup

## Proposed Changes

remove build badge until jenkins is setup

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
