### PR TITLE
chore: update poetry install link with fixed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Before going further, make sure you have ROS 2 (Jazzy or Humble) installed and s
 
 #### 1.1 Install poetry
 
-RAI uses [Poetry](https://python-poetry.org/) for python packaging and dependency management. Install poetry (1.8+) with the following line:
+RAI uses [Poetry](https://python-poetry.org/) for python packaging and dependency management. Install poetry (1.8.\*) with the following line:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 ```
 
 Alternatively, you can opt to do so by following the [official docs](https://python-poetry.org/docs/#installation).


### PR DESCRIPTION
## Purpose

Poetry just published 2.0 version, introducing multiple breaking changes e.g. `shell` removal.  

## Proposed Changes

Updates poetry installation link to use fixed 1.8.4 version.

## Testing

- `curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4`
- `poetry install`
