### PR TITLE
fix: adding task to the queue from text hmi

### DIFF
--- a/src/rai_hmi/rai_hmi/agent.py
+++ b/src/rai_hmi/rai_hmi/agent.py
@@ -33,15 +33,15 @@ def initialize_agent(hmi_node: BaseHMINode, rai_node: RaiBaseNode, memory: Memor
 
     @tool
     def get_mission_memory(uid: str) -> List[MissionMessage]:
-        """List mission memory. Mission uid is required."""
+        """List mission memory. It contains the information about running tasks. Mission uid is required."""
         return memory.get_mission_memory(uid)
 
     @tool
-    def add_task_to_queue(task: TaskInput):
-        """Use this tool to add a task to the queue. The task will be handled by the executor part of your system."""
+    def submit_mission_to_the_robot(task: TaskInput):
+        """Use this tool submit the task to the robot. The task will be handled by the executor part of your system."""
 
         uid = uuid.uuid4()
-        hmi_node.add_task_to_queue(
+        hmi_node.execute_mission(
             Task(
                 name=task.name,
                 description=task.description,
@@ -55,7 +55,7 @@ def initialize_agent(hmi_node: BaseHMINode, rai_node: RaiBaseNode, memory: Memor
         Ros2GetRobotInterfaces(node=rai_node),
         GetCameraImage(node=rai_node),
     ]
-    task_tools = [add_task_to_queue, get_mission_memory]
+    task_tools = [submit_mission_to_the_robot, get_mission_memory]
     tools = hmi_node.tools + node_tools + task_tools
 
     agent = create_conversational_agent(

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -72,7 +72,7 @@ class BaseHMINode(Node):
     If you have multiple questions, please ask them one by one allowing user to respond before
     moving forward to the next question. Keep the conversation short and to the point.
     If you are requested tasks that you are capable of perfoming as a robot, not as a
-    conversational agent, please use tools to submit them to the task queue - only 1
+    conversational agent, please use tools to submit them to the robot - only 1
     task in parallel is supported. For more complicated tasks, don't split them, just
     add as 1 task.
     They will be done by another agent resposible for communication with the robotic's
@@ -182,7 +182,7 @@ class BaseHMINode(Node):
         #     self, TaskFeedback, "provide_task_feedback", self.handle_task_feedback
         # )
 
-    def add_task_to_queue(self, task: Task):
+    def execute_mission(self, task: Task):
         """Sends a task to the action server to be handled by the rai node."""
 
         if not self.task_action_client.wait_for_server(timeout_sec=10.0):

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -35,7 +35,7 @@ from rai_hmi.chat_msgs import (
     MissionFeedbackMessage,
 )
 from rai_hmi.task import Task
-from rai_hmi.tools import QueryDatabaseTool, QueueTaskTool
+from rai_hmi.tools import QueryDatabaseTool
 from rai_interfaces.action import Task as TaskAction
 
 
@@ -138,7 +138,6 @@ class BaseHMINode(Node):
             tools.append(
                 QueryDatabaseTool(get_response=self.query_faiss_index_with_scores)
             )
-        tools.append(QueueTaskTool(add_task=self.add_task_to_queue))
         return tools
 
     def status_callback(self):

--- a/src/rai_hmi/rai_hmi/tools.py
+++ b/src/rai_hmi/rai_hmi/tools.py
@@ -18,8 +18,6 @@ from typing import Any, Type
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from .task import Task
-
 
 class QueryDatabaseInput(BaseModel):
     query: str = Field(
@@ -42,21 +40,3 @@ class QueryDatabaseTool(BaseTool):
     def _run(self, query: str):
         retrieval_response = self.get_response(query)
         return str(retrieval_response)
-
-
-class QueueTaskInput(BaseModel):
-    task: Task = Field(..., description="The task to queue")
-
-
-class QueueTaskTool(BaseTool):
-    name: str = "queue_task"
-    description: str = "Queue a task for the platform"
-    input_type: Type[QueueTaskInput] = QueueTaskInput
-
-    args_schema: Type[QueueTaskInput] = QueueTaskInput
-
-    add_task: Any
-
-    def _run(self, task: Task):
-        self.add_task(task)
-        return f"Task {task} has been queued for the LLM"


### PR DESCRIPTION

## Purpose

- In Streamlit app (`text_hmi`) task adding queue was repeated. Clear purpose of this PR
- remove `queue` related names, because there is not taks queue currently

## Proposed Changes

## Issues

## Testing

- Sending tasks from text hmi
