### PR TITLE
refactor: use second person for identity building

### DIFF
--- a/src/rai/rai/cli/rai_cli.py
+++ b/src/rai/rai/cli/rai_cli.py
@@ -96,7 +96,7 @@ def parse_whoami_package():
             "as well as the robot's capabilities and limitations including sensor and actuator information. "
             "If there are any images provided, make sure to take them into account by thoroughly analyzing them. "
             "Your description should be thorough and detailed."
-            "Your reply should start with I am a ..."
+            "Your reply should start with You are ..."
         )
 
         images = glob.glob(str(description_path / "images" / "*"))


### PR DESCRIPTION
## Purpose

A few months ago, I have been testing different styles of system prompts. The tests included first (I am a...), second (you are ...) and third person view (This is a conversation between an expert embodied AI and user).
Empirical tests showed, that the second person view worked a little bit better than the first person and much better than the third.
Due to amount of changes in the other parts of the repository, change to second person was postponed. Until today.

## Proposed Changes

Changed the prompt of identity builder to start the robot_identity.txt with You are instead of I am.

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
