### PR TITLE
fix: remove web uri image preprocess test

### DIFF
--- a/tests/messages/test_utils.py
+++ b/tests/messages/test_utils.py
@@ -31,7 +31,6 @@ def decode_image(base64_string: str) -> Image.Image:
 @pytest.mark.parametrize(
     "test_image",
     [
-        "https://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png",
         np.zeros((300, 300, 3)),
         "tests/resources/image.png",
     ],


### PR DESCRIPTION
## Purpose

CI fails because it is against wikimedia's policy to use images hosted in that way.

## Proposed Changes

Removed https image preprocessing test.

## Issues


## Testing

