### PR TITLE
docs: remove demos' repository links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ Use the [debugging assistant](./docs/debugging_assistant.md) to inspect ROS 2 ne
 ### Simulation demos
 
 Try RAI yourself with these demos:
-| Application | Robot | Description | Demo Link | Docs Link |
-| ------------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------------------------------- |
-| Mission and obstacle reasoning in orchards | Autonomous tractor | In a beautiful scene of a virtual orchard, RAI goes beyond obstacle detection to analyze best course of action for a given unexpected situation. | [🌾 demo](https://github.com/RobotecAI/rai-agriculture-demo) | [📚](docs/demos/agriculture.md) |
-| Manipulation tasks with natural language | Robot Arm (Franka Panda) | Complete flexible manipulation tasks thanks to RAI and Grounded SAM 2 | [🦾 demo](https://github.com/RobotecAI/rai-manipulation-demo) | [📚](docs/demos/manipulation.md) |
-| Autonomous mobile robot demo | Husarion ROSbot XL | Demonstrate RAI's interaction with an autonomous mobile robot platform for navigation and control | [🤖 demo](https://github.com/RobotecAI/rai-rosbot-xl-demo) | [📚](docs/demos/rosbot_xl.md) |
-| Turtlebot demo | Turtlebot | Showcase RAI's capabilities with the popular Turtlebot platform | [🐢 demo](docs/demos/turtlebot.md) | [📚](docs/demos/turtlebot.md) |
-| Speech-to-speech interaction with autonomous taxi | Simulated car | Demonstrate RAI's speech-to-speech interaction capabilities for specifying destinations to an autonomous taxi in awsim with autoware environment | [🚕 demo](docs/demos/taxi.md) | [📚](docs/demos/taxi.md) |
+| Application | Robot | Description | Docs Link |
+| ------------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| Mission and obstacle reasoning in orchards | Autonomous tractor | In a beautiful scene of a virtual orchard, RAI goes beyond obstacle detection to analyze best course of action for a given unexpected situation. | [link](docs/demos/agriculture.md) |
+| Manipulation tasks with natural language | Robot Arm (Franka Panda) | Complete flexible manipulation tasks thanks to RAI and Grounded SAM 2 | [link](docs/demos/manipulation.md) |
+| Autonomous mobile robot demo | Husarion ROSbot XL | Demonstrate RAI's interaction with an autonomous mobile robot platform for navigation and control | [link](docs/demos/rosbot_xl.md) |
+| Turtlebot demo | Turtlebot | Showcase RAI's capabilities with the popular Turtlebot platform | [link](docs/demos/turtlebot.md) |
+| Speech-to-speech interaction with autonomous taxi | Simulated car | Demonstrate RAI's speech-to-speech interaction capabilities for specifying destinations to an autonomous taxi in awsim with autoware environment | [link](docs/demos/taxi.md) |
 
 ## Community
 

--- a/docs/demos/agriculture.md
+++ b/docs/demos/agriculture.md
@@ -68,3 +68,6 @@ Used to replan the path/skip the alley.
 - The tractor performs the action and the demo continues.
 
 For more details on configuring RAI for specific robots, refer to the [RAI documentation](../create_robots_whoami.md).
+
+> [!TIP]
+> If you are having trouble running the binary, you can build it from source [here](https://github.com/RobotecAI/rai-agriculture-demo).

--- a/docs/demos/manipulation.md
+++ b/docs/demos/manipulation.md
@@ -75,3 +75,6 @@ The main logic of the demo is implemented in the `ManipulationDemo` class, which
 ```python
 examples/manipulation-demo.py
 ```
+
+> [!TIP]
+> If you are having trouble running the binary, you can build it from source [here](https://github.com/RobotecAI/rai-manipulation-demo).

--- a/docs/demos/rosbot_xl.md
+++ b/docs/demos/rosbot_xl.md
@@ -82,3 +82,6 @@ By looking at the example code in [rai/examples/rosbot-xl-demo.py](../../example
 If you wish, you can learn more about [configuring RAI for a specific robot](../create_robots_whoami.md).
 
 [rai rosbot demo]: https://github.com/RobotecAI/rai-rosbot-xl-demo
+
+> [!TIP]
+> If you are having trouble running the binary, you can build it from source [here](https://github.com/RobotecAI/rai-rosbot-xl-demo).


### PR DESCRIPTION
## Purpose

Some of the links in the main README demo's table were confusing, as they were pointing to the demos' repositories.  

## Proposed Changes

Removes the links to the repositories of the demos (o3de projects).
Add the links to the demos' readme.

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
