### PR TITLE
feat: support multiple shells in the setup script

### DIFF
--- a/setup_shell.sh
+++ b/setup_shell.sh
@@ -16,12 +16,12 @@ case "$SHELL" in
         . install/setup.zsh
         echo "Sourced zsh install"
         ;;
+    *fish)
+        echo "fish is not supported"
+        ;;
     *sh)
         . install/setup.sh
         echo "Sourced sh install."
-        ;;
-    *fish)
-        echo "fish is not supported"
         ;;
     *)
         echo "Unknown shell: $0"

--- a/setup_shell.sh
+++ b/setup_shell.sh
@@ -6,7 +6,27 @@
 
 # Suppress ShellCheck warning about not following external file
 # shellcheck disable=SC1091
-. install/setup.bash
+
+case "$SHELL" in
+    *bash)
+        . install/setup.bash
+        echo "Sourced bash install"
+        ;;
+    *zsh)
+        . install/setup.zsh
+        echo "Sourced zsh install"
+        ;;
+    *sh)
+        . install/setup.sh
+        echo "Sourced sh install."
+        ;;
+    *fish)
+        echo "fish is not supported"
+        ;;
+    *)
+        echo "Unknown shell: $0"
+        ;;
+esac
 
 export PYTHONPATH
 PYTHONPATH="$(dirname "$(dirname "$(poetry run which python)")")/lib/python$(poetry run python --version | awk '{print $2}' | cut -d. -f1,2)/site-packages:$PYTHONPATH"


### PR DESCRIPTION
## Purpose

While `bash` is the most popular shell by far, many users prefer to use `zsh` on their setups for improved interactivity. ROS2 supports setup scripts for `bash`, `zsh`, and `sh` so RAI should provide users with ability to set up either of the three out of the box.

## Proposed Changes

Adds support multiple shells in the setup script

## Issues

N/A

## Testing

the script has been tested by the following procedure:

```
chsh [shell_name]
source ./setup_shell.sh
echo $PYTHON_PATH
```

The setup has worked correctly for `bash`, `zsh`, and `sh`.