### PR TITLE
fix(text_hmi): empty allowlist == allow all

### DIFF
--- a/src/examples/turtlebot4/turtlebot_demo.py
+++ b/src/examples/turtlebot4/turtlebot_demo.py
@@ -73,7 +73,7 @@ def main(allowlist: Optional[Path] = None):
     node = RaiStateBasedLlmNode(
         observe_topics=None,
         observe_postprocessors=None,
-        whitelist=ros2_allowlist,
+        allowlist=ros2_allowlist,
         system_prompt=SYSTEM_PROMPT,
         tools=[
             Ros2PubMessageTool,

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -244,7 +244,7 @@ class RaiAsyncToolsNode(Node):
 class RaiBaseNode(Node):
     def __init__(
         self,
-        whitelist: Optional[List[str]] = None,
+        allowlist: Optional[List[str]] = None,
         *args,
         **kwargs,
     ):
@@ -258,7 +258,7 @@ class RaiBaseNode(Node):
             self.DISCOVERY_FREQ,
             self.discovery,
         )
-        self.ros_discovery_info = NodeDiscovery(whitelist=whitelist)
+        self.ros_discovery_info = NodeDiscovery(allowlist=allowlist)
         self.discovery()
         self.qos_profile = QoSProfile(
             history=HistoryPolicy.KEEP_LAST,
@@ -343,14 +343,14 @@ class RaiStateBasedLlmNode(RaiBaseNode):
         system_prompt: str,
         observe_topics: Optional[List[str]] = None,
         observe_postprocessors: Optional[Dict[str, Callable[[Any], Any]]] = None,
-        whitelist: Optional[List[str]] = None,
+        allowlist: Optional[List[str]] = None,
         tools: Optional[List[Type[BaseTool]]] = None,
         *args,
         **kwargs,
     ):
         super().__init__(
             node_name="rai_node",
-            whitelist=whitelist,
+            allowlist=allowlist,
             *args,
             **kwargs,
         )

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -62,7 +62,7 @@ class NodeDiscovery:
     topics_and_types: Dict[str, str] = field(default_factory=dict)
     services_and_types: Dict[str, str] = field(default_factory=dict)
     actions_and_types: Dict[str, str] = field(default_factory=dict)
-    whitelist: Optional[List[str]] = field(default_factory=list)
+    allowlist: Optional[List[str]] = field(default_factory=list)
 
     def set(self, topics, services, actions):
         def to_dict(info: List[Tuple[str, List[str]]]) -> Dict[str, str]:
@@ -71,16 +71,16 @@ class NodeDiscovery:
         self.topics_and_types = to_dict(topics)
         self.services_and_types = to_dict(services)
         self.actions_and_types = to_dict(actions)
-        if self.whitelist is not None:
-            self.__filter(self.whitelist)
+        if self.allowlist is not None:
+            self.__filter(self.allowlist)
 
-    def __filter(self, whitelist: List[str]):
+    def __filter(self, allowlist: List[str]):
         for d in [
             self.topics_and_types,
             self.services_and_types,
             self.actions_and_types,
         ]:
-            to_remove = [k for k in d if k not in whitelist]
+            to_remove = [k for k in d if k not in allowlist]
             for k in to_remove:
                 d.pop(k)
 

--- a/src/rai_hmi/rai_hmi/ros.py
+++ b/src/rai_hmi/rai_hmi/ros.py
@@ -37,7 +37,7 @@ def initialize_ros_nodes(
         queue=_feedbacks_queue,
         robot_description_package=robot_description_package,
     )
-    whitelist = ros2_whitelist.read_text().splitlines() if ros2_whitelist else []
+    whitelist = ros2_whitelist.read_text().splitlines() if ros2_whitelist else None
 
     rai_node = RaiBaseNode(node_name="__rai_node__", whitelist=whitelist)
 

--- a/src/rai_hmi/rai_hmi/ros.py
+++ b/src/rai_hmi/rai_hmi/ros.py
@@ -46,7 +46,9 @@ def initialize_ros_nodes(
             if not all(line.strip() for line in whitelist):
                 raise ValueError("Whitelist contains empty lines")
         except Exception as e:
-            raise RuntimeError(f"Failed to load whitelist from {ros2_whitelist}: {str(e)}")
+            raise RuntimeError(
+                f"Failed to load whitelist from {ros2_whitelist}: {str(e)}"
+            )
 
     rai_node = RaiBaseNode(node_name="__rai_node__", whitelist=whitelist)
 

--- a/src/rai_hmi/rai_hmi/ros.py
+++ b/src/rai_hmi/rai_hmi/ros.py
@@ -37,7 +37,16 @@ def initialize_ros_nodes(
         queue=_feedbacks_queue,
         robot_description_package=robot_description_package,
     )
-    whitelist = ros2_whitelist.read_text().splitlines() if ros2_whitelist else None
+    whitelist = None
+    if ros2_whitelist:
+        try:
+            if not ros2_whitelist.is_file():
+                raise ValueError(f"Whitelist path {ros2_whitelist} is not a file")
+            whitelist = ros2_whitelist.read_text().splitlines()
+            if not all(line.strip() for line in whitelist):
+                raise ValueError("Whitelist contains empty lines")
+        except Exception as e:
+            raise RuntimeError(f"Failed to load whitelist from {ros2_whitelist}: {str(e)}")
 
     rai_node = RaiBaseNode(node_name="__rai_node__", whitelist=whitelist)
 

--- a/src/rai_hmi/rai_hmi/ros.py
+++ b/src/rai_hmi/rai_hmi/ros.py
@@ -28,7 +28,7 @@ from rai_hmi.base import BaseHMINode
 def initialize_ros_nodes(
     _feedbacks_queue: Queue,
     robot_description_package: Optional[str],
-    ros2_whitelist: Optional[Path],
+    ros2_allowlist: Optional[Path],
 ) -> Tuple[BaseHMINode, RaiBaseNode]:
     rclpy.init()
 
@@ -37,20 +37,20 @@ def initialize_ros_nodes(
         queue=_feedbacks_queue,
         robot_description_package=robot_description_package,
     )
-    whitelist = None
-    if ros2_whitelist:
+    allowlist = None
+    if ros2_allowlist:
         try:
-            if not ros2_whitelist.is_file():
-                raise ValueError(f"Whitelist path {ros2_whitelist} is not a file")
-            whitelist = ros2_whitelist.read_text().splitlines()
-            if not all(line.strip() for line in whitelist):
-                raise ValueError("Whitelist contains empty lines")
+            if not ros2_allowlist.is_file():
+                raise ValueError(f"Allowlist path {ros2_allowlist} is not a file")
+            allowlist = ros2_allowlist.read_text().splitlines()
+            if not all(line.strip() for line in allowlist):
+                raise ValueError("Allowlist contains empty lines")
         except Exception as e:
             raise RuntimeError(
-                f"Failed to load whitelist from {ros2_whitelist}: {str(e)}"
+                f"Failed to load allowlist from {ros2_allowlist}: {str(e)}"
             )
 
-    rai_node = RaiBaseNode(node_name="__rai_node__", whitelist=whitelist)
+    rai_node = RaiBaseNode(node_name="__rai_node__", allowlist=allowlist)
 
     executor = MultiThreadedExecutor()
     executor.add_node(hmi_node)

--- a/src/rai_hmi/rai_hmi/text_hmi.py
+++ b/src/rai_hmi/rai_hmi/text_hmi.py
@@ -60,8 +60,8 @@ MAX_DISPLAY = 5
 @st.cache_resource
 def parse_args() -> Tuple[Optional[str], Optional[Path]]:
     robot_description_package = sys.argv[1] if len(sys.argv) > 1 else None
-    whitelist = Path(sys.argv[2]) if len(sys.argv) > 2 else None
-    return robot_description_package, whitelist
+    allowlist = Path(sys.argv[2]) if len(sys.argv) > 2 else None
+    return robot_description_package, allowlist
 
 
 @st.cache_resource
@@ -85,10 +85,10 @@ def initialize_mission_queue() -> Queue:
 def initialize_ros_nodes_streamlit(
     _feedbacks_queue: Queue,
     robot_description_package: Optional[str],
-    ros2_whitelist: Optional[Path],
+    ros2_allowlist: Optional[Path],
 ):
     return initialize_ros_nodes(
-        _feedbacks_queue, robot_description_package, ros2_whitelist
+        _feedbacks_queue, robot_description_package, ros2_allowlist
     )
 
 
@@ -272,7 +272,7 @@ class Agent:
 
 
 class StreamlitApp:
-    def __init__(self, robot_description_package, ros2_whitelist: Path) -> None:
+    def __init__(self, robot_description_package, ros2_allowlist: Path) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.robot_description_package = robot_description_package
@@ -283,7 +283,7 @@ class StreamlitApp:
 
         self.mission_queue = initialize_mission_queue()
         self.hmi_ros_node, self.rai_ros_node = self.initialize_node(
-            self.mission_queue, robot_description_package, ros2_whitelist
+            self.mission_queue, robot_description_package, ros2_allowlist
         )
         self.agent = Agent(self.hmi_ros_node, self.rai_ros_node, self.memory)
 
@@ -315,12 +315,12 @@ class StreamlitApp:
         )
 
     def initialize_node(
-        self, feedbacks_queue, robot_description_package, ros2_whitelist
+        self, feedbacks_queue, robot_description_package, ros2_allowlist
     ):
         self.logger.info("Initializing ROS 2 node...")
         with st.spinner("Initializing ROS 2 nodes..."):
             hmi_node, rai_node = initialize_ros_nodes_streamlit(
-                feedbacks_queue, robot_description_package, ros2_whitelist
+                feedbacks_queue, robot_description_package, ros2_allowlist
             )
             self.logger.info("ROS 2 node initialized")
         return hmi_node, rai_node
@@ -376,6 +376,6 @@ def decode_base64_into_image(base64_image: str):
 
 
 if __name__ == "__main__":
-    robot_description_package, ros2_whitelist = parse_args()
-    app = StreamlitApp(robot_description_package, ros2_whitelist)
+    robot_description_package, ros2_allowlist = parse_args()
+    app = StreamlitApp(robot_description_package, ros2_allowlist)
     app.run()


### PR DESCRIPTION
## Purpose

The initialization process of text_hmi was flawed due to bad whitelist handling.

## Proposed Changes

Properly initializes empty whitelist

## Issues

- Links to relevant issues

## Testing
```bash
ros2 launch rai_bringup hri.launch.py     robot_description_package:=ro
sbot_xl_whoami & 
streamlit run src/rai_hmi/rai_hmi/text_hmi.py rosbot_xl_whoami
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the whitelist variable for better initialization when `ros2_whitelist` is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->