### PR TITLE
feat: add tool for open-set detection using grounding dino

### DIFF
--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -14,6 +14,7 @@
 #
 
 from .cli import Ros2InterfaceTool, Ros2ServiceTool, Ros2TopicTool
+from .native import Ros2BaseInput, Ros2BaseTool
 from .tools import (
     AddDescribedWaypointToDatabaseTool,
     GetCurrentPositionTool,
@@ -24,6 +25,8 @@ __all__ = [
     "Ros2TopicTool",
     "Ros2InterfaceTool",
     "Ros2ServiceTool",
+    "Ros2BaseTool",
+    "Ros2BaseInput",
     "AddDescribedWaypointToDatabaseTool",
     "GetOccupancyGridTool",
     "GetCurrentPositionTool",

--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -14,7 +14,7 @@
 #
 
 from .cli import Ros2InterfaceTool, Ros2ServiceTool, Ros2TopicTool
-from .native import Ros2BaseTool
+from .native import Ros2BaseInput, Ros2BaseTool
 from .tools import (
     AddDescribedWaypointToDatabaseTool,
     GetCurrentPositionTool,
@@ -26,6 +26,7 @@ __all__ = [
     "Ros2InterfaceTool",
     "Ros2ServiceTool",
     "Ros2BaseTool",
+    "Ros2BaseInput",
     "AddDescribedWaypointToDatabaseTool",
     "GetOccupancyGridTool",
     "GetCurrentPositionTool",

--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -14,7 +14,7 @@
 #
 
 from .cli import Ros2InterfaceTool, Ros2ServiceTool, Ros2TopicTool
-from .native import Ros2BaseInput, Ros2BaseTool
+from .native import Ros2BaseTool
 from .tools import (
     AddDescribedWaypointToDatabaseTool,
     GetCurrentPositionTool,

--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
     "Ros2InterfaceTool",
     "Ros2ServiceTool",
     "Ros2BaseTool",
-    "Ros2BaseInput",
     "AddDescribedWaypointToDatabaseTool",
     "GetOccupancyGridTool",
     "GetCurrentPositionTool",

--- a/src/rai/rai/tools/ros/utils.py
+++ b/src/rai/rai/tools/ros/utils.py
@@ -34,6 +34,16 @@ def import_message_from_str(msg_type: str) -> Type[object]:
     return import_message_from_namespaced_type(msg_namespaced_type)
 
 
+def convert_ros_img_to_cv2mat(msg: sensor_msgs.msg.Image) -> cv2.typing.MatLike:
+    bridge = CvBridge()
+    cv_image = cast(cv2.Mat, bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough"))  # type: ignore
+    if cv_image.shape[-1] == 4:
+        cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGRA2RGB)
+    else:
+        cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
+    return cv_image
+
+
 def convert_ros_img_to_base64(msg: sensor_msgs.msg.Image) -> str:
     bridge = CvBridge()
     cv_image = cast(cv2.Mat, bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough"))  # type: ignore

--- a/src/rai/rai/tools/ros/utils.py
+++ b/src/rai/rai/tools/ros/utils.py
@@ -35,8 +35,11 @@ def import_message_from_str(msg_type: str) -> Type[object]:
     return import_message_from_namespaced_type(msg_namespaced_type)
 
 
-def convert_ros_img_to_ndarray(msg: sensor_msgs.msg.Image) -> np.ndarray:
-    encoding = msg.encoding.lower()
+def convert_ros_img_to_ndarray(
+    msg: sensor_msgs.msg.Image, encoding: str = ""
+) -> np.ndarray:
+    if encoding == "":
+        encoding = msg.encoding.lower()
 
     if encoding == "rgb8":
         image_data = np.frombuffer(msg.data, np.uint8)
@@ -52,7 +55,7 @@ def convert_ros_img_to_ndarray(msg: sensor_msgs.msg.Image) -> np.ndarray:
         image_data = np.frombuffer(msg.data, np.uint16)
         image = image_data.reshape((msg.height, msg.width))
     else:
-        raise ValueError(f"Unsupported encoding: {msg.encoding}")
+        raise ValueError(f"Unsupported encoding: {encoding}")
 
     return image
 

--- a/src/rai_extensions/rai_grounding_dino/README.md
+++ b/src/rai_extensions/rai_grounding_dino/README.md
@@ -58,6 +58,49 @@ ros2 launch rai_grounding_dino gdino_launch.xml [weights_path:=PATH/TO/WEIGHTS]
 > By default the weights will be downloaded to `$(ros2 pkg prefix rai_grounding_dino)/share/weights/`.
 > You can change this path if you downloaded the weights manually or moved them.
 
+### RAI Tools
+
+This package provides the following tools:
+
+- `GetDetectionTool`
+  This tool calls the grounding dino service to use the model to see if the message from the provided camera topic contains objects from a comma separated prompt.
+
+  **Example call**
+
+  ```
+  x = GetDetectionTool(node=RaiBaseNode(node_name="test_node"))._run(
+      camera_topic="/camera/camera/color/image_raw",
+      object_names=["chair", "human", "plushie", "box", "ball"],
+  )
+
+  ```
+
+  **Example output**
+
+  ```
+  I have detected the following items in the picture - chair, human
+  ```
+
+- `GetDistanceToObjectsTool`
+  This tool calls the grounding dino service to use the model to see if the message from the provided camera topic contains objects from a comma separated prompt. Then it utilises messages from depth camera to create an estimation of distance to a detected object.
+
+  **Example call**
+
+  ```
+  x = GetDistanceToObjectsTool(node=RaiBaseNode(node_name="test_node"))._run(
+      camera_topic="/camera/camera/color/image_raw",
+      depth_topic="/camera/camera/depth/image_rect_raw",
+      object_names=["chair", "human", "plushie", "box", "ball"],
+  )
+
+  ```
+
+  **Example output**
+
+  ```
+  I have detected the following items in the picture human: 1.68 m away, chair: 2.20 m away
+  ```
+
 ### Example
 
 An example client is provided with the package as `rai_grounding_dino/talker.py`

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/__init__.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/__init__.py
@@ -12,3 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .grounding_dino import GDINO_NODE_NAME, GDINO_SERVICE_NAME
+from .tools import GetDetectionTool, GetDistanceToObjectsTool
+
+__all__ = [
+    "GetDistanceToObjectsTool",
+    "GetDetectionTool",
+    "GDINO_NODE_NAME",
+    "GDINO_SERVICE_NAME",
+]

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/boxer.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/boxer.py
@@ -16,6 +16,7 @@
 from os import PathLike
 from typing import Dict
 
+import cv2
 from cv_bridge import CvBridge
 from groundingdino.util.inference import Model
 from rclpy.time import Time
@@ -83,6 +84,7 @@ class GDBoxer:
         image = self.bridge.imgmsg_to_cv2(
             image_msg, desired_encoding=image_msg.encoding
         )
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
         predictions = self.model.predict_with_classes(
             image=image,

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/grounding_dino.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/grounding_dino.py
@@ -34,11 +34,15 @@ class GDRequest(TypedDict):
     source_img: Image
 
 
+GDINO_NODE_NAME = "grounding_dino"
+GDINO_SERVICE_NAME = "grounding_dino_classify"
+
+
 class GDinoService(Node):
     def __init__(self):
-        super().__init__(node_name="grounding_dino", parameter_overrides=[])
+        super().__init__(node_name=GDINO_NODE_NAME, parameter_overrides=[])
         self.srv = self.create_service(
-            RAIGroundingDino, "grounding_dino_classify", self.classify_callback
+            RAIGroundingDino, GDINO_SERVICE_NAME, self.classify_callback
         )
         self.declare_parameter("weights_path", "")
         try:

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -1,0 +1,79 @@
+import pdb
+from typing import Optional, Type
+
+import cv2
+import rclpy
+import sensor_msgs.msg
+from langchain_core.pydantic_v1 import Field
+from rclpy import Future
+
+from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
+from rai_interfaces.msg import RAIDetectionArray
+from rai_interfaces.srv import RAIGroundingDino
+
+
+# --------------------- Inputs ---------------------
+class Ros2GetDetectionInput(Ros2BaseInput):
+    camera_topic: str = Field(
+        ...,
+        description="Ros2 topic for the camera image containing image to run detection on.",
+    )
+    service_name: str = Field(
+        ..., description="Name of the service to perform depth analysis"
+    )
+    object_name: list[str] = Field(
+        ..., description="Natural language name of the objects to detect"
+    )
+
+
+class GetDetectionTool(Ros2BaseTool):
+    name: str = "GetDetectionTool"
+    description: str = "A tool for detecting to a specified object using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
+
+    args_schema: Type[Ros2GetDetectionInput] = Ros2GetDetectionInput
+
+    def _spin(self, future: Future) -> Optional[RAIDetectionArray]:
+        rclpy.spin_once(self.node)
+        if future.done():
+            try:
+                response = future.result()
+            except Exception as e:
+                self.node.get_logger().info("Service call failed %r" % (e,))
+                raise Exception("Service call failed %r" % (e,))
+            else:
+                assert response is not None
+                self.node.get_logger().info(f"{response.detections}")
+                return response
+        return None
+
+    def _run(
+        self,
+        camera_topic: str,
+        service_name: str,
+        object_names: list[str],
+    ):
+        assert hasattr(self.node, "get_raw_message_from_topic")
+        msg = self.node.get_raw_message_from_topic(camera_topic)
+        camera_img_message = None
+        if type(msg) is sensor_msgs.msg.Image:
+            camera_img_message = msg
+        else:
+            raise Exception("Received wrong message")
+
+        cli = self.node.create_client(RAIGroundingDino, service_name)
+        while not cli.wait_for_service(timeout_sec=1.0):
+            self.node.get_logger().info("service not available, waiting again...")
+        req = RAIGroundingDino.Request()
+        req.source_img = camera_img_message
+        req.classes = " , ".join(object_names)
+        req.box_threshold = 0.4
+        req.text_threshold = 0.4
+
+        future = cli.call_async(req)
+
+        while rclpy.ok():
+            resolved = self._spin(future)
+            if resolved is not None:
+                return f"I have detected the following items in the picture {resolved.detections.detection_classes}"
+
+        return "Failed to get detection"

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -248,5 +248,5 @@ class GetDistanceToObjectsTool(GroundingDinoBaseTool):
                         for measurement in measurements
                     ]
                 )
-                return f"I have detected the following items in the picture {measurement_string}"
+                return f"I have detected the following items in the picture {measurement_string or 'no objects'}"
         return "Failed"

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -17,8 +17,7 @@ from typing import List, NamedTuple, Optional, Type
 import numpy as np
 import rclpy
 import sensor_msgs.msg
-from pydantic import Field
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from rai_grounding_dino import GDINO_SERVICE_NAME
 from rclpy import Future
 from rclpy.exceptions import (

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -158,7 +158,7 @@ class GetDetectionTool(GroundingDinoBaseTool):
             if resolved is not None:
                 detected = self._parse_detection_array(resolved)
                 names = ", ".join([det.class_name for det in detected])
-                return f"I have detected the following items in the picture {names}"
+                return f"I have detected the following items in the picture {names or 'None'}"
 
         return "Failed to get detection"
 

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -37,7 +37,9 @@ class Ros2GetDetectionInput(Ros2BaseInput):
 
 class GetDetectionTool(Ros2BaseTool):
     name: str = "GetDetectionTool"
-    description: str = "A tool for detecting to a specified object using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
+    description: str = (
+        "A tool for detecting to a specified object using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
+    )
 
     args_schema: Type[Ros2GetDetectionInput] = Ros2GetDetectionInput
 

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Type
+from typing import List, NamedTuple, Optional, Type
 
+import numpy as np
 import rclpy
 import sensor_msgs.msg
 from langchain_core.pydantic_v1 import Field
+from pydantic import BaseModel
 from rclpy import Future
+from rclpy.exceptions import (
+    ParameterNotDeclaredException,
+    ParameterUninitializedException,
+)
 
 from rai.node import RaiBaseNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
-from rai_interfaces.msg import RAIDetectionArray
+from rai.tools.ros.utils import convert_ros_img_to_ndarray
 from rai_interfaces.srv import RAIGroundingDino
 
 
@@ -32,15 +38,50 @@ class Ros2GetDetectionInput(Ros2BaseInput):
         description="Ros2 topic for the camera image containing image to run detection on.",
     )
     object_names: list[str] = Field(
-        ..., description="Natural language name of the objects to detect"
+        ..., description="Natural language names of the objects to detect"
     )
+
+
+class GetDistanceToObjectsInput(Ros2BaseInput):
+    camera_topic: str = Field(
+        ...,
+        description="Ros2 topic for the camera image containing image to run detection on.",
+    )
+    depth_topic: str = Field(
+        ...,
+        description="Ros2 topic for the depth image containing data to run distance calculations on",
+    )
+    object_names: list[str] = Field(
+        ..., description="Natural language names of the objects to detect"
+    )
+
+
+# -------------------- Utils ----------------------
+
+
+class BoundingBox(BaseModel):
+    x_center: float
+    y_center: float
+    width: float
+    height: float
+
+
+class DetectionData(BaseModel):
+    class_name: str
+    confidence: float
+    bbox: BoundingBox
+
+
+class DistanceMeasurement(NamedTuple):
+    name: str
+    distance: float
 
 
 # --------------------- Tools ---------------------
 class GroundingDinoBaseTool(Ros2BaseTool):
     node: RaiBaseNode = Field(..., exclude=True, required=True)
 
-    def _spin(self, future: Future) -> Optional[RAIDetectionArray]:
+    def _spin(self, future: Future) -> Optional[RAIGroundingDino.Response]:
         rclpy.spin_once(self.node)
         if future.done():
             try:
@@ -76,11 +117,29 @@ class GroundingDinoBaseTool(Ros2BaseTool):
         else:
             raise Exception("Received wrong message")
 
+    def _parse_detection_array(
+        self, detection_response: RAIGroundingDino.Response
+    ) -> list[DetectionData]:
+        detected = []
+        for detection in detection_response.detections.detections:
+            class_name = detection.results[0].hypothesis.class_id
+            confidence = detection.results[0].hypothesis.score
+            bbox = BoundingBox(
+                x_center=detection.bbox.center.position.x,
+                y_center=detection.bbox.center.position.y,
+                width=detection.bbox.size_x,
+                height=detection.bbox.size_y,
+            )
+            detected.append(
+                DetectionData(class_name=class_name, confidence=confidence, bbox=bbox)
+            )
+        return detected
+
 
 class GetDetectionTool(GroundingDinoBaseTool):
     name: str = "GetDetectionTool"
     description: str = (
-        "A tool for detecting to a specified object using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
+        "A tool for detecting specified objects using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
     )
 
     args_schema: Type[Ros2GetDetectionInput] = Ros2GetDetectionInput
@@ -96,6 +155,97 @@ class GetDetectionTool(GroundingDinoBaseTool):
         while rclpy.ok():
             resolved = self._spin(future)
             if resolved is not None:
-                return f"I have detected the following items in the picture {resolved.detections.detection_classes}"
+                detected = self._parse_detection_array(resolved)
+                names = [det.class_name for det in detected]
+                return f"I have detected the following items in the picture {names}"
 
         return "Failed to get detection"
+
+
+class GetDistanceToObjectsTool(GroundingDinoBaseTool):
+    name: str = "GetDistanceToObjectsTool"
+    description: str = (
+        "A tool for calculating distance to specified objects using a ros2 action. The tool call might take some time to execute and is blocking - you will not be able to check their feedback, only will be informed about the result."
+    )
+
+    args_schema: Type[GetDistanceToObjectsInput] = GetDistanceToObjectsInput
+
+    def _get_distance_from_detections(
+        self,
+        depth_img: sensor_msgs.msg.Image,
+        detections: list[DetectionData],
+        sigma_threshold: float = 1.0,
+        conversion_ratio: float = 0.001,
+    ) -> List[DistanceMeasurement]:
+        depth_arr = convert_ros_img_to_ndarray(depth_img)
+        ret = []
+        for detection in detections:
+            x_min = int(detection.bbox.x_center - (0.5 * detection.bbox.width))
+            x_max = int(detection.bbox.x_center + (0.5 * detection.bbox.width))
+            y_min = int(detection.bbox.y_center - (0.5 * detection.bbox.height))
+            y_max = int(detection.bbox.y_center + (0.5 * detection.bbox.height))
+            roi = depth_arr[x_min:x_max, y_min:y_max]
+            mean = np.mean(roi)
+            std_dev = np.std(roi)
+
+            if std_dev != 0:
+                z_scores = (roi - mean) / std_dev
+                mask = np.abs(z_scores) < sigma_threshold
+                ret.append(
+                    (detection.class_name, np.mean(roi[mask]) * conversion_ratio)
+                )
+            else:
+                ret.append((detection.class_name, mean * conversion_ratio))
+        return ret
+
+    def _run(
+        self,
+        camera_topic: str,
+        depth_topic: str,
+        object_names: list[str],
+    ):
+        camera_img_msg = self._get_image_message(camera_topic)
+        depth_img_msg = self._get_image_message(depth_topic)
+        future = self._call_gdino_node(camera_img_msg, object_names)
+        logger = self.node.get_logger()
+
+        try:
+            threshold = self.node.get_parameter("outlier_sigma_threshold").value
+            if not isinstance(threshold, float):
+                logger.error(
+                    f"Parametr outlier_sigma_threshold was set badly: {type(threshold)}: {threshold} expected float. Using default value 1.0"
+                )
+                threshold = 1.0
+        except (ParameterUninitializedException, ParameterNotDeclaredException):
+            logger.warning(
+                "Parameter outlier_sigma_threshold not found in node, using default value: 1.0"
+            )
+            threshold = 1.0
+
+        try:
+            conversion_ratio = self.node.get_parameter("conversion_ratio").value
+            if not isinstance(conversion_ratio, float):
+                logger.error(
+                    f"Parametr conversion_ratio was set badly: {type(threshold)}: {threshold} expected float. Using default value 0.001"
+                )
+                conversion_ratio = 0.001
+        except (ParameterUninitializedException, ParameterNotDeclaredException):
+            logger.warning(
+                "Parameter conversion_ratio not found in node, using default value: 0.001"
+            )
+            conversion_ratio = 0.001
+        while rclpy.ok():
+            resolved = self._spin(future)
+            if resolved is not None:
+                detected = self._parse_detection_array(resolved)
+                measurements = self._get_distance_from_detections(
+                    depth_img_msg, detected, threshold, conversion_ratio
+                )
+                measurement_string = " ".join(
+                    [
+                        f"{measurement[0]}: {measurement[1]:.2f}m away"
+                        for measurement in measurements
+                    ]
+                )
+                return f"I have detected the following items in the picture {measurement_string}"
+        return "Failed"

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -17,7 +17,7 @@ from typing import List, NamedTuple, Optional, Type
 import numpy as np
 import rclpy
 import sensor_msgs.msg
-from langchain_core.pydantic_v1 import Field
+from pydantic import Field
 from pydantic import BaseModel
 from rai_grounding_dino import GDINO_SERVICE_NAME
 from rclpy import Future

--- a/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
+++ b/src/rai_extensions/rai_grounding_dino/rai_grounding_dino/tools.py
@@ -1,7 +1,19 @@
-import pdb
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional, Type
 
-import cv2
 import rclpy
 import sensor_msgs.msg
 from langchain_core.pydantic_v1 import Field
@@ -17,9 +29,6 @@ class Ros2GetDetectionInput(Ros2BaseInput):
     camera_topic: str = Field(
         ...,
         description="Ros2 topic for the camera image containing image to run detection on.",
-    )
-    service_name: str = Field(
-        ..., description="Name of the service to perform depth analysis"
     )
     object_name: list[str] = Field(
         ..., description="Natural language name of the objects to detect"
@@ -49,7 +58,6 @@ class GetDetectionTool(Ros2BaseTool):
     def _run(
         self,
         camera_topic: str,
-        service_name: str,
         object_names: list[str],
     ):
         assert hasattr(self.node, "get_raw_message_from_topic")
@@ -60,7 +68,7 @@ class GetDetectionTool(Ros2BaseTool):
         else:
             raise Exception("Received wrong message")
 
-        cli = self.node.create_client(RAIGroundingDino, service_name)
+        cli = self.node.create_client(RAIGroundingDino, "grounding_dino_classify")
         while not cli.wait_for_service(timeout_sec=1.0):
             self.node.get_logger().info("service not available, waiting again...")
         req = RAIGroundingDino.Request()

--- a/src/rai_interfaces/msg/RAIDetectionArray.msg
+++ b/src/rai_interfaces/msg/RAIDetectionArray.msg
@@ -20,4 +20,5 @@ std_msgs/Header header
 # A list of the detected proposals. A multi-proposal detector might generate
 #   this list with many candidate detections generated from a single input.
 vision_msgs/Detection2D[] detections
+# a list of classes detected
 string[] detection_classes

--- a/src/rai_interfaces/msg/RAIDetectionArray.msg
+++ b/src/rai_interfaces/msg/RAIDetectionArray.msg
@@ -20,5 +20,5 @@ std_msgs/Header header
 # A list of the detected proposals. A multi-proposal detector might generate
 #   this list with many candidate detections generated from a single input.
 vision_msgs/Detection2D[] detections
-# a list of classes detected
+# a list of classes being detected
 string[] detection_classes


### PR DESCRIPTION
## Purpose

Adds Grounding Dino Tooling for distance estimation. Grounding Dino is used to extract the regions of the camera POV classified as certain objects. These regions can then be extracted from the depth channel, and after calibration, used to estimate distance from camera to them.

## Proposed Changes

- Adds two tools: `GetDetectionTool`, `GetDistanceToObjectsTool`.
- Defines API for the `grounding_dino` extension

## Issues

https://github.com/RobotecAI/rai/issues/194

## Testing

Tested using following script:

```
import rclpy
from rai_grounding_dino.tools import GetDetectionTool

from rai.node import RaiBaseNode

if __name__ == "__main__":
    rclpy.init()
    node=RaiBaseNode(node_name="unique_node")
    x = GetDetectionTool(node)._run(
        camera_topic="/camera/camera/color/image_raw",
        object_names=["chair"],
    )
    print(f"Detected: {x}")
    x = GetDistanceToObjectsTool(node)._run(
        camera_topic="/camera/camera/color/image_raw",
        depth_topic="/camera/camera/depth/image_raw_rect",
        object_names=["chair"],
    )
    print(f"Detected: {x}")
```

In second terminal run:

```
ros2 launch rai_grounding_dino gdino_launch.xml
```

Camera topics must be available and of the same resolution. The detection went through correctly.
