### PR TITLE
feat: integrate open-set detection tools with RaiNode

### DIFF
--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -16,16 +16,15 @@
 
 import rclpy
 import rclpy.executors
+from rai_open_set_vision import GetDetectionTool
 
-from rai.node import RaiStateBasedLlmNode
+from rai.node import RaiStateBasedLlmNode, describe_ros_image
 from rai.tools.ros.manipulation import GetObjectPositionsTool
 from rai.tools.ros.native import (
     GetCameraImage,
     Ros2PubMessageTool,
     Ros2ShowMsgInterfaceTool,
 )
-
-# from rai.tools.ros.native_actions import Ros2RunActionSync
 from rai.tools.ros.native_actions import (
     GetTransformTool,
     Ros2CancelAction,
@@ -40,11 +39,11 @@ from rai.tools.time import WaitForSecondsTool
 def main():
     rclpy.init()
 
-    # observe_topics = [
-    #     "/camera/camera/color/image_raw",
-    # ]
-    #
-    # observe_postprocessors = {"/camera/camera/color/image_raw": describe_ros_image}
+    observe_topics = [
+        "/camera/camera/color/image_raw",
+    ]
+
+    observe_postprocessors = {"/camera/camera/color/image_raw": describe_ros_image}
 
     topics_whitelist = [
         "/rosout",
@@ -126,8 +125,8 @@ def main():
     """
 
     node = RaiStateBasedLlmNode(
-        observe_topics=None,
-        observe_postprocessors=None,
+        observe_topics=observe_topics,
+        observe_postprocessors=observe_postprocessors,
         whitelist=topics_whitelist + actions_whitelist,
         system_prompt=SYSTEM_PROMPT,
         tools=[
@@ -139,9 +138,8 @@ def main():
             Ros2GetLastActionFeedback,
             Ros2ShowMsgInterfaceTool,
             WaitForSecondsTool,
-            # GetMsgFromTopic,
             GetCameraImage,
-            # GetDetectionTool,
+            GetDetectionTool,
             GetTransformTool,
             (
                 GetObjectPositionsTool,

--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -18,7 +18,7 @@ import rclpy
 import rclpy.executors
 from rai_open_set_vision import GetDetectionTool
 
-from rai.node import RaiStateBasedLlmNode, describe_ros_image
+from rai.node import RaiStateBasedLlmNode
 from rai.tools.ros.manipulation import GetObjectPositionsTool
 from rai.tools.ros.native import (
     GetCameraImage,
@@ -39,11 +39,11 @@ from rai.tools.time import WaitForSecondsTool
 def main():
     rclpy.init()
 
-    observe_topics = [
-        "/camera/camera/color/image_raw",
-    ]
-
-    observe_postprocessors = {"/camera/camera/color/image_raw": describe_ros_image}
+    # observe_topics = [
+    #     "/camera/camera/color/image_raw",
+    # ]
+    #
+    # observe_postprocessors = {"/camera/camera/color/image_raw": describe_ros_image}
 
     topics_whitelist = [
         "/rosout",
@@ -54,7 +54,7 @@ def main():
         "/map",
         "/scan",
         "/diagnostics",
-        "/cmd_vel",
+        # "/cmd_vel",
         "/led_strip",
     ]
 
@@ -125,8 +125,8 @@ def main():
     """
 
     node = RaiStateBasedLlmNode(
-        observe_topics=observe_topics,
-        observe_postprocessors=observe_postprocessors,
+        observe_topics=None,
+        observe_postprocessors=None,
         whitelist=topics_whitelist + actions_whitelist,
         system_prompt=SYSTEM_PROMPT,
         tools=[

--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -82,6 +82,7 @@ def main():
 
     <rule> use /cmd_vel topic very carefully. Obstacle detection works only with nav2 stack, so be careful when it is not used. </rule>>
     <rule> be patient with running ros2 actions. usually the take some time to run. </rule>
+    <rule> Always check your transform before and after you perform ros2 actions, so that you can verify if it worked. </rule>
 
     Navigation tips:
     - it's good to start finding objects by rotating, then navigating to some diverse location with occasional rotations. Remember to frequency detect objects.

--- a/examples/rosbot-xl-generic-node-demo.py
+++ b/examples/rosbot-xl-generic-node-demo.py
@@ -16,25 +16,24 @@
 
 import rclpy
 import rclpy.executors
-from rai_open_set_vision.tools import GetDetectionTool, GetDistanceToObjectsTool
 
 from rai.node import RaiStateBasedLlmNode
+from rai.tools.ros.manipulation import GetObjectPositionsTool
 from rai.tools.ros.native import (
     GetCameraImage,
-    GetMsgFromTopic,
     Ros2PubMessageTool,
     Ros2ShowMsgInterfaceTool,
 )
 
 # from rai.tools.ros.native_actions import Ros2RunActionSync
 from rai.tools.ros.native_actions import (
+    GetTransformTool,
     Ros2CancelAction,
     Ros2GetActionResult,
     Ros2GetLastActionFeedback,
     Ros2IsActionComplete,
     Ros2RunActionAsync,
 )
-from rai.tools.ros.tools import GetCurrentPositionTool
 from rai.tools.time import WaitForSecondsTool
 
 
@@ -50,7 +49,9 @@ def main():
     topics_whitelist = [
         "/rosout",
         "/camera/camera/color/image_raw",
+        "/camera/camera/color/camera_info",
         "/camera/camera/depth/image_rect_raw",
+        "/camera/camera/depth/camera_info",
         "/map",
         "/scan",
         "/diagnostics",
@@ -136,12 +137,21 @@ def main():
             Ros2GetActionResult,
             Ros2GetLastActionFeedback,
             Ros2ShowMsgInterfaceTool,
-            GetCurrentPositionTool,
             WaitForSecondsTool,
-            GetMsgFromTopic,
+            # GetMsgFromTopic,
             GetCameraImage,
-            GetDetectionTool,
-            GetDistanceToObjectsTool,
+            # GetDetectionTool,
+            GetTransformTool,
+            (
+                GetObjectPositionsTool,
+                dict(
+                    target_frame="odom",
+                    source_frame="sensor_frame",
+                    camera_topic="/camera/camera/color/image_raw",
+                    depth_topic="/camera/camera/depth/image_rect_raw",
+                    camera_info_topic="/camera/camera/color/camera_info",
+                ),
+            ),
         ],
     )
 

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -403,14 +403,21 @@ class RaiStateBasedLlmNode(RaiBaseNode):
     def _initialize_tools(self, tools: List[Type[BaseTool]]):
         initialized_tools = list()
         for tool_cls in tools:
+            args = None
+            if type(tool_cls) is tuple:
+                tool_cls, args = tool_cls
             if issubclass(tool_cls, Ros2BaseTool):
                 if (
                     issubclass(tool_cls, Ros2BaseActionTool)
                     or "DetectionTool" in tool_cls.__name__
                     or "GetDistance" in tool_cls.__name__
                     or "GetTransformTool" in tool_cls.__name__
+                    or "GetObjectPositionsTool" in tool_cls.__name__
                 ):  # TODO(boczekbartek): develop a way to handle all mutially
-                    tool = tool_cls(node=self._async_tool_node)
+                    if args:
+                        tool = tool_cls(node=self._async_tool_node, **args)
+                    else:
+                        tool = tool_cls(node=self._async_tool_node)
                 else:
                     tool = tool_cls(node=self)
             else:
@@ -496,11 +503,10 @@ class RaiStateBasedLlmNode(RaiBaseNode):
                 else:
                     last_msg = msg.content
 
-                if len(str(last_msg)) > 0 and "Retrieved state: {}" not in last_msg:
-                    feedback_msg = TaskAction.Feedback()
-                    feedback_msg.current_status = f"{graph_node_name}: {last_msg}"
+                feedback_msg = TaskAction.Feedback()
+                feedback_msg.current_status = f"{graph_node_name}: {last_msg}"
 
-                    goal_handle.publish_feedback(feedback_msg)
+                goal_handle.publish_feedback(feedback_msg)
 
             # ---- Share Action Result ----
             if state is None:

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -416,6 +416,7 @@ class RaiStateBasedLlmNode(RaiBaseNode):
                     or "GetDistance" in tool_cls.__name__
                     or "GetTransformTool" in tool_cls.__name__
                     or "GetObjectPositionsTool" in tool_cls.__name__
+                    or "GetDetectionTool" in tool_cls.__name__
                 ):  # TODO(boczekbartek): develop a way to handle all mutially
                     if args:
                         tool = tool_cls(node=self._async_tool_node, **args)

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -184,14 +184,14 @@ class Ros2GetLastActionFeedback(Ros2BaseActionTool):
     args_schema: Type[Ros2BaseInput] = Ros2BaseInput
 
     def _run(self) -> str:
-        return str(self.node.action_feedback)
+        return str(self.node.feedback)
 
 
 class GetTransformTool(Ros2BaseActionTool):
     name: str = "GetTransform"
     description: str = "Get transform between two frames"
 
-    def _run(self, target_frame="map", source_frame="body_link") -> dict:
+    def _run(self, target_frame="odom", source_frame="body_link") -> dict:
         return message_to_ordereddict(
             get_transform(self.node, target_frame, source_frame)
         )

--- a/src/rai/rai/tools/utils.py
+++ b/src/rai/rai/tools/utils.py
@@ -43,7 +43,6 @@ from tf2_ros import Buffer, TransformListener
 from rai.messages import ToolMultimodalMessage
 
 
-# Copied from https://github.com/ros2/rclpy/blob/jazzy/rclpy/rclpy/wait_for_message.py, to support humble
 def wait_for_message(
     msg_type,
     node: "Node",

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -36,11 +36,15 @@ class RosoutBuffer:
         )
         llm = llm
         self.llm = self.template | llm
+        self.filter_out = ["rviz", "rai"]
 
     def clear(self):
         self._buffer.clear()
 
     def append(self, line: str):
+        for w in self.filter_out:
+            if w in line:
+                return
         self._buffer.append(line)
         if len(self._buffer) > self.bufsize:
             self._buffer.popleft()

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
@@ -25,11 +25,13 @@ from rclpy.exceptions import (
     ParameterUninitializedException,
 )
 from rclpy.task import Future
+from rclpy.wait_for_message import wait_for_message
 
 from rai.node import RaiAsyncToolsNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_ndarray
-from rai.tools.utils import wait_for_message
+
+# from rai.tools.utils import wait_for_message
 from rai_interfaces.srv import RAIGroundingDino
 
 
@@ -115,7 +117,7 @@ class GroundingDinoBaseTool(Ros2BaseTool):
         future = cli.call_async(req)
         return future
 
-    def get_img_from_topic(self, topic: str, timeout_sec: int = 2):
+    def get_img_from_topic(self, topic: str, timeout_sec: int = 4):
         success, msg = wait_for_message(
             sensor_msgs.msg.Image,
             self.node,

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
@@ -25,13 +25,11 @@ from rclpy.exceptions import (
     ParameterUninitializedException,
 )
 from rclpy.task import Future
-from rclpy.wait_for_message import wait_for_message
 
 from rai.node import RaiAsyncToolsNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_ndarray
-
-# from rai.tools.utils import wait_for_message
+from rai.tools.utils import wait_for_message
 from rai_interfaces.srv import RAIGroundingDino
 
 

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
@@ -27,13 +27,14 @@ from rclpy.exceptions import (
     ParameterUninitializedException,
 )
 
-# from rai.tools.utils import wait_for_message
-from rclpy.wait_for_message import wait_for_message
-
 from rai.tools.ros import Ros2BaseInput
 from rai.tools.ros.native_actions import Ros2BaseActionTool
 from rai.tools.ros.utils import convert_ros_img_to_base64, convert_ros_img_to_ndarray
+from rai.tools.utils import wait_for_message
 from rai_interfaces.srv import RAIGroundedSam, RAIGroundingDino
+
+# from rclpy.wait_for_message import wait_for_message
+
 
 # --------------------- Inputs ---------------------
 

--- a/src/rai_hmi/rai_hmi/agent.py
+++ b/src/rai_hmi/rai_hmi/agent.py
@@ -33,15 +33,15 @@ def initialize_agent(hmi_node: BaseHMINode, rai_node: RaiBaseNode, memory: Memor
 
     @tool
     def get_mission_memory(uid: str) -> List[MissionMessage]:
-        """List mission memory. Mission uid is required."""
+        """List mission memory. It contains the information about running tasks. Mission uid is required."""
         return memory.get_mission_memory(uid)
 
     @tool
-    def add_task_to_queue(task: TaskInput):
-        """Use this tool to add a task to the queue. The task will be handled by the executor part of your system."""
+    def submit_mission_to_the_robot(task: TaskInput):
+        """Use this tool submit the task to the robot. The task will be handled by the executor part of your system."""
 
         uid = uuid.uuid4()
-        hmi_node.add_task_to_queue(
+        hmi_node.execute_mission(
             Task(
                 name=task.name,
                 description=task.description,
@@ -55,7 +55,7 @@ def initialize_agent(hmi_node: BaseHMINode, rai_node: RaiBaseNode, memory: Memor
         Ros2GetRobotInterfaces(node=rai_node),
         GetCameraImage(node=rai_node),
     ]
-    task_tools = [add_task_to_queue, get_mission_memory]
+    task_tools = [submit_mission_to_the_robot, get_mission_memory]
     tools = hmi_node.tools + node_tools + task_tools
 
     agent = create_conversational_agent(

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -72,7 +72,7 @@ class BaseHMINode(Node):
     If you have multiple questions, please ask them one by one allowing user to respond before
     moving forward to the next question. Keep the conversation short and to the point.
     If you are requested tasks that you are capable of perfoming as a robot, not as a
-    conversational agent, please use tools to submit them to the task queue - only 1
+    conversational agent, please use tools to submit them to the robot - only 1
     task in parallel is supported. For more complicated tasks, don't split them, just
     add as 1 task.
     They will be done by another agent resposible for communication with the robotic's
@@ -182,7 +182,7 @@ class BaseHMINode(Node):
         #     self, TaskFeedback, "provide_task_feedback", self.handle_task_feedback
         # )
 
-    def add_task_to_queue(self, task: Task):
+    def execute_mission(self, task: Task):
         """Sends a task to the action server to be handled by the rai node."""
 
         if not self.task_action_client.wait_for_server(timeout_sec=10.0):

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -35,7 +35,7 @@ from rai_hmi.chat_msgs import (
     MissionFeedbackMessage,
 )
 from rai_hmi.task import Task
-from rai_hmi.tools import QueryDatabaseTool, QueueTaskTool
+from rai_hmi.tools import QueryDatabaseTool
 from rai_interfaces.action import Task as TaskAction
 
 
@@ -138,7 +138,6 @@ class BaseHMINode(Node):
             tools.append(
                 QueryDatabaseTool(get_response=self.query_faiss_index_with_scores)
             )
-        tools.append(QueueTaskTool(add_task=self.add_task_to_queue))
         return tools
 
     def status_callback(self):

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -77,6 +77,7 @@ class BaseHMINode(Node):
     add as 1 task.
     They will be done by another agent resposible for communication with the robotic's
     stack.
+    If you are asked about logs, or what was write or wrong about the mission, use get_mission_memory tool to get such information.
     """
 
     def __init__(

--- a/src/rai_hmi/rai_hmi/tools.py
+++ b/src/rai_hmi/rai_hmi/tools.py
@@ -18,8 +18,6 @@ from typing import Any, Type
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from .task import Task
-
 
 class QueryDatabaseInput(BaseModel):
     query: str = Field(
@@ -42,21 +40,3 @@ class QueryDatabaseTool(BaseTool):
     def _run(self, query: str):
         retrieval_response = self.get_response(query)
         return str(retrieval_response)
-
-
-class QueueTaskInput(BaseModel):
-    task: Task = Field(..., description="The task to queue")
-
-
-class QueueTaskTool(BaseTool):
-    name: str = "queue_task"
-    description: str = "Queue a task for the platform"
-    input_type: Type[QueueTaskInput] = QueueTaskInput
-
-    args_schema: Type[QueueTaskInput] = QueueTaskInput
-
-    add_task: Any
-
-    def _run(self, task: Task):
-        self.add_task(task)
-        return f"Task {task} has been queued for the LLM"


### PR DESCRIPTION
## Purpose

`rai_open_set_vision` tools are currently only used in [manipulation_demo.py](https://github.com/RobotecAI/rai/blob/development/examples/manipulation-demo.py.)

The aim of this PR is to integrate them rai-wide and enable using them in other use-cases.

## Proposed Changes

- integrate [rai_open_set_vision](https://github.com/RobotecAI/rai/tree/development/src/rai_extensions/rai_open_set_vision) with [RaiNode](https://github.com/RobotecAI/rai/blob/development/src/rai/rai/node.py) and make the available through ros2 action bases mission interface of the node.

## Issues

TBD

## Testing

TBD


