### PR TITLE
chore: reduce system prompt logging verbosity

### DIFF
--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -109,7 +109,8 @@ def append_whoami_info_to_prompt(
         prompt=prompt,
     )
 
-    node.get_logger().info(f"System prompt initialized: {system_prompt}")
+    node.get_logger().info("System prompt initialized")
+    node.get_logger().debug(system_prompt)
     return system_prompt
 
 

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -110,7 +110,7 @@ def append_whoami_info_to_prompt(
     )
 
     node.get_logger().info("System prompt initialized")
-    node.get_logger().debug(system_prompt)
+    node.get_logger().debug(f"System prompt:\n{system_prompt}")
     return system_prompt
 
 

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -580,7 +580,7 @@ class RaiStateBasedLlmNode(RaiBaseNode):
         state_dict["logs_summary"] = self.rosout_buffer.summarize()
         te = time.perf_counter() - ts
         self.get_logger().info(f"Logs summary retrieved in: {te:.2f}")
-        self.get_logger().info(f"{state_dict=}")
+        self.get_logger().debug(f"{state_dict=}")
         self.state_dict = state_dict
 
     def get_robot_state(self) -> Dict[str, str]:

--- a/src/rai_hmi/rai_hmi/voice_hmi.py
+++ b/src/rai_hmi/rai_hmi/voice_hmi.py
@@ -130,9 +130,8 @@ class VoiceHMINode(BaseHMINode):
             if node_name == "thinker":
                 last_message = state[node_name]["messages"][-1].content
                 if last_message != "":
-                    self.get_logger().info(
-                        f'Sending message to human: "{last_message}"'
-                    )
+                    self.get_logger().info("Sending reply to human")
+                    self.get_logger().debug(f'Message: "{last_message}"')
                     self.split_and_publish(last_message)
 
         self.get_logger().info("Processing finished")


### PR DESCRIPTION
## Purpose

HRI launchfile runs multiple nodes which log a lot of redundant data making the output hard to follow

## Proposed Changes

Reduces overall verbosity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging clarity by adjusting log levels for system prompts and state updates, reducing verbosity during normal operations.
	- Enhanced message tracking in the VoiceHMINode by simplifying log messages while retaining detailed debug logs for better traceability.

These changes aim to streamline logging processes, making it easier for users to understand system behavior without overwhelming them with information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->