### PR TITLE
fix(`rosbot_demo`): add openset vision to launch

### DIFF
--- a/examples/rosbot-xl.launch.py
+++ b/examples/rosbot-xl.launch.py
@@ -14,8 +14,11 @@
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.launch_description_sources import (
+    AnyLaunchDescriptionSource,
+    PythonLaunchDescriptionSource,
+)
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -41,6 +44,17 @@ def generate_launch_description():
                 cmd=["bash", "run-nav.bash"],
                 cwd="src/examples/rai-rosbot-xl-demo",
                 output="screen",
+            ),
+            IncludeLaunchDescription(
+                AnyLaunchDescriptionSource(
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("rai_bringup"),
+                            "launch",
+                            "openset.launch.py",
+                        ]
+                    )
+                )
             ),
         ]
     )


### PR DESCRIPTION
## Purpose

- Runs `rai_openset_vision` nodes with Rosbot XL demo. This part is currently missing 
and robot will not perform vision related tasks well.

## Proposed Changes

- [ ] add `rai_openset_vision` to rosbot demo launch file.

## Issues

## Testing

```bash
ros2 launch examples/rosbot-xl.launch.py game_launcher:=/home/bboczek/Downloads/RAIROSBotXLDemoGamePackage/RAIROSBotXLDemo.GameLauncher
```

In Streamlit:
```
- submit mission for the robot to check how far is the bed
- what is the result?
```


