### PR TITLE
feat: insert system prompt when not present

### DIFF
--- a/src/rai/rai/agents/conversational_agent.py
+++ b/src/rai/rai/agents/conversational_agent.py
@@ -35,11 +35,15 @@ class State(TypedDict):
 
 def agent(llm: BaseChatModel, logger: loggers_type, system_prompt: str, state: State):
     logger.info("Running thinker")
-    prompt = (
-        system_prompt
-        + "\nYour main task is to converse with the user and fulfill their requests using available tooling. "
-    )
-    ai_msg = llm.invoke([SystemMessage(content=prompt)] + state["messages"])
+
+    # If there are no messages, do nothing
+    if len(state["messages"]) == 0:
+        return state
+
+    # Insert system message if not already present
+    if not isinstance(state["messages"][0], SystemMessage):
+        state["messages"].insert(0, SystemMessage(content=system_prompt))
+    ai_msg = llm.invoke(state["messages"])
     state["messages"].append(ai_msg)
     return state
 


### PR DESCRIPTION
## Purpose

Previously system prompt wasn't added to the state['messages'] resulting in poor tracing.

## Proposed Changes

This PR fixes this behavior by inserting system prompt message into state['messages'] if there is no system message yet.

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
