### PR TITLE
fix(docs and code): text_hmi

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can start by running the following examples:
 Chat seamlessly with your ROS 2 environment, retrieve images from cameras, adjust parameters, and get information about your ROS interfaces.
 
 ```bash
-streamlit run src/rai_hmi/rai_hmi/streamlit_hmi_node.py
+streamlit run src/rai_hmi/rai_hmi/text_hmi.py
 ```
 
 Remember to run this command in a sourced shell.

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -157,6 +157,14 @@ class BaseHMINode(Node):
         return output
 
     def _initialize_system_prompt(self):
+        if self.robot_description_package == "":
+            self.get_logger().warning(
+                "Robot description package not set, using empty identity and constitution."
+            )
+            return SYSTEM_PROMPT.format(
+                constitution="",
+                identity="",
+            )
         while not self.constitution_service.wait_for_service(timeout_sec=1.0):
             self.get_logger().info(
                 "Constitution service of rai_whoami not available, waiting..."

--- a/src/rai_hmi/rai_hmi/text_hmi.py
+++ b/src/rai_hmi/rai_hmi/text_hmi.py
@@ -328,7 +328,7 @@ class StreamlitApp:
     def get_system_status(self) -> SystemStatus:
         return SystemStatus(
             robot_database=self.hmi_ros_node.faiss_index is not None,
-            system_prompt=self.hmi_ros_node.system_prompt == "",
+            system_prompt=self.hmi_ros_node.system_prompt != "",
         )
 
     def initialize_node(self, feedbacks_queue, robot_description_package):


### PR DESCRIPTION
## Purpose

Readme included wrong command for running the default streamlit based hmi.

## Proposed Changes

- fix: typo in compare statement
-  feat: allow empty identity and constitution in base hmi node
- docs: update text hmi command
- 
## Issues

- Links to relevant issues

## Testing

Manually tested using
```
streamlit run src/rai_hmi/rai_hmi/text_hmi.py
```

and
```
ros2 run rai_whoami rai_whoami_node --ros-args -p robot_description_package:="rosbot_xl_whoami" & 
streamlit run src/rai_hmi/rai_hmi/text_hmi.py "rosbot_xl_whoami"
```