### PR TITLE
docs(voice_interface.md): fix typo in docker run command for OpenTTS

### DIFF
--- a/docs/human_robot_interface/voice_interface.md
+++ b/docs/human_robot_interface/voice_interface.md
@@ -27,7 +27,7 @@ ros2 launch rai_bringup hri.launch.py tts_vendor:=opentts robot_description_pack
 ```
 
 > [!NOTE]
-> Run OpenTTS with `docker run -it -p 5500:5500 synesthesiam/opentts:en--no-espeak`
+> Run OpenTTS with `docker run -it -p 5500:5500 synesthesiam/opentts:en --no-espeak`
 
 ### ElevenLabs
 


### PR DESCRIPTION
## Purpose

Docs on how to run local tts had a typo

## Proposed Changes

typo fix

## Issues

#212 

## Testing

- How was it tested, what were the results?
