### PR TITLE
fix(demos): wrong argument name and type in priority of task

### DIFF
--- a/examples/agriculture-demo.py
+++ b/examples/agriculture-demo.py
@@ -117,7 +117,7 @@ def main():
         f"{tractor_prefix}/camera_image_color": describe_ros_image
     }
 
-    topics_whitelist = [
+    topics_allowlist = [
         "/rosout",
         f"{tractor_prefix}/camera_image_color",
         # Services
@@ -127,7 +127,7 @@ def main():
         f"{tractor_prefix}/replan",
     ]
 
-    actions_whitelist = []
+    actions_allowlist = []
 
     SYSTEM_PROMPT = f"""
     You are autonomous tractor {tractor_number} operating in an agricultural field. You are activated whenever the tractor stops due to an unexpected situation. Your task is to call a service based on your assessment of the situation.
@@ -146,7 +146,7 @@ def main():
     rai_node = RaiStateBasedLlmNode(
         observe_topics=observe_topics,
         observe_postprocessors=observe_postprocessors,
-        whitelist=topics_whitelist + actions_whitelist,
+        allowlist=topics_allowlist + actions_allowlist,
         system_prompt=SYSTEM_PROMPT,
         tools=[
             Ros2ShowMsgInterfaceTool,

--- a/examples/agriculture-demo.py
+++ b/examples/agriculture-demo.py
@@ -75,7 +75,7 @@ class MockBehaviorTreeNode(Node):
 
             # Send goal to perform_task action server
             goal_msg = Task.Goal()
-            goal_msg.priority = 10
+            goal_msg.priority = "high"
             goal_msg.description = ""
             goal_msg.task = "Anomaly detected. Please decide what to do."
 

--- a/examples/rosbot-xl-demo.py
+++ b/examples/rosbot-xl-demo.py
@@ -46,7 +46,7 @@ def main():
     #
     # observe_postprocessors = {"/camera/camera/color/image_raw": describe_ros_image}
 
-    topics_whitelist = [
+    topics_allowlist = [
         "/rosout",
         "/camera/camera/color/image_raw",
         "/camera/camera/depth/image_rect_raw",
@@ -57,7 +57,7 @@ def main():
         "/led_strip",
     ]
 
-    actions_whitelist = [
+    actions_allowlist = [
         "/backup",
         "/compute_path_through_poses",
         "/compute_path_to_pose",
@@ -126,7 +126,7 @@ def main():
     node = RaiStateBasedLlmNode(
         observe_topics=None,
         observe_postprocessors=None,
-        whitelist=topics_whitelist + actions_whitelist,
+        allowlist=topics_allowlist + actions_allowlist,
         system_prompt=SYSTEM_PROMPT,
         tools=[
             Ros2PubMessageTool,


### PR DESCRIPTION
Please don't squash this PR!

## Purpose

- This PR renames `whitelist` to `allowlist` in rai examples
- Bug seem to be introduced in https://github.com/RobotecAI/rai/pull/318, where
RaiNode argument was renamed 

## Proposed Changes

- fix argument name and rename `whitelist` to `allowlist`

## Issues

## Testing

> __NOTE__: binaries were downloaded using likns from [Simulation Demos](https://github.com/RobotecAI/rai/tree/development?tab=readme-ov-file#simulation-demos)

- [x] rosbot demo
```bash
ros2 launch examples/rosbotxl.launch.xml game_launcher:=/home/bboczek/Downloads/RAIROSBotXLDemoGamePackage/RAIROSBotXLDemo.GameLauncher
```

- [x] agri demo
       - something seem to be off. Waiting for fix (see my comment in  https://github.com/RobotecAI/rai/issues/292)
       - fixed now

```bash
# terminal 1
python examples/agriculture-demo.py --tractor_number 1
# terminal 2
/home/bboczek/Downloads/RAIAgricultureDemoGamePackage/RAIAgricultureDemo.GameLauncher
```
