### PR TITLE
refactor: add default value for keep_speaker_busy parameter to tts launchfiles

### DIFF
--- a/src/rai_tts/launch/elevenlabs.launch.py
+++ b/src/rai_tts/launch/elevenlabs.launch.py
@@ -54,7 +54,9 @@ def generate_launch_description():
             ],
             name="ffplay_sine_wave",
             output="screen",
-            condition=IfCondition(LaunchConfiguration("keep_speaker_busy")),
+            condition=IfCondition(
+                LaunchConfiguration("keep_speaker_busy", default=False)
+            ),
         ),
     ]
 

--- a/src/rai_tts/launch/opentts.launch.py
+++ b/src/rai_tts/launch/opentts.launch.py
@@ -56,7 +56,9 @@ def generate_launch_description():
                 ],
                 name="ffplay_sine_wave",
                 output="screen",
-                condition=IfCondition(LaunchConfiguration("keep_speaker_busy")),
+                condition=IfCondition(
+                    LaunchConfiguration("keep_speaker_busy", default=False)
+                ),
             ),
         ]
     )


### PR DESCRIPTION
## Purpose

The TTS launch files previously required the keep_speaker_busy parameter to always be provided. Since this is more of a fine-tuning option, I have added a default value for the parameter.

## Proposed Changes

- Added default parameters for tts keep_speaker_busy parameter

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
