### PR TITLE
CI: pre-commit runner ubuntu image update

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Purpose

To fix an issue with PEP 668 disallowing to install pre-commit via pre-commit/action@v3.0.1 on gh-hosted runner.

## Proposed Changes

GH runner image is changed from `latest` to `22.04` as the latest version is `24.04` which uses python 3.12 with PEP 668 implemented. 22.04 uses python 3.10 without PEP 668 what should solve the issue.

## Issues

N/A

## Testing

This draft PR tests itself as only by PR we can test CI pre-commit job execution.
