### PR TITLE
refactor: internal ros communication

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,10 +16,10 @@ embeddings_model = "text-embedding-ada-002"
 base_url = "https://api.openai.com/v1/" # for openai compatible apis
 
 [ollama]
-simple_model = "llama3.2"
-complex_model = "llama3.1:70b"
+simple_model = "qwq"
+complex_model = "qwen2.5:7b"
 embeddings_model = "llama3.2"
-base_url = "http://localhost:11434"
+base_url = "http://via-ip-robo-srv-004.robotec.tm.pl:11434"
 
 [tracing]
 project = "rai"

--- a/config.toml
+++ b/config.toml
@@ -16,10 +16,10 @@ embeddings_model = "text-embedding-ada-002"
 base_url = "https://api.openai.com/v1/" # for openai compatible apis
 
 [ollama]
-simple_model = "qwq"
-complex_model = "qwen2.5:7b"
+simple_model = "llama3.2"
+complex_model = "llama3.1:70b"
 embeddings_model = "llama3.2"
-base_url = "http://via-ip-robo-srv-004.robotec.tm.pl:11434"
+base_url = "http://localhost:11434"
 
 [tracing]
 project = "rai"

--- a/examples/rosbot-xl-demo.py
+++ b/examples/rosbot-xl-demo.py
@@ -18,10 +18,10 @@ from typing import Optional
 import rclpy
 import rclpy.executors
 import rclpy.logging
+from rai_open_set_vision.tools import GetDetectionTool, GetDistanceToObjectsTool
 
 from rai.node import RaiStateBasedLlmNode
 from rai.tools.ros.native import (
-    GetCameraImage,
     GetMsgFromTopic,
     Ros2GetRobotInterfaces,
     Ros2PubMessageTool,
@@ -131,9 +131,11 @@ def main(allowlist: Optional[Path] = None):
             GetTransformTool,
             WaitForSecondsTool,
             GetMsgFromTopic,
-            GetCameraImage,
+            GetDetectionTool,
+            GetDistanceToObjectsTool,
         ],
     )
+    node.declare_parameter("conversion_ratio", 1.0)
 
     node.spin()
     rclpy.shutdown()

--- a/src/rai/rai/agents/tool_runner.py
+++ b/src/rai/rai/agents/tool_runner.py
@@ -62,7 +62,7 @@ class ToolRunner(RunnableCallable):
             raise ValueError("Last message is not an AIMessage")
 
         def run_one(call: ToolCall):
-            self.logger.info(f"Running tool: {call['name']}")
+            self.logger.info(f"Running tool: {call['name']}, args: {call['args']}")
             artifact = None
 
             try:

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-import functools
 import time
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 import rclpy
 import rclpy.callback_groups
@@ -24,31 +23,20 @@ import rclpy.node
 import rclpy.qos
 import rclpy.subscription
 import rclpy.task
-import rosidl_runtime_py.set_message
-import rosidl_runtime_py.utilities
 import sensor_msgs.msg
-from action_msgs.msg import GoalStatus
 from langchain.tools import BaseTool
 from langchain.tools.render import render_text_description_and_args
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langgraph.graph.graph import CompiledGraph
-from rclpy.action.client import ActionClient
 from rclpy.action.server import ActionServer, GoalResponse, ServerGoalHandle
 from rclpy.node import Node
-from rclpy.qos import (
-    DurabilityPolicy,
-    HistoryPolicy,
-    LivelinessPolicy,
-    QoSProfile,
-    ReliabilityPolicy,
-)
-from rclpy.topic_endpoint_info import TopicEndpointInfo
 from std_srvs.srv import Trigger
 
 from rai.agents.state_based import Report, State, create_state_based_agent
 from rai.messages import HumanMultimodalMessage
+from rai.ros2_apis import Ros2ActionsAPI, Ros2TopicsAPI
 from rai.tools.ros.native import Ros2BaseTool
-from rai.tools.ros.utils import convert_ros_img_to_base64, import_message_from_str
+from rai.tools.ros.utils import convert_ros_img_to_base64
 from rai.utils.model_initialization import get_llm_model, get_tracing_callbacks
 from rai.utils.ros import NodeDiscovery
 from rai.utils.ros_async import get_future_result
@@ -127,349 +115,6 @@ def append_tools_text_description_to_prompt(prompt: str, tools: List[BaseTool]) 
     """
 
 
-def ros2_build_msg(msg_type: str, msg_args: Dict[str, Any]) -> Tuple[object, Type]:
-    """
-    Import message and create it. Return both ready message and message class.
-
-    msgs args can have two formats:
-    { "goal" : {arg 1 : xyz, ... } or {arg 1 : xyz, ... }
-    """
-
-    msg_cls: Type = rosidl_runtime_py.utilities.get_interface(msg_type)
-    msg = msg_cls.Goal()
-
-    if "goal" in msg_args:
-        msg_args = msg_args["goal"]
-    rosidl_runtime_py.set_message.set_message_fields(msg, msg_args)
-    return msg, msg_cls
-
-
-class Ros2ActionsHelper:
-    def __init__(self, node: rclpy.node.Node):
-        self.node = node
-
-        self.goal_handle = None
-        self.result_future = None
-        self.feedback = None
-        self.status: Optional[int] = None
-        self.client: Optional[ActionClient] = None
-        self.action_feedback: Optional[Any] = None
-
-    def get_logger(self):
-        return self.node.get_logger()
-
-    def run_action(
-        self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
-    ):
-        if not self.is_task_complete():
-            raise AssertionError(
-                "Another ros2 action is currently running and parallel actions are not supported. Please wait until the previous action is complete before starting a new one. You can also cancel the current one."
-            )
-
-        if action_name[0] != "/":
-            action_name = "/" + action_name
-            self.get_logger().info(f"Action name corrected to: {action_name}")
-
-        try:
-            goal_msg, msg_cls = ros2_build_msg(action_type, action_goal_args)
-        except Exception as e:
-            return f"Failed to build message: {e}"
-
-        self.client = ActionClient(self.node, msg_cls, action_name)
-        self.msg_cls = msg_cls
-
-        retries = 0
-        while not self.client.wait_for_server(timeout_sec=1.0):
-            retries += 1
-            if retries > 5:
-                raise Exception(
-                    f"Action server '{action_name}' is not available. Make sure `action_name` is correct..."
-                )
-            self.get_logger().info(
-                f"'{action_name}' action server not available, waiting..."
-            )
-
-        self.get_logger().info(f"Sending action message: {goal_msg}")
-
-        send_goal_future = self.client.send_goal_async(
-            goal_msg, self._feedback_callback
-        )
-        self.get_logger().info("Action goal sent!")
-
-        self.goal_handle = get_future_result(send_goal_future)
-
-        if not self.goal_handle:
-            raise Exception(f"Action '{action_name}' not sent to server")
-
-        if not self.goal_handle.accepted:
-            raise Exception(f"Action '{action_name}' not accepted by server")
-
-        self.result_future = self.goal_handle.get_result_async()
-        self.get_logger().info("Action sent!")
-        return f"{action_name} started successfully with args: {action_goal_args}"
-
-    def get_task_result(self) -> str:
-        if not self.is_task_complete():
-            return "Task is not complete yet"
-
-        def parse_status(status: int) -> str:
-            return {
-                GoalStatus.STATUS_SUCCEEDED: "succeeded",
-                GoalStatus.STATUS_ABORTED: "aborted",
-                GoalStatus.STATUS_CANCELED: "canceled",
-                GoalStatus.STATUS_ACCEPTED: "accepted",
-                GoalStatus.STATUS_CANCELING: "canceling",
-                GoalStatus.STATUS_EXECUTING: "executing",
-                GoalStatus.STATUS_UNKNOWN: "unknown",
-            }.get(status, "unknown")
-
-        result = self.result_future.result()
-
-        self.destroy_client()
-        if result.status == GoalStatus.STATUS_SUCCEEDED:
-            msg = f"Result succeeded: {result.result}"
-            self.get_logger().info(msg)
-            return msg
-        else:
-            str_status = parse_status(result.status)
-            error_code_str = self.parse_error_code(result.result.error_code)
-            msg = f"Result {str_status}, because of: error_code={result.result.error_code}({error_code_str}), error_msg={result.result.error_msg}"
-            self.get_logger().info(msg)
-            return msg
-
-    def parse_error_code(self, code: int) -> str:
-        code_to_name = {
-            v: k for k, v in vars(self.msg_cls.Result).items() if isinstance(v, int)
-        }
-        return code_to_name.get(code, "UNKNOWN")
-
-    def _feedback_callback(self, msg):
-        self.get_logger().info(f"Received ros2 action feedback: {msg}")
-        self.action_feedback = msg
-
-    def is_task_complete(self):
-        if not self.result_future:
-            # task was cancelled or completed
-            return True
-
-        result = get_future_result(self.result_future, timeout_sec=0.10)
-        if result is not None:
-            self.status = result.status
-            if self.status != GoalStatus.STATUS_SUCCEEDED:
-                self.get_logger().debug(
-                    f"Task with failed with status code: {self.status}"
-                )
-                return True
-        else:
-            self.get_logger().info("There is no result")
-            # Timed out, still processing, not complete yet
-            return False
-
-        self.get_logger().info("Task succeeded!")
-        return True
-
-    def cancel_task(self) -> Union[str, bool]:
-        self.get_logger().info("Canceling current task.")
-        try:
-            if self.result_future and self.goal_handle:
-                future = self.goal_handle.cancel_goal_async()
-                result = get_future_result(future, timeout_sec=1.0)
-                return "Failed to cancel result" if result is None else True
-            return True
-        finally:
-            self.destroy_client()
-
-    def destroy_client(self):
-        if self.client:
-            self.client.destroy()
-
-
-class Ros2TopicsHandler:
-    def __init__(
-        self,
-        node: rclpy.node.Node,
-        callback_group: rclpy.callback_groups.CallbackGroup,
-        ros_discovery_info: NodeDiscovery,
-    ) -> None:
-        self.node = node
-        self.qos_profile = QoSProfile(
-            history=HistoryPolicy.KEEP_LAST,
-            depth=1,
-            reliability=ReliabilityPolicy.BEST_EFFORT,
-            durability=DurabilityPolicy.VOLATILE,
-            liveliness=LivelinessPolicy.AUTOMATIC,
-        )
-        self.callback_group = callback_group
-        self.last_subscription_msgs_buffer = dict()
-        self.qos_profile_cache: Dict[str, QoSProfile] = dict()
-
-        self.ros_discovery_info = ros_discovery_info
-
-    def get_logger(self):
-        return self.node.get_logger()
-
-    def adapt_requests_to_offers(
-        self, publisher_info: List[TopicEndpointInfo]
-    ) -> QoSProfile:
-        if not publisher_info:
-            return QoSProfile(depth=1)
-
-        num_endpoints = len(publisher_info)
-        reliability_reliable_count = 0
-        durability_transient_local_count = 0
-
-        for endpoint in publisher_info:
-            profile = endpoint.qos_profile
-            if profile.reliability == ReliabilityPolicy.RELIABLE:
-                reliability_reliable_count += 1
-            if profile.durability == DurabilityPolicy.TRANSIENT_LOCAL:
-                durability_transient_local_count += 1
-
-        request_qos = QoSProfile(
-            history=HistoryPolicy.KEEP_LAST,
-            depth=1,
-            liveliness=LivelinessPolicy.AUTOMATIC,
-        )
-
-        # Set reliability based on publisher offers
-        if reliability_reliable_count == num_endpoints:
-            request_qos.reliability = ReliabilityPolicy.RELIABLE
-        else:
-            if reliability_reliable_count > 0:
-                self.get_logger().warning(
-                    "Some, but not all, publishers are offering RELIABLE reliability. "
-                    "Falling back to BEST_EFFORT as it will connect to all publishers. "
-                    "Some messages from Reliable publishers could be dropped."
-                )
-            request_qos.reliability = ReliabilityPolicy.BEST_EFFORT
-
-        # Set durability based on publisher offers
-        if durability_transient_local_count == num_endpoints:
-            request_qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
-        else:
-            if durability_transient_local_count > 0:
-                self.get_logger().warning(
-                    "Some, but not all, publishers are offering TRANSIENT_LOCAL durability. "
-                    "Falling back to VOLATILE as it will connect to all publishers. "
-                    "Previously-published latched messages will not be retrieved."
-                )
-            request_qos.durability = DurabilityPolicy.VOLATILE
-
-        return request_qos
-
-    def create_subscription_by_topic_name(self, topic):
-        if self.has_subscription(topic):
-            self.get_logger().warning(
-                f"Subscription to {topic} already exists. To override use destroy_subscription_by_topic_name first"
-            )
-            return
-
-        msg_type = self.get_msg_type(topic)
-
-        if topic not in self.qos_profile_cache:
-            self.get_logger().debug(f"Getting qos profile for topic: {topic}")
-            qos_profile = self.adapt_requests_to_offers(
-                self.node.get_publishers_info_by_topic(topic)
-            )
-            self.qos_profile_cache[topic] = qos_profile
-        else:
-            self.get_logger().debug(f"Using cached qos profile for topic: {topic}")
-            qos_profile = self.qos_profile_cache[topic]
-
-        topic_callback = functools.partial(
-            self.generic_state_subscriber_callback, topic
-        )
-
-        self.node.create_subscription(
-            msg_type,
-            topic,
-            callback=topic_callback,
-            callback_group=self.callback_group,
-            qos_profile=qos_profile,
-        )
-
-    def get_msg_type(self, topic: str, n_tries: int = 5) -> Any:
-        """Sometimes node fails to do full discovery, therefore we need to retry"""
-        for _ in range(n_tries):
-            if topic in self.ros_discovery_info.topics_and_types:
-                msg_type = self.ros_discovery_info.topics_and_types[topic]
-                return import_message_from_str(msg_type)
-            else:
-                # Wait for next discovery cycle
-                self.get_logger().info(f"Waiting for topic: {topic}")
-                if self.ros_discovery_info:
-                    time.sleep(self.ros_discovery_info.period_sec)
-                else:
-                    time.sleep(1.0)
-        raise KeyError(f"Topic {topic} not found")
-
-    def set_ros_discovery_info(self, new_ros_discovery_info: NodeDiscovery):
-        self.ros_discovery_info = new_ros_discovery_info
-
-    def get_raw_message_from_topic(
-        self, topic: str, timeout_sec: int = 5, topic_wait_sec: int = 2
-    ) -> Any:
-        self.get_logger().debug(f"Getting msg from topic: {topic}")
-
-        ts = time.perf_counter()
-
-        for _ in range(topic_wait_sec * 10):
-            if topic not in self.ros_discovery_info.topics_and_types:
-                time.sleep(0.1)
-                continue
-            else:
-                break
-
-        if topic not in self.ros_discovery_info.topics_and_types:
-            raise KeyError(
-                f"Topic {topic} not found. Available topics: {self.ros_discovery_info.topics_and_types.keys()}"
-            )
-
-        if topic in self.last_subscription_msgs_buffer:
-            self.get_logger().info("Returning cached message")
-            return self.last_subscription_msgs_buffer[topic]
-        else:
-            self.create_subscription_by_topic_name(topic)
-            try:
-                msg = self.last_subscription_msgs_buffer.get(topic, None)
-                while msg is None and time.perf_counter() - ts < timeout_sec:
-                    msg = self.last_subscription_msgs_buffer.get(topic, None)
-                    self.get_logger().info("Waiting for message...")
-                    time.sleep(0.1)
-
-                success = msg is not None
-
-                if success:
-                    self.get_logger().debug(
-                        f"Received message of type {type(msg)} from topic {topic}"
-                    )
-                    return msg
-                else:
-                    error = f"No message received in {timeout_sec} seconds from topic {topic}"
-                    self.get_logger().error(error)
-                    return error
-            finally:
-                self.destroy_subscription_by_topic_name(topic)
-
-    def generic_state_subscriber_callback(self, topic_name: str, msg: Any):
-        self.get_logger().debug(
-            f"Received message of type {type(msg)} from topic {topic_name}"
-        )
-        self.last_subscription_msgs_buffer[topic_name] = msg
-
-    def has_subscription(self, topic: str) -> bool:
-        for sub in self.node._subscriptions:
-            if sub.topic == topic:
-                return True
-        return False
-
-    def destroy_subscription_by_topic_name(self, topic: str):
-        self.last_subscription_msgs_buffer.clear()
-        for sub in self.node._subscriptions:
-            if sub.topic == topic:
-                self.node.destroy_subscription(sub)
-
-
 class RaiBaseNode(Node):
     def __init__(
         self,
@@ -483,8 +128,8 @@ class RaiBaseNode(Node):
 
         # ---------- ROS helpers ----------
         self.ros_discovery_info = NodeDiscovery(self, allowlist=allowlist)
-        self.async_action_client = Ros2ActionsHelper(self)
-        self.topics_handler = Ros2TopicsHandler(
+        self.async_action_client = Ros2ActionsAPI(self)
+        self.topics_handler = Ros2TopicsAPI(
             self, self.callback_group, self.ros_discovery_info
         )
         self.ros_discovery_info.add_setter(self.topics_handler.set_ros_discovery_info)

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -45,7 +45,6 @@ from rclpy.qos import (
 from rclpy.topic_endpoint_info import TopicEndpointInfo
 from std_srvs.srv import Trigger
 
-import rai.utils.ros
 from rai.agents.state_based import Report, State, create_state_based_agent
 from rai.messages import HumanMultimodalMessage
 from rai.tools.ros.native import Ros2BaseTool
@@ -144,7 +143,7 @@ def ros2_build_msg(msg_type: str, msg_args: Dict[str, Any]) -> Tuple[object, Typ
     return msg, msg_cls
 
 
-class AsyncRos2ActionClient:
+class Ros2ActionsHelper:
     def __init__(self, node: rclpy.node.Node):
         self.node = node
 
@@ -475,7 +474,7 @@ class RaiBaseNode(Node):
 
         # ---------- ROS helpers ----------
         self.ros_discovery_info = NodeDiscovery(self, allowlist=allowlist)
-        self.async_action_client = AsyncRos2ActionClient(self)
+        self.async_action_client = Ros2ActionsHelper(self)
         self.topics_handler = Ros2TopicsHandler(
             self, self.callback_group, self.ros_discovery_info
         )
@@ -508,7 +507,7 @@ class RaiBaseNode(Node):
 
     # ------------- other methods -------------
     def spin(self):
-        executor = rai.utils.ros.MultiThreadedExecutorFixed()
+        executor = rclpy.executors.MultiThreadedExecutor()
         executor.add_node(self)
         executor.spin()
         rclpy.shutdown()

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -519,7 +519,6 @@ class RaiBaseNode(Node):
         executor = MultiThreadedExecutorFixed()
         executor.add_node(self)
         executor.spin()
-        rclpy.shutdown()
 
 
 def parse_task_goal(ros_action_goal: TaskAction.Goal) -> Dict[str, Any]:

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Un
 import rclpy
 import rclpy.callback_groups
 import rclpy.executors
+import rclpy.node
 import rclpy.qos
 import rclpy.subscription
 import rclpy.task
@@ -32,7 +33,6 @@ from langchain.tools.render import render_text_description_and_args
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langgraph.graph.graph import CompiledGraph
 from rclpy.action.client import ActionClient
-from rclpy.action.graph import get_action_names_and_types
 from rclpy.action.server import ActionServer, GoalResponse, ServerGoalHandle
 from rclpy.node import Node
 from rclpy.qos import (
@@ -52,6 +52,7 @@ from rai.tools.ros.native import Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_base64, import_message_from_str
 from rai.utils.model_initialization import get_llm_model, get_tracing_callbacks
 from rai.utils.ros import NodeDiscovery
+from rai.utils.ros_async import get_future_result
 from rai.utils.ros_logs import create_logs_parser
 from rai_interfaces.action import Task as TaskAction
 
@@ -92,15 +93,15 @@ def append_whoami_info_to_prompt(
         node.get_logger().info("Identity service not available, waiting again...")
 
     constitution_future = constitution_service.call_async(Trigger.Request())
-    rclpy.spin_until_future_complete(node, constitution_future)
-    constitution_response = constitution_future.result()
+    constitution_response: Optional[Trigger.Response] = get_future_result(
+        constitution_future
+    )
     constitution_message = (
         "" if constitution_response is None else constitution_response.message
     )
 
     identity_future = identity_service.call_async(Trigger.Request())
-    rclpy.spin_until_future_complete(node, identity_future)
-    identity_response = identity_future.result()
+    identity_response: Optional[Trigger.Response] = get_future_result(identity_future)
     identity_message = "" if identity_response is None else identity_response.message
 
     system_prompt = WHOAMI_SYSTEM_PROMPT_TEMPLATE.format(
@@ -143,36 +144,24 @@ def ros2_build_msg(msg_type: str, msg_args: Dict[str, Any]) -> Tuple[object, Typ
     return msg, msg_cls
 
 
-class RaiBaseNode(Node):
-    def __init__(
-        self,
-        allowlist: Optional[List[str]] = None,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-
-        self.DISCOVERY_FREQ = 2.0
-        self.DISCOVERY_DEPTH = 5
-        self.timer = self.create_timer(
-            self.DISCOVERY_FREQ,
-            self.discovery,
-        )
-        self.ros_discovery_info = NodeDiscovery(allowlist=allowlist)
-        self.discovery()
-        self.qos_profile_cache: Dict[str, QoSProfile] = dict()
-
-        executor = rai.utils.ros.MultiThreadedExecutorFixed()
-        executor.add_node(self)
-        self.ros_executor = executor
+class AsyncRos2ActionClient:
+    def __init__(self, node: rclpy.node.Node):
+        self.node = node
 
         self.goal_handle = None
         self.result_future = None
         self.feedback = None
-        self.status = None
+        self.status: Optional[int] = None
+        self.client: Optional[ActionClient] = None
+        self.action_feedback: Optional[Any] = None
 
-    def _run_action(self, action_name, action_type, action_goal_args):
-        if not self._is_task_complete():
+    def get_logger(self):
+        return self.node.get_logger()
+
+    def run_action(
+        self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
+    ):
+        if not self.is_task_complete():
             raise AssertionError(
                 "Another ros2 action is currently running and parallel actions are not supported. Please wait until the previous action is complete before starting a new one. You can also cancel the current one."
             )
@@ -186,7 +175,7 @@ class RaiBaseNode(Node):
         except Exception as e:
             return f"Failed to build message: {e}"
 
-        self.client = ActionClient(self, msg_cls, action_name)
+        self.client = ActionClient(self.node, msg_cls, action_name)
         self.msg_cls = msg_cls
 
         retries = 0
@@ -206,8 +195,8 @@ class RaiBaseNode(Node):
             goal_msg, self._feedback_callback
         )
         self.get_logger().info("Action goal sent!")
-        rclpy.spin_until_future_complete(self, send_goal_future)
-        self.goal_handle = send_goal_future.result()
+
+        self.goal_handle = get_future_result(send_goal_future)
 
         if not self.goal_handle:
             raise Exception(f"Action '{action_name}' not sent to server")
@@ -219,8 +208,8 @@ class RaiBaseNode(Node):
         self.get_logger().info("Action sent!")
         return f"{action_name} started successfully with args: {action_goal_args}"
 
-    def _get_task_result(self) -> str:
-        if not self._is_task_complete():
+    def get_task_result(self) -> str:
+        if not self.is_task_complete():
             return "Task is not complete yet"
 
         def parse_status(status: int) -> str:
@@ -236,8 +225,7 @@ class RaiBaseNode(Node):
 
         result = self.result_future.result()
 
-        self.destroy_client(self.client)
-
+        self.destroy_client()
         if result.status == GoalStatus.STATUS_SUCCEEDED:
             msg = f"Result succeeded: {result.result}"
             self.get_logger().info(msg)
@@ -260,13 +248,14 @@ class RaiBaseNode(Node):
         self.get_logger().info(f"Received ros2 action feedback: {msg}")
         self.action_feedback = msg
 
-    def _is_task_complete(self):
+    def is_task_complete(self):
         if not self.result_future:
             # task was cancelled or completed
             return True
-        rclpy.spin_until_future_complete(self, self.result_future, timeout_sec=0.10)
-        if self.result_future.result():
-            self.status = self.result_future.result().status
+
+        result = get_future_result(self.result_future, timeout_sec=0.10)
+        if result is not None:
+            self.status = result.status
             if self.status != GoalStatus.STATUS_SUCCEEDED:
                 self.get_logger().debug(
                     f"Task with failed with status code: {self.status}"
@@ -280,183 +269,46 @@ class RaiBaseNode(Node):
         self.get_logger().info("Task succeeded!")
         return True
 
-    def _cancel_task(self):
+    def cancel_task(self) -> Union[str, bool]:
         self.get_logger().info("Canceling current task.")
-        if self.result_future and self.goal_handle:
-            future = self.goal_handle.cancel_goal_async()
-            rclpy.spin_until_future_complete(self, future)
-        self.destroy_client(self.client)
-        return True
+        try:
+            if self.result_future and self.goal_handle:
+                future = self.goal_handle.cancel_goal_async()
+                result = get_future_result(future, timeout_sec=1.0)
+                return "Failed to cancel result" if result is None else True
+            return True
+        finally:
+            self.destroy_client()
 
-    def spin(self):
-        self.ros_executor.spin()
-        rclpy.shutdown()
-
-    def discovery(self):
-        self.ros_discovery_info.set(
-            self.get_topic_names_and_types(),
-            self.get_service_names_and_types(),
-            get_action_names_and_types(self),
-        )
-
-    def get_msg_type(self, topic: str, n_tries: int = 5) -> Any:
-        """Sometimes node fails to do full discovery, therefore we need to retry"""
-        for _ in range(n_tries):
-            if topic in self.ros_discovery_info.topics_and_types:
-                msg_type = self.ros_discovery_info.topics_and_types[topic]
-                return import_message_from_str(msg_type)
-            else:
-                self.get_logger().info(f"Waiting for topic: {topic}")
-                self.discovery()
-                time.sleep(self.DISCOVERY_FREQ)
-        raise KeyError(f"Topic {topic} not found")
+    def destroy_client(self):
+        if self.client:
+            self.client.destroy()
 
 
-def parse_task_goal(ros_action_goal: TaskAction.Goal) -> Dict[str, Any]:
-    return dict(
-        task=ros_action_goal.task,
-        description=ros_action_goal.description,
-        priority=ros_action_goal.priority,
-    )
-
-
-class RaiStateBasedLlmNode(RaiBaseNode):
-    AGENT_RECURSION_LIMIT = 500
-
+class Ros2TopicsHandler:
     def __init__(
         self,
-        system_prompt: str,
-        observe_topics: Optional[List[str]] = None,
-        observe_postprocessors: Optional[Dict[str, Callable[[Any], Any]]] = None,
-        allowlist: Optional[List[str]] = None,
-        tools: Optional[List[Type[BaseTool]]] = None,
-        logs_parser_type: Literal["llm", "rai_state_logs"] = "rai_state_logs",
-        *args,
-        **kwargs,
-    ):
-        super().__init__(
-            node_name="rai_node",
-            allowlist=allowlist,
-            *args,
-            **kwargs,
+        node: rclpy.node.Node,
+        callback_group: rclpy.callback_groups.CallbackGroup,
+        ros_discovery_info: NodeDiscovery,
+    ) -> None:
+        self.node = node
+        self.qos_profile = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            durability=DurabilityPolicy.VOLATILE,
+            liveliness=LivelinessPolicy.AUTOMATIC,
         )
-
-        # ---------- ROS configuration ----------
-        self.callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
-
-        # ---------- Robot State ----------
+        self.callback_group = callback_group
         self.last_subscription_msgs_buffer = dict()
-        self.state_topics = observe_topics if observe_topics is not None else []
-        self.state_postprocessors = (
-            observe_postprocessors if observe_postprocessors is not None else dict()
-        )
-        self._initialize_robot_state_interfaces(self.state_topics)
-        self.state_update_timer = self.create_timer(
-            7.0,
-            self.state_update_callback,
-            callback_group=rclpy.callback_groups.MutuallyExclusiveCallbackGroup(),
-        )
-        self.state_dict = dict()
+        self.qos_profile_cache: Dict[str, QoSProfile] = dict()
 
-        # ---------- Task Queue ----------
-        self.task_action_server = ActionServer(
-            self,
-            TaskAction,
-            "perform_task",
-            execute_callback=self.agent_loop,
-            goal_callback=self.goal_callback,
-        )
-        # Node is busy when task is executed. Only 1 task is allowed
-        self.busy = False
-        self.current_task = None
+        self.ros_discovery_info = ros_discovery_info
 
-        # ---------- LLM Agents ----------
-        self.tools = self._initialize_tools(tools) if tools is not None else []
-        self.system_prompt = self._initialize_system_prompt(system_prompt)
-        self.llm_app: CompiledGraph = create_state_based_agent(
-            llm=get_llm_model(model_type="complex_model"),
-            tools=self.tools,
-            state_retriever=self.get_robot_state,
-            logger=self.get_logger(),
-        )
-
-        # We have to use a separate node that we can manually spin for ros-service based
-        # parser and this node ros-subscriber based parser
-        logs_parser_node = self if logs_parser_type == "llm" else self._async_tool_node
-        self.logs_parser = create_logs_parser(
-            logs_parser_type, logs_parser_node, callback_group=self.callback_group
-        )
-        self.simple_llm = get_llm_model(model_type="simple_model")
-
-    def summarize_logs(self) -> str:
-        return self.logs_parser.summarize()
-
-    def _initialize_tools(self, tools: List[Type[BaseTool]]):
-        initialized_tools: List[BaseTool] = list()
-        for tool_cls in tools:
-            if issubclass(tool_cls, Ros2BaseTool):
-                tool = tool_cls(node=self)
-            else:
-                tool = tool_cls()
-
-            initialized_tools.append(tool)
-        return initialized_tools
-
-    def _initialize_system_prompt(self, prompt: str):
-        system_prompt = append_whoami_info_to_prompt(self, prompt)
-        system_prompt = append_tools_text_description_to_prompt(
-            system_prompt, self.tools
-        )
-        return system_prompt
-
-    def _initialize_robot_state_interfaces(self, topics: List[str]):
-        for topic in topics:
-            self.create_subscription_by_topic_name(topic)
-
-    def get_raw_message_from_topic(self, topic: str, timeout_sec: int = 5) -> Any:
-        self.get_logger().debug(f"Getting msg from topic: {topic}")
-
-        ts = time.perf_counter()
-
-        if topic not in self.ros_discovery_info.topics_and_types:
-            raise KeyError(
-                f"Topic {topic} not found. Available topics: {self.ros_discovery_info.topics_and_types.keys()}"
-            )
-
-        if topic in self.last_subscription_msgs_buffer:
-            self.get_logger().info("Returning cached message")
-            return self.last_subscription_msgs_buffer[topic]
-        else:
-            self.create_subscription_by_topic_name(topic)
-            try:
-                msg = self.last_subscription_msgs_buffer.get(topic, None)
-                while msg is None and time.perf_counter() - ts < timeout_sec:
-                    msg = self.last_subscription_msgs_buffer.get(topic, None)
-                    rclpy.spin_once(self, timeout_sec=0.1)
-                    self.get_logger().info("Waiting for message...")
-                    time.sleep(0.1)
-
-                success = msg is not None
-
-                if success:
-                    self.get_logger().debug(
-                        f"Received message of type {type(msg)} from topic {topic}"
-                    )
-                    return msg
-                else:
-                    error = f"No message received in {timeout_sec} seconds from topic {topic}"
-                    self.get_logger().error(error)
-                    return error
-            finally:
-                self.destroy_subscription_by_topic_name(topic)
-
-    def generic_state_subscriber_callback(self, topic_name: str, msg: Any):
-        self.get_logger().debug(
-            f"Received message of type {type(msg)} from topic {topic_name}"
-        )
-
-        self.last_subscription_msgs_buffer[topic_name] = msg
-
+    def get_logger(self):
+        return self.node.get_logger()
+    
     def adapt_requests_to_offers(
         self, publisher_info: List[TopicEndpointInfo]
     ) -> QoSProfile:
@@ -518,7 +370,7 @@ class RaiStateBasedLlmNode(RaiBaseNode):
         if topic not in self.qos_profile_cache:
             self.get_logger().debug(f"Getting qos profile for topic: {topic}")
             qos_profile = self.adapt_requests_to_offers(
-                self.get_publishers_info_by_topic(topic)
+                self.node.get_publishers_info_by_topic(topic)
             )
             self.qos_profile_cache[topic] = qos_profile
         else:
@@ -529,26 +381,237 @@ class RaiStateBasedLlmNode(RaiBaseNode):
             self.generic_state_subscriber_callback, topic
         )
 
-
-        self.create_subscription(
+        self.node.create_subscription(
             msg_type,
             topic,
             callback=topic_callback,
             callback_group=self.callback_group,
             qos_profile=qos_profile,
         )
+    
+    def get_msg_type(self, topic: str, n_tries: int = 5) -> Any:
+        """Sometimes node fails to do full discovery, therefore we need to retry"""
+        for _ in range(n_tries):
+            if topic in self.ros_discovery_info.topics_and_types:
+                msg_type = self.ros_discovery_info.topics_and_types[topic]
+                return import_message_from_str(msg_type)
+            else:
+                # Wait for next discovery cycle
+                self.get_logger().info(f"Waiting for topic: {topic}")
+                if self.ros_discovery_info:
+                    time.sleep(self.ros_discovery_info.period_sec)
+                else:
+                    time.sleep(1.0)
+        raise KeyError(f"Topic {topic} not found")
+
+    def set_ros_discovery_info(self, new_ros_discovery_info: NodeDiscovery):
+        self.ros_discovery_info = new_ros_discovery_info
+
+    def get_raw_message_from_topic(self, topic: str, timeout_sec: int = 5) -> Any:
+        self.get_logger().debug(f"Getting msg from topic: {topic}")
+
+        ts = time.perf_counter()
+
+        if topic not in self.ros_discovery_info.topics_and_types:
+            raise KeyError(
+                f"Topic {topic} not found. Available topics: {self.ros_discovery_info.topics_and_types.keys()}"
+            )
+
+        if topic in self.last_subscription_msgs_buffer:
+            self.get_logger().info("Returning cached message")
+            return self.last_subscription_msgs_buffer[topic]
+        else:
+            self.create_subscription_by_topic_name(topic)
+            try:
+                msg = self.last_subscription_msgs_buffer.get(topic, None)
+                while msg is None and time.perf_counter() - ts < timeout_sec:
+                    msg = self.last_subscription_msgs_buffer.get(topic, None)
+                    self.get_logger().info("Waiting for message...")
+                    time.sleep(0.1)
+
+                success = msg is not None
+
+                if success:
+                    self.get_logger().debug(
+                        f"Received message of type {type(msg)} from topic {topic}"
+                    )
+                    return msg
+                else:
+                    error = f"No message received in {timeout_sec} seconds from topic {topic}"
+                    self.get_logger().error(error)
+                    return error
+            finally:
+                self.destroy_subscription_by_topic_name(topic)
+
+    def generic_state_subscriber_callback(self, topic_name: str, msg: Any):
+        self.get_logger().debug(
+            f"Received message of type {type(msg)} from topic {topic_name}"
+        )
+        self.last_subscription_msgs_buffer[topic_name] = msg
 
     def has_subscription(self, topic: str) -> bool:
-        for sub in self._subscriptions:
+        for sub in self.node._subscriptions:
             if sub.topic == topic:
                 return True
         return False
 
     def destroy_subscription_by_topic_name(self, topic: str):
         self.last_subscription_msgs_buffer.clear()
-        for sub in self._subscriptions:
+        for sub in self.node._subscriptions:
             if sub.topic == topic:
-                self.destroy_subscription(sub)
+                self.node.destroy_subscription(sub)
+
+
+class RaiBaseNode(Node):
+    def __init__(
+        self,
+        allowlist: Optional[List[str]] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        # ---------- ROS configuration ----------
+        self.callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
+        # ---------- ROS helpers ----------
+        self.ros_discovery_info = NodeDiscovery(self, allowlist=allowlist)
+        self.async_action_client = AsyncRos2ActionClient(self)
+        self.topics_handler = Ros2TopicsHandler(
+            self, self.callback_group, self.ros_discovery_info
+        )
+        self.ros_discovery_info.add_setter(self.topics_handler.set_ros_discovery_info)
+
+    # ------------- ros2 topics interface -------------
+    def get_raw_message_from_topic(self, topic: str, timeout_sec: int = 5) -> Any:
+        return self.topics_handler.get_raw_message_from_topic(topic, timeout_sec)
+
+    # ------------- ros2 actions interface -------------
+    def run_action(
+        self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
+    ):
+        return self.async_action_client.run_action(
+            action_name, action_type, action_goal_args
+        )
+
+    def get_task_result(self) -> str:
+        return self.async_action_client.get_task_result()
+
+    def is_task_complete(self) -> bool:
+        return self.async_action_client.is_task_complete()
+
+    @property
+    def action_feedback(self) -> Any:
+        return self.async_action_client.action_feedback
+
+    def cancel_task(self) -> Union[str, bool]:
+        return self.async_action_client.cancel_task()
+
+    # ------------- other methods -------------
+    def spin(self):
+        executor = rai.utils.ros.MultiThreadedExecutorFixed()
+        executor.add_node(self)
+        executor.spin()
+        rclpy.shutdown()
+
+
+def parse_task_goal(ros_action_goal: TaskAction.Goal) -> Dict[str, Any]:
+    return dict(
+        task=ros_action_goal.task,
+        description=ros_action_goal.description,
+        priority=ros_action_goal.priority,
+    )
+
+
+class RaiStateBasedLlmNode(RaiBaseNode):
+    AGENT_RECURSION_LIMIT = 500
+    STATE_UPDATE_PERIOD = 5.0
+
+    def __init__(
+        self,
+        system_prompt: str,
+        observe_topics: Optional[List[str]] = None,
+        observe_postprocessors: Optional[Dict[str, Callable[[Any], Any]]] = None,
+        allowlist: Optional[List[str]] = None,
+        tools: Optional[List[Type[BaseTool]]] = None,
+        logs_parser_type: Literal["llm", "rai_state_logs"] = "rai_state_logs",
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            node_name="rai_node",
+            allowlist=allowlist,
+            *args,
+            **kwargs,
+        )
+
+        # ---------- Robot State ----------
+        self.state_topics = observe_topics if observe_topics is not None else []
+        self.state_postprocessors = (
+            observe_postprocessors if observe_postprocessors is not None else dict()
+        )
+        self._initialize_robot_state_interfaces(self.state_topics)
+        self.state_update_timer = self.create_timer(
+            self.STATE_UPDATE_PERIOD,
+            self.state_update_callback,
+            callback_group=rclpy.callback_groups.MutuallyExclusiveCallbackGroup(),
+        )
+        self.state_dict = dict()
+
+        # ---------- Task Queue ----------
+        self.task_action_server = ActionServer(
+            self,
+            TaskAction,
+            "perform_task",
+            execute_callback=self.agent_loop,
+            callback_group=self.callback_group,
+            goal_callback=self.goal_callback,
+        )
+        # Node is busy when task is executed. Only 1 task is allowed
+        self.busy = False
+        self.current_task = None
+
+        # ---------- LLM Agents ----------
+        self.tools = self._initialize_tools(tools) if tools is not None else []
+        self.system_prompt = self._initialize_system_prompt(system_prompt)
+        self.llm_app: CompiledGraph = create_state_based_agent(
+            llm=get_llm_model(model_type="complex_model"),
+            tools=self.tools,
+            state_retriever=self.get_robot_state,
+            logger=self.get_logger(),
+        )
+
+        self.simple_llm = get_llm_model(model_type="simple_model")
+        self.logs_parser = create_logs_parser(
+            logs_parser_type,
+            self,
+            callback_group=self.callback_group,
+            llm=self.simple_llm,
+        )
+
+    def summarize_logs(self) -> str:
+        return self.logs_parser.summarize()
+
+    def _initialize_tools(self, tools: List[Type[BaseTool]]):
+        initialized_tools: List[BaseTool] = list()
+        for tool_cls in tools:
+            if issubclass(tool_cls, Ros2BaseTool):
+                tool = tool_cls(node=self)
+            else:
+                tool = tool_cls()
+
+            initialized_tools.append(tool)
+        return initialized_tools
+
+    def _initialize_system_prompt(self, prompt: str):
+        system_prompt = append_whoami_info_to_prompt(self, prompt)
+        system_prompt = append_tools_text_description_to_prompt(
+            system_prompt, self.tools
+        )
+        return system_prompt
+
+    def _initialize_robot_state_interfaces(self, topics: List[str]):
+        for topic in topics:
+            self.topics_handler.create_subscription_by_topic_name(topic)
 
     def goal_callback(self, _) -> GoalResponse:
         """Accept or reject a client request to begin an action."""
@@ -657,6 +720,7 @@ class RaiStateBasedLlmNode(RaiBaseNode):
             self.current_task = None
 
     def state_update_callback(self):
+        self.get_logger().info("Updating state.")
         state_dict = dict()
         state_dict["current_task"] = self.current_task
 
@@ -670,18 +734,18 @@ class RaiStateBasedLlmNode(RaiBaseNode):
         self.get_logger().info(f"Logs summary retrieved in: {te:.2f}")
         self.get_logger().debug(f"{state_dict=}")
 
-        if self.last_subscription_msgs_buffer is None:
+        if self.topics_handler.last_subscription_msgs_buffer is None:
             self.state_dict = state_dict
             return
 
         for t in self.state_topics:
-            if t not in self.last_subscription_msgs_buffer:
+            if t not in self.topics_handler.last_subscription_msgs_buffer:
                 msg = "No message yet"
                 state_dict[t] = msg
                 continue
 
             ts = time.perf_counter()
-            msg = self.last_subscription_msgs_buffer[t]
+            msg = self.topics_handler.last_subscription_msgs_buffer[t]
             if t in self.state_postprocessors:
                 msg = self.state_postprocessors[t](msg)
             te = time.perf_counter() - ts
@@ -690,6 +754,7 @@ class RaiStateBasedLlmNode(RaiBaseNode):
             state_dict[t] = msg
 
         self.state_dict = state_dict
+        self.get_logger().info("State updated.")
 
     def get_robot_state(self) -> Dict[str, str]:
         return self.state_dict

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -52,6 +52,7 @@ from rai.tools.ros.utils import convert_ros_img_to_base64, import_message_from_s
 from rai.utils.model_initialization import get_llm_model, get_tracing_callbacks
 from rai.utils.ros import NodeDiscovery
 from rai.utils.ros_async import get_future_result
+from rai.utils.ros_executors import MultiThreadedExecutorFixed
 from rai.utils.ros_logs import create_logs_parser
 from rai_interfaces.action import Task as TaskAction
 
@@ -515,7 +516,7 @@ class RaiBaseNode(Node):
 
     # ------------- other methods -------------
     def spin(self):
-        executor = rclpy.executors.MultiThreadedExecutor()
+        executor = MultiThreadedExecutorFixed()
         executor.add_node(self)
         executor.spin()
         rclpy.shutdown()

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -237,10 +237,9 @@ class Ros2ActionsHelper:
             return msg
 
     def parse_error_code(self, code: int) -> str:
-        name_to_code = self.msg_cls.Result.__prepare__(
-            name="", bases=""
-        )  # arguments are not used
-        code_to_name = {v: k for k, v in name_to_code.items()}
+        code_to_name = {
+            v: k for k, v in vars(self.msg_cls.Result).items() if isinstance(v, int)
+        }
         return code_to_name.get(code, "UNKNOWN")
 
     def _feedback_callback(self, msg):

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -307,7 +307,7 @@ class Ros2TopicsHandler:
 
     def get_logger(self):
         return self.node.get_logger()
-    
+
     def adapt_requests_to_offers(
         self, publisher_info: List[TopicEndpointInfo]
     ) -> QoSProfile:
@@ -363,9 +363,9 @@ class Ros2TopicsHandler:
                 f"Subscription to {topic} already exists. To override use destroy_subscription_by_topic_name first"
             )
             return
-       
+
         msg_type = self.get_msg_type(topic)
-        
+
         if topic not in self.qos_profile_cache:
             self.get_logger().debug(f"Getting qos profile for topic: {topic}")
             qos_profile = self.adapt_requests_to_offers(
@@ -387,7 +387,7 @@ class Ros2TopicsHandler:
             callback_group=self.callback_group,
             qos_profile=qos_profile,
         )
-    
+
     def get_msg_type(self, topic: str, n_tries: int = 5) -> Any:
         """Sometimes node fails to do full discovery, therefore we need to retry"""
         for _ in range(n_tries):

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -406,10 +406,19 @@ class Ros2TopicsHandler:
     def set_ros_discovery_info(self, new_ros_discovery_info: NodeDiscovery):
         self.ros_discovery_info = new_ros_discovery_info
 
-    def get_raw_message_from_topic(self, topic: str, timeout_sec: int = 5) -> Any:
+    def get_raw_message_from_topic(
+        self, topic: str, timeout_sec: int = 5, topic_wait_sec: int = 2
+    ) -> Any:
         self.get_logger().debug(f"Getting msg from topic: {topic}")
 
         ts = time.perf_counter()
+
+        for _ in range(topic_wait_sec * 10):
+            if topic not in self.ros_discovery_info.topics_and_types:
+                time.sleep(0.1)
+                continue
+            else:
+                break
 
         if topic not in self.ros_discovery_info.topics_and_types:
             raise KeyError(

--- a/src/rai/rai/ros2_apis.py
+++ b/src/rai/rai/ros2_apis.py
@@ -1,0 +1,363 @@
+import functools
+import time
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+import rclpy
+import rclpy.callback_groups
+import rclpy.executors
+import rclpy.node
+import rclpy.qos
+import rclpy.subscription
+import rclpy.task
+import rosidl_runtime_py.set_message
+import rosidl_runtime_py.utilities
+from action_msgs.msg import GoalStatus
+from rclpy.action.client import ActionClient
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    LivelinessPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from rclpy.topic_endpoint_info import TopicEndpointInfo
+
+from rai.tools.ros.utils import import_message_from_str
+from rai.utils.ros import NodeDiscovery
+from rai.utils.ros_async import get_future_result
+
+
+def ros2_build_msg(msg_type: str, msg_args: Dict[str, Any]) -> Tuple[object, Type]:
+    """
+    Import message and create it. Return both ready message and message class.
+
+    msgs args can have two formats:
+    { "goal" : {arg 1 : xyz, ... } or {arg 1 : xyz, ... }
+    """
+
+    msg_cls: Type = rosidl_runtime_py.utilities.get_interface(msg_type)
+    msg = msg_cls.Goal()
+
+    if "goal" in msg_args:
+        msg_args = msg_args["goal"]
+    rosidl_runtime_py.set_message.set_message_fields(msg, msg_args)
+    return msg, msg_cls
+
+
+class Ros2TopicsAPI:
+    def __init__(
+        self,
+        node: rclpy.node.Node,
+        callback_group: rclpy.callback_groups.CallbackGroup,
+        ros_discovery_info: NodeDiscovery,
+    ) -> None:
+        self.node = node
+        self.callback_group = callback_group
+        self.last_subscription_msgs_buffer = dict()
+        self.qos_profile_cache: Dict[str, QoSProfile] = dict()
+
+        self.ros_discovery_info = ros_discovery_info
+
+    def get_logger(self):
+        return self.node.get_logger()
+
+    def adapt_requests_to_offers(
+        self, publisher_info: List[TopicEndpointInfo]
+    ) -> QoSProfile:
+        if not publisher_info:
+            return QoSProfile(depth=1)
+
+        num_endpoints = len(publisher_info)
+        reliability_reliable_count = 0
+        durability_transient_local_count = 0
+
+        for endpoint in publisher_info:
+            profile = endpoint.qos_profile
+            if profile.reliability == ReliabilityPolicy.RELIABLE:
+                reliability_reliable_count += 1
+            if profile.durability == DurabilityPolicy.TRANSIENT_LOCAL:
+                durability_transient_local_count += 1
+
+        request_qos = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            liveliness=LivelinessPolicy.AUTOMATIC,
+        )
+
+        # Set reliability based on publisher offers
+        if reliability_reliable_count == num_endpoints:
+            request_qos.reliability = ReliabilityPolicy.RELIABLE
+        else:
+            if reliability_reliable_count > 0:
+                self.get_logger().warning(
+                    "Some, but not all, publishers are offering RELIABLE reliability. "
+                    "Falling back to BEST_EFFORT as it will connect to all publishers. "
+                    "Some messages from Reliable publishers could be dropped."
+                )
+            request_qos.reliability = ReliabilityPolicy.BEST_EFFORT
+
+        # Set durability based on publisher offers
+        if durability_transient_local_count == num_endpoints:
+            request_qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        else:
+            if durability_transient_local_count > 0:
+                self.get_logger().warning(
+                    "Some, but not all, publishers are offering TRANSIENT_LOCAL durability. "
+                    "Falling back to VOLATILE as it will connect to all publishers. "
+                    "Previously-published latched messages will not be retrieved."
+                )
+            request_qos.durability = DurabilityPolicy.VOLATILE
+
+        return request_qos
+
+    def create_subscription_by_topic_name(self, topic):
+        if self.has_subscription(topic):
+            self.get_logger().warning(
+                f"Subscription to {topic} already exists. To override use destroy_subscription_by_topic_name first"
+            )
+            return
+
+        msg_type = self.get_msg_type(topic)
+
+        if topic not in self.qos_profile_cache:
+            self.get_logger().debug(f"Getting qos profile for topic: {topic}")
+            qos_profile = self.adapt_requests_to_offers(
+                self.node.get_publishers_info_by_topic(topic)
+            )
+            self.qos_profile_cache[topic] = qos_profile
+        else:
+            self.get_logger().debug(f"Using cached qos profile for topic: {topic}")
+            qos_profile = self.qos_profile_cache[topic]
+
+        topic_callback = functools.partial(
+            self.generic_state_subscriber_callback, topic
+        )
+
+        self.node.create_subscription(
+            msg_type,
+            topic,
+            callback=topic_callback,
+            callback_group=self.callback_group,
+            qos_profile=qos_profile,
+        )
+
+    def get_msg_type(self, topic: str, n_tries: int = 5) -> Any:
+        """Sometimes node fails to do full discovery, therefore we need to retry"""
+        for _ in range(n_tries):
+            if topic in self.ros_discovery_info.topics_and_types:
+                msg_type = self.ros_discovery_info.topics_and_types[topic]
+                return import_message_from_str(msg_type)
+            else:
+                # Wait for next discovery cycle
+                self.get_logger().info(f"Waiting for topic: {topic}")
+                if self.ros_discovery_info:
+                    time.sleep(self.ros_discovery_info.period_sec)
+                else:
+                    time.sleep(1.0)
+        raise KeyError(f"Topic {topic} not found")
+
+    def set_ros_discovery_info(self, new_ros_discovery_info: NodeDiscovery):
+        self.ros_discovery_info = new_ros_discovery_info
+
+    def get_raw_message_from_topic(
+        self, topic: str, timeout_sec: int = 5, topic_wait_sec: int = 2
+    ) -> Any:
+        self.get_logger().debug(f"Getting msg from topic: {topic}")
+
+        ts = time.perf_counter()
+
+        for _ in range(topic_wait_sec * 10):
+            if topic not in self.ros_discovery_info.topics_and_types:
+                time.sleep(0.1)
+                continue
+            else:
+                break
+
+        if topic not in self.ros_discovery_info.topics_and_types:
+            raise KeyError(
+                f"Topic {topic} not found. Available topics: {self.ros_discovery_info.topics_and_types.keys()}"
+            )
+
+        if topic in self.last_subscription_msgs_buffer:
+            self.get_logger().info("Returning cached message")
+            return self.last_subscription_msgs_buffer[topic]
+        else:
+            self.create_subscription_by_topic_name(topic)
+            try:
+                msg = self.last_subscription_msgs_buffer.get(topic, None)
+                while msg is None and time.perf_counter() - ts < timeout_sec:
+                    msg = self.last_subscription_msgs_buffer.get(topic, None)
+                    self.get_logger().info("Waiting for message...")
+                    time.sleep(0.1)
+
+                success = msg is not None
+
+                if success:
+                    self.get_logger().debug(
+                        f"Received message of type {type(msg)} from topic {topic}"
+                    )
+                    return msg
+                else:
+                    error = f"No message received in {timeout_sec} seconds from topic {topic}"
+                    self.get_logger().error(error)
+                    return error
+            finally:
+                self.destroy_subscription_by_topic_name(topic)
+
+    def generic_state_subscriber_callback(self, topic_name: str, msg: Any):
+        self.get_logger().debug(
+            f"Received message of type {type(msg)} from topic {topic_name}"
+        )
+        self.last_subscription_msgs_buffer[topic_name] = msg
+
+    def has_subscription(self, topic: str) -> bool:
+        for sub in self.node._subscriptions:
+            if sub.topic == topic:
+                return True
+        return False
+
+    def destroy_subscription_by_topic_name(self, topic: str):
+        self.last_subscription_msgs_buffer.clear()
+        for sub in self.node._subscriptions:
+            if sub.topic == topic:
+                self.node.destroy_subscription(sub)
+
+
+class Ros2ActionsAPI:
+    def __init__(self, node: rclpy.node.Node):
+        self.node = node
+
+        self.goal_handle = None
+        self.result_future = None
+        self.feedback = None
+        self.status: Optional[int] = None
+        self.client: Optional[ActionClient] = None
+        self.action_feedback: Optional[Any] = None
+
+    def get_logger(self):
+        return self.node.get_logger()
+
+    def run_action(
+        self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
+    ):
+        if not self.is_task_complete():
+            raise AssertionError(
+                "Another ros2 action is currently running and parallel actions are not supported. Please wait until the previous action is complete before starting a new one. You can also cancel the current one."
+            )
+
+        if action_name[0] != "/":
+            action_name = "/" + action_name
+            self.get_logger().info(f"Action name corrected to: {action_name}")
+
+        try:
+            goal_msg, msg_cls = ros2_build_msg(action_type, action_goal_args)
+        except Exception as e:
+            return f"Failed to build message: {e}"
+
+        self.client = ActionClient(self.node, msg_cls, action_name)
+        self.msg_cls = msg_cls
+
+        retries = 0
+        while not self.client.wait_for_server(timeout_sec=1.0):
+            retries += 1
+            if retries > 5:
+                raise Exception(
+                    f"Action server '{action_name}' is not available. Make sure `action_name` is correct..."
+                )
+            self.get_logger().info(
+                f"'{action_name}' action server not available, waiting..."
+            )
+
+        self.get_logger().info(f"Sending action message: {goal_msg}")
+
+        send_goal_future = self.client.send_goal_async(
+            goal_msg, self._feedback_callback
+        )
+        self.get_logger().info("Action goal sent!")
+
+        self.goal_handle = get_future_result(send_goal_future)
+
+        if not self.goal_handle:
+            raise Exception(f"Action '{action_name}' not sent to server")
+
+        if not self.goal_handle.accepted:
+            raise Exception(f"Action '{action_name}' not accepted by server")
+
+        self.result_future = self.goal_handle.get_result_async()
+        self.get_logger().info("Action sent!")
+        return f"{action_name} started successfully with args: {action_goal_args}"
+
+    def get_task_result(self) -> str:
+        if not self.is_task_complete():
+            return "Task is not complete yet"
+
+        def parse_status(status: int) -> str:
+            return {
+                GoalStatus.STATUS_SUCCEEDED: "succeeded",
+                GoalStatus.STATUS_ABORTED: "aborted",
+                GoalStatus.STATUS_CANCELED: "canceled",
+                GoalStatus.STATUS_ACCEPTED: "accepted",
+                GoalStatus.STATUS_CANCELING: "canceling",
+                GoalStatus.STATUS_EXECUTING: "executing",
+                GoalStatus.STATUS_UNKNOWN: "unknown",
+            }.get(status, "unknown")
+
+        result = self.result_future.result()
+
+        self.destroy_client()
+        if result.status == GoalStatus.STATUS_SUCCEEDED:
+            msg = f"Result succeeded: {result.result}"
+            self.get_logger().info(msg)
+            return msg
+        else:
+            str_status = parse_status(result.status)
+            error_code_str = self.parse_error_code(result.result.error_code)
+            msg = f"Result {str_status}, because of: error_code={result.result.error_code}({error_code_str}), error_msg={result.result.error_msg}"
+            self.get_logger().info(msg)
+            return msg
+
+    def parse_error_code(self, code: int) -> str:
+        code_to_name = {
+            v: k for k, v in vars(self.msg_cls.Result).items() if isinstance(v, int)
+        }
+        return code_to_name.get(code, "UNKNOWN")
+
+    def _feedback_callback(self, msg):
+        self.get_logger().info(f"Received ros2 action feedback: {msg}")
+        self.action_feedback = msg
+
+    def is_task_complete(self):
+        if not self.result_future:
+            # task was cancelled or completed
+            return True
+
+        result = get_future_result(self.result_future, timeout_sec=0.10)
+        if result is not None:
+            self.status = result.status
+            if self.status != GoalStatus.STATUS_SUCCEEDED:
+                self.get_logger().debug(
+                    f"Task with failed with status code: {self.status}"
+                )
+                return True
+        else:
+            self.get_logger().info("There is no result")
+            # Timed out, still processing, not complete yet
+            return False
+
+        self.get_logger().info("Task succeeded!")
+        return True
+
+    def cancel_task(self) -> Union[str, bool]:
+        self.get_logger().info("Canceling current task.")
+        try:
+            if self.result_future and self.goal_handle:
+                future = self.goal_handle.cancel_goal_async()
+                result = get_future_result(future, timeout_sec=1.0)
+                return "Failed to cancel result" if result is None else True
+            return True
+        finally:
+            self.destroy_client()
+
+    def destroy_client(self):
+        if self.client:
+            self.client.destroy()

--- a/src/rai/rai/ros2_apis.py
+++ b/src/rai/rai/ros2_apis.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import functools
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -184,7 +184,7 @@ class Ros2PubMessageTool(Ros2BaseTool):
         msg, msg_cls = self._build_msg(msg_type, msg_args)
 
         publisher = self.node.create_publisher(
-            msg_cls, topic_name, 10
+            msg_cls, topic_name, 10, callback_group=self.node.callback_group
         )  # TODO(boczekbartek): infer qos profile from topic info
 
         def callback():
@@ -192,7 +192,9 @@ class Ros2PubMessageTool(Ros2BaseTool):
             self.logger.info(f"Published message '{msg}' to topic '{topic_name}'")
 
         ts = time.perf_counter()
-        timer = self.node.create_timer(1.0 / rate, callback)
+        timer = self.node.create_timer(
+            1.0 / rate, callback, callback_group=self.node.callback_group
+        )
 
         while time.perf_counter() - ts < timeout_seconds:
             time.sleep(0.1)

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -141,7 +141,7 @@ class Ros2RunActionAsync(Ros2BaseActionTool):
     def _run(
         self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
     ):
-        return self.node._run_action(action_name, action_type, action_goal_args)
+        return self.node.run_action(action_name, action_type, action_goal_args)
 
 
 class Ros2IsActionComplete(Ros2BaseActionTool):
@@ -151,7 +151,7 @@ class Ros2IsActionComplete(Ros2BaseActionTool):
     args_schema: Type[Ros2BaseInput] = Ros2BaseInput
 
     def _run(self) -> bool:
-        return self.node._is_task_complete()
+        return self.node.is_task_complete()
 
 
 class Ros2GetActionResult(Ros2BaseActionTool):
@@ -161,7 +161,7 @@ class Ros2GetActionResult(Ros2BaseActionTool):
     args_schema: Type[Ros2BaseInput] = Ros2BaseInput
 
     def _run(self) -> bool:
-        return self.node._get_task_result()
+        return self.node.get_task_result()
 
 
 class Ros2CancelAction(Ros2BaseActionTool):
@@ -171,7 +171,7 @@ class Ros2CancelAction(Ros2BaseActionTool):
     args_schema: Type[Ros2BaseInput] = Ros2BaseInput
 
     def _run(self) -> bool:
-        return self.node._cancel_task()
+        return self.node.cancel_task()
 
 
 class Ros2GetLastActionFeedback(Ros2BaseActionTool):
@@ -197,7 +197,7 @@ class GetTransformTool(Ros2BaseActionTool):
 
     args_schema: Type[GetTransformInput] = GetTransformInput
 
-    def _run(self, target_frame="map", source_frame="body_link") -> dict:
+    def _run(self, target_frame="odom", source_frame="body_link") -> dict:
         return message_to_ordereddict(
             get_transform(self.node, target_frame, source_frame)
         )

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2024 Robotec.AI
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -187,9 +186,16 @@ class Ros2GetLastActionFeedback(Ros2BaseActionTool):
         return str(self.node.action_feedback)
 
 
+class GetTransformInput(BaseModel):
+    target_frame: str = Field(default="map", description="Target frame")
+    source_frame: str = Field(default="body_link", description="Source frame")
+
+
 class GetTransformTool(Ros2BaseActionTool):
     name: str = "GetTransform"
     description: str = "Get transform between two frames"
+
+    args_schema: Type[GetTransformInput] = GetTransformInput
 
     def _run(self, target_frame="map", source_frame="body_link") -> dict:
         return message_to_ordereddict(

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -197,7 +197,7 @@ class GetTransformTool(Ros2BaseActionTool):
 
     args_schema: Type[GetTransformInput] = GetTransformInput
 
-    def _run(self, target_frame="odom", source_frame="body_link") -> dict:
+    def _run(self, target_frame="map", source_frame="body_link") -> dict:
         return message_to_ordereddict(
             get_transform(self.node, target_frame, source_frame)
         )

--- a/src/rai/rai/tools/ros/utils.py
+++ b/src/rai/rai/tools/ros/utils.py
@@ -169,7 +169,7 @@ def get_transform(
         target_frame, source_frame, rclpy.time.Time()
     )
 
-    node.ros_executor.spin_until_future_complete(future, timeout_sec=timeout_sec)
+    rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
 
     transform = future.result()
 

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -12,18 +12,68 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+import rclpy.callback_groups
+import rclpy.node
+from rclpy.action.graph import get_action_names_and_types
+from rclpy.executors import (
+    ConditionReachedException,
+    ExternalShutdownException,
+    MultiThreadedExecutor,
+    ShutdownException,
+    TimeoutException,
+    TimeoutObject,
+)
 
-@dataclass
+
 class NodeDiscovery:
-    topics_and_types: Dict[str, str] = field(default_factory=dict)
-    services_and_types: Dict[str, str] = field(default_factory=dict)
-    actions_and_types: Dict[str, str] = field(default_factory=dict)
-    allowlist: Optional[List[str]] = field(default_factory=list)
+    def __init__(
+        self,
+        node: rclpy.node.Node,
+        allowlist: Optional[List[str]] = None,
+        period_sec: float = 2.0,
+        setters: Optional[List[Callable]] = None,
+    ) -> None:
+        self.period_sec = period_sec
+        self.node = node
+        self.allowlist = allowlist
 
-    def set(self, topics, services, actions):
+        self.topcies_and_types: Dict[str, str] = dict()
+        self.services_and_types: Dict[str, str] = dict()
+        self.actions_and_types: Dict[str, str] = dict()
+        self.allowlist: Optional[List[str]] = allowlist
+
+        self.timer = self.node.create_timer(
+            self.period_sec,
+            self.discovery_callback,
+            callback_group=rclpy.callback_groups.MutuallyExclusiveCallbackGroup(),
+        )
+
+        # callables (e.g. fun(x: NodeDiscovery)) that will receive the discovery info on every timer callback
+        # allows to register other entities that needs up-to-date discovery info
+        if setters is None:
+            self.setters = list()
+        else:
+            self.setters = setters
+
+        # make first callback as fast as possible
+        self.discovery_callback()
+
+    def add_setter(self, setter: Callable):
+        self.setters.append(setter)
+
+    def discovery_callback(self):
+        self.node.get_logger().info("Discovery callback")
+        self.__set(
+            self.node.get_topic_names_and_types(),
+            self.node.get_service_names_and_types(),
+            get_action_names_and_types(self.node),
+        )
+        for callable in self.setters:
+            callable(self)
+
+    def __set(self, topics, services, actions):
         def to_dict(info: List[Tuple[str, List[str]]]) -> Dict[str, str]:
             return {k: v[0] for k, v in info}
 

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -30,7 +30,6 @@ class NodeDiscovery:
     ) -> None:
         self.period_sec = period_sec
         self.node = node
-        self.allowlist = allowlist
 
         self.topics_and_types: Dict[str, str] = dict()
         self.services_and_types: Dict[str, str] = dict()

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -57,7 +57,6 @@ class NodeDiscovery:
         self.setters.append(setter)
 
     def discovery_callback(self):
-        self.node.get_logger().info("Discovery callback")
         self.__set(
             self.node.get_topic_names_and_types(),
             self.node.get_service_names_and_types(),

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -65,8 +65,8 @@ class NodeDiscovery:
             self.node.get_service_names_and_types(),
             get_action_names_and_types(self.node),
         )
-        for callable in self.setters:
-            callable(self)
+        for setter in self.setters:
+            setter(self)
 
     def __set(self, topics, services, actions):
         def to_dict(info: List[Tuple[str, List[str]]]) -> Dict[str, str]:

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -31,7 +31,7 @@ class NodeDiscovery:
         self.node = node
         self.allowlist = allowlist
 
-        self.topcies_and_types: Dict[str, str] = dict()
+        self.topics_and_types: Dict[str, str] = dict()
         self.services_and_types: Dict[str, str] = dict()
         self.actions_and_types: Dict[str, str] = dict()
         self.allowlist: Optional[List[str]] = allowlist

--- a/src/rai/rai/utils/ros.py
+++ b/src/rai/rai/utils/ros.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from typing import Callable, Dict, List, Optional, Tuple
 
 import rclpy.callback_groups
@@ -24,7 +25,7 @@ class NodeDiscovery:
         self,
         node: rclpy.node.Node,
         allowlist: Optional[List[str]] = None,
-        period_sec: float = 2.0,
+        period_sec: float = 0.5,
         setters: Optional[List[Callable]] = None,
     ) -> None:
         self.period_sec = period_sec
@@ -51,6 +52,8 @@ class NodeDiscovery:
             self.setters = setters
 
         # make first callback as fast as possible
+        # sleep before first callback due ros discovery issue: https://github.com/ros2/ros2/issues/1057
+        time.sleep(0.5)
         self.discovery_callback()
 
     def add_setter(self, setter: Callable):

--- a/src/rai/rai/utils/ros_async.py
+++ b/src/rai/rai/utils/ros_async.py
@@ -1,0 +1,23 @@
+import time
+from typing import Any, Optional
+
+import rclpy.task
+
+
+def get_future_result(
+    future: rclpy.task.Future, timeout_sec: float = 5.0
+) -> Optional[Any]:
+    """Replaces rclpy.spin_until_future_complete"""
+    result = None
+
+    def callback(future: rclpy.task.Future) -> None:
+        nonlocal result
+        result = future.result()
+
+    future.add_done_callback(callback)
+
+    ts = time.perf_counter()
+    while result is None and time.perf_counter() - ts < timeout_sec:
+        time.sleep(0.1)
+
+    return result

--- a/src/rai/rai/utils/ros_async.py
+++ b/src/rai/rai/utils/ros_async.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 from typing import Any, Optional
 

--- a/src/rai/rai/utils/ros_executors.py
+++ b/src/rai/rai/utils/ros_executors.py
@@ -1,0 +1,48 @@
+from typing import Callable, Optional, Union
+
+from rclpy.executors import (
+    ConditionReachedException,
+    ExternalShutdownException,
+    MultiThreadedExecutor,
+    ShutdownException,
+    TimeoutException,
+    TimeoutObject,
+)
+
+
+class MultiThreadedExecutorFixed(MultiThreadedExecutor):
+    """
+    Adresses a comment:
+    ```python
+    # make a copy of the list that we iterate over while modifying it
+    # (https://stackoverflow.com/q/1207406/3753684)
+    ```
+    from the rclpy implementation
+    """
+
+    def _spin_once_impl(
+        self,
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None,
+        wait_condition: Callable[[], bool] = lambda: False,
+    ) -> None:
+        try:
+            handler, entity, node = self.wait_for_ready_callbacks(
+                timeout_sec, None, wait_condition
+            )
+        except ExternalShutdownException:
+            pass
+        except ShutdownException:
+            pass
+        except TimeoutException:
+            pass
+        except ConditionReachedException:
+            pass
+        else:
+            self._executor.submit(handler)
+            self._futures.append(handler)
+            futures = self._futures.copy()
+            for future in futures[:]:
+                if future.done():
+                    futures.remove(future)
+                    future.result()  # raise any exceptions
+            self._futures = futures

--- a/src/rai/rai/utils/ros_executors.py
+++ b/src/rai/rai/utils/ros_executors.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Callable, Optional, Union
 
 from rclpy.executors import (

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
@@ -26,7 +26,7 @@ from rclpy.exceptions import (
 )
 from rclpy.task import Future
 
-from rai.node import RaiAsyncToolsNode
+from rai.node import RaiBaseNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_ndarray
 from rai.tools.utils import wait_for_message
@@ -81,7 +81,7 @@ class DistanceMeasurement(NamedTuple):
 
 # --------------------- Tools ---------------------
 class GroundingDinoBaseTool(Ros2BaseTool):
-    node: RaiAsyncToolsNode = Field(..., exclude=True, required=True)
+    node: RaiBaseNode = Field(..., exclude=True, required=True)
 
     box_threshold: float = Field(default=0.35, description="Box threshold for GDINO")
     text_threshold: float = Field(default=0.45, description="Text threshold for GDINO")

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, NamedTuple, Optional, Type
+from typing import List, NamedTuple, Type
 
 import numpy as np
 import rclpy
@@ -30,6 +30,7 @@ from rai.node import RaiBaseNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_ndarray
 from rai.tools.utils import wait_for_message
+from rai.utils.ros_async import get_future_result
 from rai_interfaces.srv import RAIGroundingDino
 
 
@@ -85,20 +86,6 @@ class GroundingDinoBaseTool(Ros2BaseTool):
 
     box_threshold: float = Field(default=0.35, description="Box threshold for GDINO")
     text_threshold: float = Field(default=0.45, description="Text threshold for GDINO")
-
-    def _spin(self, future: Future) -> Optional[RAIGroundingDino.Response]:
-        rclpy.spin_once(self.node)
-        if future.done():
-            try:
-                response = future.result()
-            except Exception as e:
-                self.node.get_logger().info("Service call failed %r" % (e,))
-                raise Exception("Service call failed %r" % (e,))
-            else:
-                assert response is not None
-                self.node.get_logger().info(f"{response.detections}")
-                return response
-        return None
 
     def _call_gdino_node(
         self, camera_img_message: sensor_msgs.msg.Image, object_names: list[str]
@@ -174,12 +161,16 @@ class GetDetectionTool(GroundingDinoBaseTool):
         camera_img_msg = self._get_image_message(camera_topic)
         future = self._call_gdino_node(camera_img_msg, object_names)
 
-        while rclpy.ok():
-            resolved = self._spin(future)
-            if resolved is not None:
-                detected = self._parse_detection_array(resolved)
-                names = ", ".join([det.class_name for det in detected])
-                return f"I have detected the following items in the picture {names or 'None'}"
+        resolved = get_future_result(future)
+
+        if resolved is not None:
+            detected = self._parse_detection_array(resolved)
+            names = ", ".join([det.class_name for det in detected])
+            return (
+                f"I have detected the following items in the picture {names or 'None'}"
+            )
+        else:
+            return "Service call failed. Can't get detections."
 
         return "Failed to get detection"
 
@@ -256,18 +247,17 @@ class GetDistanceToObjectsTool(GroundingDinoBaseTool):
                 "Parameter conversion_ratio not found in node, using default value: 0.001"
             )
             conversion_ratio = 0.001
-        while rclpy.ok():
-            resolved = self._spin(future)
-            if resolved is not None:
-                detected = self._parse_detection_array(resolved)
-                measurements = self._get_distance_from_detections(
-                    depth_img_msg, detected, threshold, conversion_ratio
-                )
-                measurement_string = ", ".join(
-                    [
-                        f"{measurement[0]}: {measurement[1]:.2f}m away"
-                        for measurement in measurements
-                    ]
-                )
-                return f"I have detected the following items in the picture {measurement_string or 'no objects'}"
+        resolved = get_future_result(future)
+        if resolved is not None:
+            detected = self._parse_detection_array(resolved)
+            measurements = self._get_distance_from_detections(
+                depth_img_msg, detected, threshold, conversion_ratio
+            )
+            measurement_string = ", ".join(
+                [
+                    f"{measurement[0]}: {measurement[1]:.2f}m away"
+                    for measurement in measurements
+                ]
+            )
+            return f"I have detected the following items in the picture {measurement_string or 'no objects'}"
         return "Failed"

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
@@ -29,6 +29,7 @@ from rclpy.exceptions import (
 from rai.node import RaiBaseNode
 from rai.tools.ros import Ros2BaseInput, Ros2BaseTool
 from rai.tools.ros.utils import convert_ros_img_to_base64, convert_ros_img_to_ndarray
+from rai.utils.ros_async import get_future_result
 from rai_interfaces.srv import RAIGroundedSam, RAIGroundingDino
 
 # --------------------- Inputs ---------------------
@@ -77,30 +78,10 @@ class GetSegmentationTool(Ros2BaseTool):
     def _get_gdino_response(
         self, future: Future
     ) -> Optional[RAIGroundingDino.Response]:
-        rclpy.spin_once(self.node)
-        if future.done():
-            try:
-                response = future.result()
-            except Exception as e:
-                self.node.get_logger().info("Service call failed %r" % (e,))
-                raise Exception("Service call failed %r" % (e,))
-            else:
-                assert response is not None
-                return response
-        return None
+        return get_future_result(future)
 
     def _get_gsam_response(self, future: Future) -> Optional[RAIGroundedSam.Response]:
-        rclpy.spin_once(self.node)
-        if future.done():
-            try:
-                response = future.result()
-            except Exception as e:
-                self.node.get_logger().info("Service call failed %r" % (e,))
-                raise Exception("Service call failed %r" % (e,))
-            else:
-                assert response is not None
-                return response
-        return None
+        return get_future_result(future)
 
     def _get_image_message(self, topic: str) -> sensor_msgs.msg.Image:
         msg = self.node.get_raw_message_from_topic(topic)

--- a/src/rai_hmi/rai_hmi/base.py
+++ b/src/rai_hmi/rai_hmi/base.py
@@ -250,12 +250,12 @@ class BaseHMINode(Node):
 
     def task_result_callback(self, future, uid: UUID4):
         """Callback for handling the result from the action server."""
-        result = future.result().result
+        result: TaskAction.Result = future.result().result
         self.task_running[uid] = False
         self.task_feedbacks.put(MissionDoneMessage(uid=uid, result=result))
         if result.success:
             self.get_logger().info(f"Task completed successfully: {result.report}")
             self.task_results[uid] = result
         else:
-            self.get_logger().error(f"Task failed: {result.result_message}")
+            self.get_logger().error(f"Task failed: {result.report}")
             self.task_results[uid] = "ERROR"

--- a/tests/messages/test_transport.py
+++ b/tests/messages/test_transport.py
@@ -100,6 +100,9 @@ def test_transport(qos_profile: str):
     rai_base_node = RaiBaseNode(
         node_name="test_transport_" + str(uuid.uuid4()).replace("-", "")
     )
+
+    thread2 = threading.Thread(target=rai_base_node.spin)
+    thread2.start()
     topics = ["/image", "/text"]
     try:
         for topic in topics:
@@ -107,6 +110,9 @@ def test_transport(qos_profile: str):
             assert not isinstance(output, str), "No message received"
     finally:
         executor.shutdown()
+        rai_base_node.executor.shutdown()
+        rai_base_node.destroy_node()
         publisher.destroy_node()
         rclpy.shutdown()
         thread.join(timeout=1.0)
+        thread2.join(timeout=1.0)


### PR DESCRIPTION
## Purpose

- Refactors internal ros communication and they way ros2-based tools communicate with the agent.

## Proposed Changes

- replace nodes spinning by the executor/rclpy by callbacks - from my testing this is the only reliable method for waiting on `rclpy.Future` for nodes that are being span by `executor.spin()`
- this allows to remove the dedicated node for tools that needed to spin on futures
- refactor `RaiNode` and extract methods to separate classes to improve code clarity
- improve feedback from `ros2 action`s by parsing `nav2` error codes

## Issues

- https://github.com/RobotecAI/rai/issues/313
   - in this PR an alternative approach described in this issue is used and extended

## Testing

- on rosbot-xl demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for transform checking in robot interactions
	- Introduced new tools for robot interfaces and transform retrieval

- **Improvements**
	- Enhanced logging for tool execution
	- Improved ROS 2 action and topic handling
	- Updated node discovery and asynchronous future result management

- **Technical Updates**
	- Refactored node and tool classes for better organization
	- Updated callback group handling
	- Modified error handling and logging mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->