### PR TITLE
chore: update models' config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ region_name = "us-east-1"
 
 [openai]
 simple_model = "gpt-4o-mini"
-complex_model = "gpt-4o"
+complex_model = "gpt-4o-2024-08-06"
 embeddings_model = "text-embedding-ada-002"
 
 [ollama]

--- a/src/rai/rai/config/models.py
+++ b/src/rai/rai/config/models.py
@@ -31,18 +31,11 @@ class AWSBedrockKwargs(TypedDict):
 
 # OpenAI Models
 OPENAI_MULTIMODAL: OpenAIKwargs = {
-    "model": "gpt-4o",
-}
-OPENAI_LLM: OpenAIKwargs = {
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o-2024-08-06",
 }
 
-OPENAI_GPT_4o: OpenAIKwargs = {
-    "model": "gpt-4o",
-}
-
-OPENAI_GPT_3_5_TURBO: OpenAIKwargs = {
-    "model": "gpt-3.5-turbo",
+OPENAI_MINI: OpenAIKwargs = {
+    "model": "gpt-4o-mini",
 }
 
 # AWS Bedrock Models

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import pytest
 from _pytest.terminal import TerminalReporter
 from tabulate import tabulate
 
-from rai.config.models import BEDROCK_CLAUDE_HAIKU, OPENAI_LLM, OPENAI_MULTIMODAL
+from rai.config.models import BEDROCK_CLAUDE_HAIKU, OPENAI_MINI
 
 
 @pytest.fixture
@@ -42,14 +42,14 @@ def rai_python_modules():
 def chat_openai_multimodal():
     from langchain_openai.chat_models import ChatOpenAI
 
-    return ChatOpenAI(**OPENAI_MULTIMODAL)
+    return ChatOpenAI(**OPENAI_MINI)
 
 
 @pytest.fixture
 def chat_openai_text():
     from langchain_openai.chat_models import ChatOpenAI
 
-    return ChatOpenAI(**OPENAI_LLM)
+    return ChatOpenAI(**OPENAI_MINI)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Purpose

OpenAI has changed pricing for the latest gpt-4o model (gpt-4o-2024-08-06). This model will be the new default 4o on the 2nd of October 2024. Since the gpt-4o-2024-08-06 is on average ~45% cheaper than the current default 4o, the changes are introduced to minimize costs.

## Proposed Changes

Updated configuration for the default, goto models.

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
