### PR TITLE
docs: fix link to rosbot-xl python script

### DIFF
--- a/docs/demos/rosbot_xl.md
+++ b/docs/demos/rosbot_xl.md
@@ -72,7 +72,7 @@ Please refer to [rai husarion rosbot xl demo][rai rosbot demo] for more details.
 
 ### What is happening?
 
-By looking at the example code in `src/examples/rosbot-xl-generic-node-demo.py` you can see that:
+By looking at the example code in [rai/examples/rosbot-xl-demo.py](../../examples/rosbot-xl-demo.py) `examples` you can see that:
 
 - This node has no information about the robot besides what it can get from `rai_whoami_node`.
 - Topics can be whitelisted to only receive information about the robot.


### PR DESCRIPTION
Fixes script link in rosbot-xl demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Husarion Robot XL demo documentation to reflect new file paths and clearer instructions.
	- Adjusted formatting in the "Quick start" section for improved clarity.
	- Retained important notes regarding the agent's capabilities and upcoming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->