### PR TITLE
fix: demo repo dir name

### DIFF
--- a/demos.repos
+++ b/demos.repos
@@ -1,5 +1,5 @@
 repositories:
-  src/examples/rosbot-xl-demo:
+  src/examples/rai-rosbot-xl-demo:
     type: git
     url: https://github.com/RobotecAI/rai-rosbot-xl-demo.git
     version: development

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -31,7 +31,7 @@ vcs import < demos.repos
 
 4. Start navigation stack:
    ```bash
-   ./src/examples/rosbot-xl-demo/run-nav.sh
+   ./src/examples/rai-rosbot-xl-demo/run-nav.sh
    ```
 
 ### Building the project yourself


### PR DESCRIPTION
## Purpose

Fix the name of the rosbot xl demo directory so it will be consistent across all repositories and instructions.

## Proposed Changes

Directory name for the cloned repo to be exact as the cloned repo name: `rosbot-xl-demo` -> `rai-rosbot-xl-demo`

## Testing

- Going through readme
