### PR TITLE
feat: rai_hmi api for universal voice-based apps

### DIFF
--- a/src/rai_bringup/launch/voice.launch.py
+++ b/src/rai_bringup/launch/voice.launch.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.substitutions import FindPackageShare
+
+
+def include_tts_launch(context, *args, **kwargs):
+    tts_vendor = LaunchConfiguration("tts_vendor").perform(context)
+    if tts_vendor == "opentts":
+        launch_file = "opentts.launch.py"
+    else:
+        launch_file = "elevenlabs.launch.py"
+
+    return [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [FindPackageShare("rai_tts"), f"/launch/{launch_file}"]
+            )
+        )
+    ]
+
+
+def include_asr_launch(context, *args, **kwargs):
+    asr_vendor = LaunchConfiguration("asr_vendor").perform(context)
+    if asr_vendor == "openai":
+        launch_file = "openai.launch.py"
+    else:
+        launch_file = "local.launch.py"
+
+    return [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [FindPackageShare("rai_asr"), f"/launch/{launch_file}"]
+            )
+        )
+    ]
+
+
+def generate_launch_description():
+    tts_vendor_arg = DeclareLaunchArgument(
+        "tts_vendor",
+        default_value="elevenlabs",
+        description="TTS vendor to use (opentts or elevenlabs)",
+    )
+    asr_vendor_arg = DeclareLaunchArgument(
+        "asr_vendor",
+        default_value="local",
+        description="ASR vendor to use (openai or whisper)",
+    )
+
+    tts_launch_inclusion = OpaqueFunction(function=include_tts_launch)
+    asr_launch_inclusion = OpaqueFunction(function=include_asr_launch)
+
+    return LaunchDescription(
+        [
+            tts_vendor_arg,
+            asr_vendor_arg,
+            tts_launch_inclusion,
+            asr_launch_inclusion,
+        ]
+    )

--- a/src/rai_hmi/rai_hmi/api.py
+++ b/src/rai_hmi/rai_hmi/api.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from abc import abstractmethod
+from queue import Queue
+
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from std_msgs.msg import String
+
+from rai_hmi.base import BaseHMINode
+
+
+def split_message(message: str):
+    sentences = re.split(r"(?<=\.)\s|[:!]", message)
+    for sentence in sentences:
+        if sentence:
+            yield sentence
+
+
+class GenericVoiceNode(BaseHMINode):
+    def __init__(self, node_name: str, queue: Queue, robot_description_package: str):
+        super().__init__(node_name, queue, robot_description_package)
+
+        self.callback_group = ReentrantCallbackGroup()
+        reliable_qos = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_ALL,
+        )
+        self.hmi_subscription = self.create_subscription(
+            String,
+            "/from_human",
+            self.handle_human_message,
+            qos_profile=reliable_qos,
+        )
+        self.hmi_publisher = self.create_publisher(
+            String,
+            "/to_human",
+            qos_profile=reliable_qos,
+            callback_group=self.callback_group,
+        )
+
+    @abstractmethod
+    def _handle_human_message(self, msg: String):
+        pass
+
+    def handle_human_message(self, msg: String):
+        self.processing = True
+        self._handle_human_message(msg)
+        self.processing = False


### PR DESCRIPTION
## Purpose

RAI_HMI implements two ways of handling user interaction: via text and via voice. However, these implementations are hard to reuse as there is a lot of use-case specific code.

## Proposed Changes

This PR introduces external api of the RAI_HMI module.

No docs are added yet, I will do that after broader tests with the taxi-demo

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
