### PR TITLE
build: remove CI on draft PRs

### DIFF
--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -2,6 +2,7 @@ name: build and test
 
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - development
 

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -2,7 +2,7 @@ name: build and test
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
     branches:
       - development
 

--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-and-test-ros2:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         include:

--- a/.github/workflows/poetry-update.yml
+++ b/.github/workflows/poetry-update.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   upgrade-dependencies:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/poetry-update.yml
+++ b/.github/workflows/poetry-update.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   upgrade-dependencies:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Purpose

The purpose of a draft PR is to contain incomplete work, which may contain mistakes. Having CI build run on draft PRs is a waste of cloud computations.

## Proposed Changes

removes CI on draft PRs

## Issues

N/A

## Testing

This PR was created as a draft, then it was opened as ready for review, to verify that checks are run in valid circumstance.
