### PR TITLE
style: remove additional hash after license header

### DIFF
--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 
 import rclpy

--- a/src/rai/rai/__init__.py
+++ b/src/rai/rai/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 from rai.apps.high_level_api import ROS2Agent
 
 __all__ = ["ROS2Agent"]

--- a/src/rai/rai/agents/__init__.py
+++ b/src/rai/rai/agents/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/agents/conversational_agent.py
+++ b/src/rai/rai/agents/conversational_agent.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import logging
 from functools import partial

--- a/src/rai/rai/agents/state_based.py
+++ b/src/rai/rai/agents/state_based.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import logging
 import time

--- a/src/rai/rai/apps/__init__.py
+++ b/src/rai/rai/apps/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/apps/document_loader.py
+++ b/src/rai/rai/apps/document_loader.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional, Type

--- a/src/rai/rai/apps/high_level_api.py
+++ b/src/rai/rai/apps/high_level_api.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import List, Literal
 

--- a/src/rai/rai/apps/state_analyzer.py
+++ b/src/rai/rai/apps/state_analyzer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate

--- a/src/rai/rai/apps/talk_to_docs.py
+++ b/src/rai/rai/apps/talk_to_docs.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import logging
 import operator

--- a/src/rai/rai/apps/task_executor.py
+++ b/src/rai/rai/apps/task_executor.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import logging
 import time

--- a/src/rai/rai/apps/task_planner.py
+++ b/src/rai/rai/apps/task_planner.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate

--- a/src/rai/rai/cli/__init__.py
+++ b/src/rai/rai/cli/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/cli/rai_cli.py
+++ b/src/rai/rai/cli/rai_cli.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import argparse
 import glob

--- a/src/rai/rai/config/__init__.py
+++ b/src/rai/rai/config/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/config/models.py
+++ b/src/rai/rai/config/models.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import Literal, TypedDict
 

--- a/src/rai/rai/extensions/__init__.py
+++ b/src/rai/rai/extensions/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/extensions/navigator.py
+++ b/src/rai/rai/extensions/navigator.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import rclpy
 from builtin_interfaces.msg import Duration

--- a/src/rai/rai/messages/__init__.py
+++ b/src/rai/rai/messages/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from .multimodal import (
     AiMultimodalMessage,

--- a/src/rai/rai/messages/multimodal.py
+++ b/src/rai/rai/messages/multimodal.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 

--- a/src/rai/rai/messages/utils.py
+++ b/src/rai/rai/messages/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 from typing import Any, Callable, Union

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import functools
 import time

--- a/src/rai/rai/tools/__init__.py
+++ b/src/rai/rai/tools/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from .cli import Ros2InterfaceTool, Ros2ServiceTool, Ros2TopicTool
 from .tools import (

--- a/src/rai/rai/tools/ros/cli.py
+++ b/src/rai/rai/tools/ros/cli.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import subprocess
 from typing import Type

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import json
 from typing import Any, Dict, OrderedDict, Tuple, Type

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import Any, Dict, Optional, Tuple, Type
 

--- a/src/rai/rai/tools/ros/tools.py
+++ b/src/rai/rai/tools/ros/tools.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 import json

--- a/src/rai/rai/tools/ros/utils.py
+++ b/src/rai/rai/tools/ros/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 from typing import Type, Union, cast

--- a/src/rai/rai/tools/time.py
+++ b/src/rai/rai/tools/time.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import time
 from typing import Type

--- a/src/rai/rai/tools/utils.py
+++ b/src/rai/rai/tools/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 import logging

--- a/src/rai/setup.py
+++ b/src/rai/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from setuptools import find_packages, setup
 

--- a/src/rai_asr/launch/transcribe.launch.py
+++ b/src/rai_asr/launch/transcribe.launch.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument

--- a/src/rai_asr/rai_asr/__init__.py
+++ b/src/rai_asr/rai_asr/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai_asr/rai_asr/asr_node.py
+++ b/src/rai_asr/rai_asr/asr_node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import io
 import threading

--- a/src/rai_asr/setup.py
+++ b/src/rai_asr/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 from glob import glob

--- a/src/rai_bringup/launch/hri.launch.py
+++ b/src/rai_bringup/launch/hri.launch.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from launch import LaunchDescription
 from launch.actions import (

--- a/src/rai_bringup/setup.py
+++ b/src/rai_bringup/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 from glob import glob

--- a/src/rai_grounding_dino/rai_grounding_dino/__init__.py
+++ b/src/rai_grounding_dino/rai_grounding_dino/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai_grounding_dino/rai_grounding_dino/boxer.py
+++ b/src/rai_grounding_dino/rai_grounding_dino/boxer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from os import PathLike
 from typing import Dict

--- a/src/rai_grounding_dino/rai_grounding_dino/config.py
+++ b/src/rai_grounding_dino/rai_grounding_dino/config.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 # Description: Configuration file for the groundingdino model.
 # Copyright: IDEA-Research

--- a/src/rai_grounding_dino/rai_grounding_dino/grounding_dino.py
+++ b/src/rai_grounding_dino/rai_grounding_dino/grounding_dino.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 import subprocess

--- a/src/rai_grounding_dino/rai_grounding_dino/talker.py
+++ b/src/rai_grounding_dino/rai_grounding_dino/talker.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import cv2
 import numpy as np

--- a/src/rai_grounding_dino/setup.py
+++ b/src/rai_grounding_dino/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 from glob import glob

--- a/src/rai_hmi/rai_hmi/__init__.py
+++ b/src/rai_hmi/rai_hmi/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai_hmi/rai_hmi/hmi_node.py
+++ b/src/rai_hmi/rai_hmi/hmi_node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import asyncio
 from typing import List

--- a/src/rai_hmi/rai_hmi/streamlit_hmi_node.py
+++ b/src/rai_hmi/rai_hmi/streamlit_hmi_node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 import sys

--- a/src/rai_hmi/rai_hmi/task.py
+++ b/src/rai_hmi/rai_hmi/task.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from enum import Enum
 

--- a/src/rai_hmi/rai_hmi/tools.py
+++ b/src/rai_hmi/rai_hmi/tools.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import Any, Type
 

--- a/src/rai_hmi/setup.py
+++ b/src/rai_hmi/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from setuptools import find_packages, setup
 

--- a/src/rai_tts/launch/elevenlabs.launch.py
+++ b/src/rai_tts/launch/elevenlabs.launch.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 

--- a/src/rai_tts/launch/opentts.launch.py
+++ b/src/rai_tts/launch/opentts.launch.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 

--- a/src/rai_tts/rai_tts/__init__.py
+++ b/src/rai_tts/rai_tts/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai_tts/rai_tts/tts_clients.py
+++ b/src/rai_tts/rai_tts/tts_clients.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 import tempfile

--- a/src/rai_tts/rai_tts/tts_node.py
+++ b/src/rai_tts/rai_tts/tts_node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import re
 import subprocess

--- a/src/rai_tts/setup.py
+++ b/src/rai_tts/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 from glob import glob

--- a/src/rai_whoami/rai_whoami/__init__.py
+++ b/src/rai_whoami/rai_whoami/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/src/rai_whoami/rai_whoami/rai_whoami_node.py
+++ b/src/rai_whoami/rai_whoami/rai_whoami_node.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import os
 

--- a/src/rai_whoami/setup.py
+++ b/src/rai_whoami/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from setuptools import find_packages, setup
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import glob
 import importlib

--- a/tests/smoke/import_test.py
+++ b/tests/smoke/import_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import importlib
 import os

--- a/tests/tools/test_multimodal.py
+++ b/tests/tools/test_multimodal.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import base64
 import os


### PR DESCRIPTION
Merge after #189 and #190
## Purpose

removing the additional hash after license header

## Tests
Tested with regex over all files 
```
grep -rPzo "# limitations under the License.\n#" .
```