### PR TITLE
patch(rai_whatisee): include cv_bridge.hpp or .h based on current ROS 2 version

### DIFF
--- a/src/perception/rai_whatisee/CMakeLists.txt
+++ b/src/perception/rai_whatisee/CMakeLists.txt
@@ -12,10 +12,10 @@ if(DEFINED ENV{ROS_DISTRO})
   elseif($ENV{ROS_DISTRO} STREQUAL "jazzy")
     add_definitions(-DROS_DISTRO_JAZZY)
   else()
-    message(WARNING "Unknown ROS 2 distribution: $ENV{ROS_DISTRO}. Defaulting to .hpp include.")
+    message(WARNING "Unsupported ROS 2 distribution: $ENV{ROS_DISTRO}. Defaulting to .hpp include.")
   endif()
 else()
-  message(WARNING "ROS_DISTRO environment variable not set. Defaulting to .hpp include.")
+  message(FATAL_ERROR "ROS_DISTRO environment variable not set. Make sure to source your ROS 2 distribution before compiling").
 endif()
 
 # find dependencies

--- a/src/perception/rai_whatisee/CMakeLists.txt
+++ b/src/perception/rai_whatisee/CMakeLists.txt
@@ -5,6 +5,19 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Determine ROS 2 distribution
+if(DEFINED ENV{ROS_DISTRO})
+  if($ENV{ROS_DISTRO} STREQUAL "humble")
+    add_definitions(-DROS_DISTRO_HUMBLE)
+  elseif($ENV{ROS_DISTRO} STREQUAL "jazzy")
+    add_definitions(-DROS_DISTRO_JAZZY)
+  else()
+    message(WARNING "Unknown ROS 2 distribution: $ENV{ROS_DISTRO}. Defaulting to .hpp include.")
+  endif()
+else()
+  message(WARNING "ROS_DISTRO environment variable not set. Defaulting to .hpp include.")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/src/perception/rai_whatisee/CMakeLists.txt
+++ b/src/perception/rai_whatisee/CMakeLists.txt
@@ -15,7 +15,7 @@ if(DEFINED ENV{ROS_DISTRO})
     message(WARNING "Unsupported ROS 2 distribution: $ENV{ROS_DISTRO}. Defaulting to .hpp include.")
   endif()
 else()
-  message(FATAL_ERROR "ROS_DISTRO environment variable not set. Make sure to source your ROS 2 distribution before compiling").
+  message(FATAL_ERROR "ROS_DISTRO environment variable not set. Make sure to source your ROS 2 distribution before compiling.")
 endif()
 
 # find dependencies

--- a/src/perception/rai_whatisee/src/rai_whatisee_node.cpp
+++ b/src/perception/rai_whatisee/src/rai_whatisee_node.cpp
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(ROS_DISTRO_HUMBLE)
 #include <cv_bridge/cv_bridge.h>
+#elif defined(ROS_DISTRO_JAZZY)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.hpp>  // Default to .hpp for future distributions
+#endif
 
 #include <mutex>
 #include <opencv2/opencv.hpp>


### PR DESCRIPTION
## Purpose

ros jazzy does not include cv_bridge.h file.

## Proposed Changes

The changes fix this by importing cv_bdridge.(h|hpp) based on ROS 2 version.

## Issues

- Links to relevant issues

## Testing

Tested by building on both humble and jazzy
