### PR TITLE
feat(`rai_node`): execute mission as ros2 action

### DIFF
--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -24,7 +24,7 @@ from langchain.tools.render import render_text_description_and_args
 from langchain_openai import ChatOpenAI
 
 from rai.agents.state_based import create_state_based_agent
-from rai.node import RaiNode, describe_ros_image, wait_for_2s
+from rai.node import RaiNode, describe_ros_image
 from rai.tools.ros.native import (
     GetCameraImage,
     GetMsgFromTopic,
@@ -32,6 +32,7 @@ from rai.tools.ros.native import (
 )
 from rai.tools.ros.native_actions import Ros2RunActionSync
 from rai.tools.ros.tools import GetOccupancyGridTool
+from rai.tools.time import WaitForSecondsTool
 
 
 def main():
@@ -84,7 +85,7 @@ def main():
     )
 
     tools = [
-        wait_for_2s,
+        WaitForSecondsTool(),
         GetMsgFromTopic(node=node),
         Ros2RunActionSync(node=node),
         GetCameraImage(node=node),

--- a/src/rai/rai/agents/state_based.py
+++ b/src/rai/rai/agents/state_based.py
@@ -303,7 +303,7 @@ def retriever_wrapper(
     info = str_output(retrieved_info)
     state["messages"].append(
         HumanMultimodalMessage(
-            content="Retrieved state: {}".format(info), images=images, audios=audios
+            content=f"Retrieved state: {info}", images=images, audios=audios
         )
     )
     return state

--- a/src/rai/rai/agents/state_based.py
+++ b/src/rai/rai/agents/state_based.py
@@ -17,6 +17,7 @@ import logging
 import pickle
 import time
 from functools import partial
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -84,15 +85,31 @@ class Report(BaseModel):
     )
 
 
-def get_stored_artifacts(tool_call_id: str) -> List[Any]:
-    with open("artifact_database.pkl", "rb") as file:
-        artifact_database = pickle.load(file)
+def get_stored_artifacts(
+    tool_call_id: str, db_path="artifact_database.pkl"
+) -> List[Any]:
+    # TODO(boczekbartek): refactor
+    db_path = Path(db_path)
+    if not db_path.is_file():
+        return []
+
+    with db_path.open("rb") as db:
+        artifact_database = pickle.load(db)
         if tool_call_id in artifact_database:
             return artifact_database[tool_call_id]
+
     return []
 
 
-def store_artifacts(tool_call_id: str, artifacts: List[Any]):
+def store_artifacts(
+    tool_call_id: str, artifacts: List[Any], db_path="artifact_database.pkl"
+):
+    # TODO(boczekbartek): refactor
+    db_path = Path(db_path)
+    if not db_path.is_file():
+        artifact_database = {}
+        with open("artifact_database.pkl", "wb") as file:
+            pickle.dump(artifact_database, file)
     with open("artifact_database.pkl", "rb") as file:
         artifact_database = pickle.load(file)
         if tool_call_id not in artifact_database:

--- a/src/rai/rai/agents/state_based.py
+++ b/src/rai/rai/agents/state_based.py
@@ -76,6 +76,9 @@ class Report(BaseModel):
     steps: List[str] = Field(
         ..., title="Steps", description="The steps taken to solve the problem"
     )
+    success: bool = Field(
+        ..., title="Success", description="Whether the problem was solved"
+    )
     response_to_user: str = Field(
         ..., title="Response", description="The response to the user"
     )

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -72,8 +72,6 @@ class Ros2BaseTool(BaseTool):
     node: rclpy.node.Node = Field(..., exclude=True, required=True)
 
     args_schema: Type[Ros2BaseInput] = Ros2BaseInput
-    handle_tool_error = True
-    handle_validation_error = True
 
     @property
     def logger(self) -> RcutilsLogger:

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -56,7 +56,7 @@ class Ros2GetActionNamesAndTypesTool(Ros2BaseTool):
 class Ros2RunActionSync(Ros2BaseTool):
     name: str = "Ros2RunAction"
     description: str = (
-        "A tool for running a ros2 action. Actions might take some time to execute and are blocking - you will not be able to check their feedback, only will be informed about the result"
+        "A tool for running a ros2 action. Make sure you know the action interface first!!! Actions might take some time to execute and are blocking - you will not be able to check their feedback, only will be informed about the result"
     )
 
     args_schema: Type[Ros2ActionRunnerInput] = Ros2ActionRunnerInput

--- a/src/rai/rai/tools/time.py
+++ b/src/rai/rai/tools/time.py
@@ -17,17 +17,7 @@ import time
 from typing import Type
 
 from langchain.pydantic_v1 import BaseModel, Field
-from langchain.tools import tool
 from langchain_core.tools import BaseTool
-
-
-@tool
-def sleep_max_5s(n: int):
-    """Wait n seconds, max 5s"""
-    if n > 5:
-        n = 5
-
-    time.sleep(n)
 
 
 class WaitForSecondsToolInput(BaseModel):
@@ -44,11 +34,14 @@ class WaitForSecondsTool(BaseTool):
         "A tool for waiting. "
         "Useful for pausing execution for a specified number of seconds. "
         "Input should be the number of seconds to wait."
+        "Maximum allowed time is 5 seconds"
     )
 
     args_schema: Type[WaitForSecondsToolInput] = WaitForSecondsToolInput
 
     def _run(self, seconds: int):
         """Waits for the specified number of seconds."""
+        if seconds > 5:
+            seconds = 5
         time.sleep(seconds)
         return f"Waited for {seconds} seconds."

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -1,0 +1,76 @@
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, List, Optional, Tuple
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.prompts import ChatPromptTemplate
+
+
+class RosoutBuffer:
+    def __init__(self, llm: BaseChatModel, bufsize: int = 100) -> None:
+        self.bufsize = bufsize
+        self._buffer: Deque[str] = deque()
+        self.template = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "Shorten the following log keeping its format - for example merge simillar or repeating lines",
+                ),
+                ("human", "{rosout}"),
+            ]
+        )
+        llm = llm
+        self.llm = self.template | llm
+
+    def clear(self):
+        self._buffer.clear()
+
+    def append(self, line: str):
+        self._buffer.append(line)
+        if len(self._buffer) > self.bufsize:
+            self._buffer.popleft()
+
+    def get_raw_logs(self, last_n: int = 30) -> str:
+        return "\n".join(list(self._buffer)[-last_n:])
+
+    def summarize(self):
+        if len(self._buffer) == 0:
+            return "No logs"
+        buffer = self.get_raw_logs()
+        response = self.llm.invoke({"rosout": buffer})
+        return str(response.content)
+
+
+@dataclass
+class NodeDiscovery:
+    topics_and_types: Dict[str, str] = field(default_factory=dict)
+    services_and_types: Dict[str, str] = field(default_factory=dict)
+    actions_and_types: Dict[str, str] = field(default_factory=dict)
+    whitelist: Optional[List[str]] = field(default_factory=list)
+
+    def set(self, topics, services, actions):
+        def to_dict(info: List[Tuple[str, List[str]]]) -> Dict[str, str]:
+            return {k: v[0] for k, v in info}
+
+        self.topics_and_types = to_dict(topics)
+        self.services_and_types = to_dict(services)
+        self.actions_and_types = to_dict(actions)
+        if self.whitelist is not None:
+            self.__filter(self.whitelist)
+
+    def __filter(self, whitelist: List[str]):
+        for d in [
+            self.topics_and_types,
+            self.services_and_types,
+            self.actions_and_types,
+        ]:
+            to_remove = [k for k in d if k not in whitelist]
+            for k in to_remove:
+                d.pop(k)
+
+    def dict(self):
+        return {
+            "topics_and_types": self.topics_and_types,
+            "services_and_types": self.services_and_types,
+            "actions_and_types": self.actions_and_types,
+        }

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Deque, Dict, List, Optional, Tuple

--- a/src/rai_hmi/rai_hmi/text_hmi.py
+++ b/src/rai_hmi/rai_hmi/text_hmi.py
@@ -228,8 +228,9 @@ def display_agent_message(
         return  # we do not handle system messages
     elif isinstance(message, MissionMessage):
         logger.info("Displaying mission message")
-        avatar, content = message.render_steamlit()
-        st.chat_message("bot", avatar=avatar).markdown(content)
+        with st.expander(label=message.STATUS):
+            avatar, content = message.render_steamlit()
+            st.chat_message("bot", avatar=avatar).markdown(content)
     else:
         raise ValueError("Unknown message type")
 


### PR DESCRIPTION
## Purpose

- This PR adds support for the execution of missions as ros2 actions.

## Proposed Changes

- implement mission in `rai_node` as ros2 actions. Action server is `/perform_task`.
- refactor `src/rai/rai/node.py`
- add expanders in streamlit UI for mission messages
- slightly adjusted prompts

## Issues

- https://github.com/RobotecAI/rai/issues/169

## Testing
Terminal 1
```bash
. ./setup_shell.sh
ros2 run rai_whoami rai_whoami_node --ros-args -p robot_description_package:="rosbot_xl_whoami"
```
Terminal 2
Run simulation:
https://github.com/RobotecAI/rai-rosbot-xl-demo/releases/tag/v0.1.0

Terminal 3
```bash
cd src/examples/rosbot-xl-demo
./run-nav.bash
```

Terminal 4
```bash
. ./setup_shell.sh
python examples/rosbot-xl-generic-node-demo.py
```

Terminal 5
```bash
. ./setup_shell.sh
streamlit run src/rai_hmi/rai_hmi/streamlit_hmi_node.py rosbot_xl_whoami
```

- User Streamlit Web UI to add tasks to husarion. For example:
- "spin 90 degrees to the right"

## TODOs
- [x] Only 1 mission is supported at once:
    ![image](https://github.com/user-attachments/assets/19ea5814-48b2-4d52-81b3-19ceff877c03)
- [x] Agent can respond in a template to easily parse to `rai_interfaces/../Task.action`
- [x] Fix `[WARN] [1725631842.744809111] [rai_node.action_server]: Goal state not set, assuming aborted. Goal ID: [143 141  99 196 101 201  72 161 176  90  69  28   3 219 125 208]`
- [x] Fix tool calling in `src/rai/rai/node.py`