### PR TITLE
Revert "CI: update to self-hosted runner (#245)"

### DIFF
--- a/.github/workflows/poetry-test.yml
+++ b/.github/workflows/poetry-test.yml
@@ -9,30 +9,19 @@ on:
 jobs:
   build-and-test-ros2:
     if: github.event.pull_request.draft == false
-
-    runs-on:
-      - self-hosted
-      - ${{ matrix.ros_distro }}
-
-    continue-on-error: true
-
     strategy:
       matrix:
-        ros_distro:
-          - jazzy
-          - humble
+        include:
+          - ros_distro: jazzy
+            ubuntu_version: "24.04"
+          - ros_distro: humble
+            ubuntu_version: "22.04"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
 
     container:
       image: osrf/ros:${{ matrix.ros_distro }}-desktop-full
 
     steps:
-      - name: Clean up workspace
-        run: |
-          ls -la $GITHUB_WORKSPACE
-          rm -rf $GITHUB_WORKSPACE/* || true
-          rm -rf $GITHUB_WORKSPACE/.??* || true
-          ls -la $GITHUB_WORKSPACE
-
       - uses: actions/checkout@v4
 
       - name: Install Poetry


### PR DESCRIPTION
This reverts commit 354d48036a65f6649244b07e09f36911273527e8.

## Purpose

Local runners failed. 

## Proposed Changes

Reverts change to use locally hosted runners

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
