### PR TITLE
feat: improve ros2 pub msg tool

### DIFF
--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -65,7 +65,7 @@ class PubRos2MessageToolInput(BaseModel):
     msg_args: Dict[str, Any] = Field(
         ..., description="The arguments of the service call."
     )
-    rate: int = Field(1, description="The rate at which to publish the message.")
+    rate: int = Field(10, description="The rate at which to publish the message.")
     timeout_seconds: int = Field(1, description="The timeout in seconds.")
 
 

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -140,7 +140,7 @@ class Ros2PubMessageTool(Ros2BaseTool):
     name: str = "PubRos2MessageTool"
     description: str = """A tool for publishing a message to a ros2 topic
 
-    By default only 1 message is published. If you want to publish multiple messages, you can specify 'rate' and 'timeout_sec'.
+    By default 10 messages are published for 1 second. If you want to publish multiple messages, you can specify 'rate' and 'timeout_sec'.
     Example usage:
 
     ```python
@@ -150,7 +150,7 @@ class Ros2PubMessageTool(Ros2BaseTool):
             "topic_name": "/some_topic",
             "msg_type": "geometry_msgs/Point",
             "msg_args": {"x": 0.0, "y": 0.0, "z": 0.0},
-            "rate" : 1,
+            "rate" : 10,
             "timeout_sec" : 1
         }
     )
@@ -173,7 +173,7 @@ class Ros2PubMessageTool(Ros2BaseTool):
         topic_name: str,
         msg_type: str,
         msg_args: Dict[str, Any],
-        rate: int = 1,
+        rate: int = 10,
         timeout_seconds: int = 1,
     ):
         """Publishes a message to the specified topic."""


### PR DESCRIPTION
## Purpose

Improves `Ros2PubMessageTool`.

## Proposed Changes

In current version the tool is not very useful for example for publishing to `/cmd_vel`. 
New implementation enables setting `rate` and `timeout`. By default `rate=10 hz` and `timeout=1 sec`.

## Issues

## Testing

