### PR TITLE
fix(`text_hmi`): uids are strings

### DIFF
--- a/src/rai_hmi/rai_hmi/agent.py
+++ b/src/rai_hmi/rai_hmi/agent.py
@@ -40,16 +40,16 @@ def initialize_agent(hmi_node: BaseHMINode, rai_node: RaiBaseNode, memory: Memor
     def add_task_to_queue(task: TaskInput):
         """Use this tool to add a task to the queue. The task will be handled by the executor part of your system."""
 
-        uid = uuid.uuid1()
+        uid = uuid.uuid4()
         hmi_node.add_task_to_queue(
             Task(
                 name=task.name,
                 description=task.description,
                 priority=task.priority,
-                uid=uid,
+                uid=str(uid),
             )
         )
-        return f"UID={uid} | Task added to the queue: {task.json()}"
+        return f"UID={uid} | Task added to the queue: {task.model_dump_json()}"
 
     node_tools = tools = [
         Ros2GetRobotInterfaces(node=rai_node),

--- a/src/rai_hmi/rai_hmi/task.py
+++ b/src/rai_hmi/rai_hmi/task.py
@@ -15,7 +15,7 @@
 
 from enum import Enum
 
-from pydantic import UUID4, BaseModel
+from pydantic import BaseModel
 
 
 class Priority(str, Enum):
@@ -33,4 +33,4 @@ class TaskInput(BaseModel):
 
 
 class Task(TaskInput):
-    uid: UUID4
+    uid: str

--- a/src/rai_hmi/rai_hmi/text_hmi_utils.py
+++ b/src/rai_hmi/rai_hmi/text_hmi_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-import uuid
 from pprint import pformat
 from typing import List, Optional, Set, cast
 
@@ -45,12 +44,11 @@ class Memory:
         if not uid:
             return self.mission_memory
 
-        _uid = uuid.UUID(uid)
         print(f"{self.missions_uids=}")
-        if _uid not in self.missions_uids:
-            raise AssertionError(f"Mission with {_uid=} not found")
+        if uid not in self.missions_uids:
+            raise AssertionError(f"Mission with {uid=} not found")
 
-        return [m for m in self.mission_memory if m.uid == _uid]
+        return [m for m in self.mission_memory if m.uid == uid]
 
     def __repr__(self) -> str:
         return f"===> Chat <===\n{pformat(self.chat_memory)}\n\n===> Mission <===\n{pformat(self.mission_memory)}\n\n===> Tool calls <===\n{pformat(self.tool_calls)}"


### PR DESCRIPTION
## Purpose

- Fixes `text_hmi`. When mission was submitted by HMI node - the interface failed becasue UUID is not json serializable.
- most probably introduced during migration to `pydantic@v2`

## Proposed Changes

Use string UUIDs

## Issues


## Testing

