### PR TITLE
Manipulation demo: Set calibration parameters

### DIFF
--- a/examples/manipulation-demo.py
+++ b/examples/manipulation-demo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.parameter import Parameter
 from langchain_core.messages import HumanMessage
 
 from rai.agents.conversational_agent import create_conversational_agent
@@ -23,6 +24,7 @@ from rai.utils.model_initialization import get_llm_model
 
 rclpy.init()
 node = RaiBaseNode(node_name="manipulation_demo")
+node.declare_parameter("conversion_ratio", 1.0)
 
 tools = [
     GetObjectPositionsTool(

--- a/examples/manipulation-demo.py
+++ b/examples/manipulation-demo.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import rclpy
-from rclpy.parameter import Parameter
 from langchain_core.messages import HumanMessage
 
 from rai.agents.conversational_agent import create_conversational_agent

--- a/src/rai/rai/tools/ros/manipulation.py
+++ b/src/rai/rai/tools/ros/manipulation.py
@@ -57,9 +57,9 @@ class MoveToPointTool(BaseTool):
 
     manipulator_frame: str = Field(..., description="Manipulator frame")
     min_z: float = Field(default=0.135, description="Minimum z coordinate [m]")
-    calibration_x: float = Field(default=0.071, description="Calibration x [m]")
-    calibration_y: float = Field(default=-0.025, description="Calibration y [m]")
-    calibration_z: float = Field(default=0.148, description="Calibration z [m]")
+    calibration_x: float = Field(default=0.0, description="Calibration x [m]")
+    calibration_y: float = Field(default=0.0, description="Calibration y [m]")
+    calibration_z: float = Field(default=0.0, description="Calibration z [m]")
     additional_height: float = Field(
         default=0.05, description="Additional height for the place task [m]"
     )


### PR DESCRIPTION
## Purpose

The purpose of this PR is to fix the manipulation demo calibration parameters.

## Proposed Changes

Sets the default calibration parameters in manipulation to zeroes and adds appropriate conversion_ratio parameter value in the manipulation demo example.

## Issues

N/A

## Testing

The manipulation demo was ran and tested for grasping objects.
