### PR TITLE
fix(README.md): remove sourcing poetry before first colcon build

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ rosdep install --from-paths src --ignore-src -r -y
 Run the configuration tool to set up your vendor and other settings:
 
 ```bash
-poetry shell
-streamlit run src/rai/rai/utils/configurator.py
+poetry run streamlit run src/rai/rai/utils/configurator.py
 ```
 
 > [!TIP]  


### PR DESCRIPTION
## Purpose

When the README.md instructions were followed, the first colcon build would return an error regarding python `empy` package. 

## Proposed Changes

Removed unnecessary `poetry shell` before first 

## Testing

- Followed through updated installation steps, the problem did not occur.


