### PR TITLE
refactor: simplify ros2 tools

### DIFF
--- a/examples/rosbot-xl-demo.py
+++ b/examples/rosbot-xl-demo.py
@@ -18,23 +18,26 @@ from typing import Optional
 import rclpy
 import rclpy.executors
 import rclpy.logging
-from rai_open_set_vision.tools import GetDetectionTool, GetDistanceToObjectsTool
 
+from rai.base_node import (
+    ros2_cancel_action,
+    ros2_get_action_feedback,
+    ros2_get_action_result,
+    ros2_is_action_complete,
+    ros2_run_action_async,
+)
 from rai.node import RaiStateBasedLlmNode
 from rai.tools.ros.native import (
-    GetMsgFromTopic,
-    Ros2GetRobotInterfaces,
-    Ros2PubMessageTool,
-    Ros2ShowMsgInterfaceTool,
+    ros2_get_msg_from_topic,
+    ros2_get_robot_interfaces,
+    ros2_get_transform,
+    ros2_pub_msg,
+    ros2_show_msg_interface,
 )
-from rai.tools.ros.native_actions import (
-    GetTransformTool,
-    Ros2CancelAction,
-    Ros2GetActionResult,
-    Ros2GetLastActionFeedback,
-    Ros2RunActionAsync,
-)
-from rai.tools.time import WaitForSecondsTool
+from rai.tools.time import wait_for_seconds
+
+# from rai_open_set_vision.tools import GetDetectionTool, GetDistanceToObjectsTool
+
 
 p = argparse.ArgumentParser()
 p.add_argument("--allowlist", type=Path, required=False, default=None)
@@ -121,18 +124,17 @@ def main(allowlist: Optional[Path] = None):
         allowlist=ros2_allowlist,
         system_prompt=SYSTEM_PROMPT,
         tools=[
-            Ros2GetRobotInterfaces,
-            Ros2PubMessageTool,
-            Ros2RunActionAsync,
-            Ros2CancelAction,
-            Ros2GetActionResult,
-            Ros2GetLastActionFeedback,
-            Ros2ShowMsgInterfaceTool,
-            GetTransformTool,
-            WaitForSecondsTool,
-            GetMsgFromTopic,
-            GetDetectionTool,
-            GetDistanceToObjectsTool,
+            ros2_cancel_action,
+            ros2_get_action_feedback,
+            ros2_get_action_result,
+            ros2_is_action_complete,
+            ros2_run_action_async,
+            ros2_get_msg_from_topic,
+            ros2_get_robot_interfaces,
+            ros2_pub_msg,
+            ros2_show_msg_interface,
+            ros2_get_transform,
+            wait_for_seconds,
         ],
     )
     node.declare_parameter("conversion_ratio", 1.0)

--- a/src/rai/rai/base_node.py
+++ b/src/rai/rai/base_node.py
@@ -1,0 +1,96 @@
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+import rclpy.callback_groups
+from langchain.tools import tool
+from langchain_core.tools import InjectedToolArg
+from rclpy.node import Node
+
+from rai.ros2_apis import Ros2ActionsAPI, Ros2TopicsAPI
+from rai.utils.ros import NodeDiscovery
+from rai.utils.ros_executors import MultiThreadedExecutorFixed
+
+
+class RaiBaseNode(Node):
+    def __init__(
+        self,
+        allowlist: Optional[List[str]] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
+        self.ros_discovery_info = NodeDiscovery(self, allowlist=allowlist)
+        self.async_action_client = Ros2ActionsAPI(self)
+        self.topics_handler = Ros2TopicsAPI(
+            self, self.callback_group, self.ros_discovery_info
+        )
+        self.ros_discovery_info.add_setter(self.topics_handler.set_ros_discovery_info)
+
+    # ------------- ros2 topics interface -------------
+    def get_raw_message_from_topic(self, topic: str, timeout_sec: int = 5) -> Any:
+        return self.topics_handler.get_raw_message_from_topic(topic, timeout_sec)
+
+    # ------------- ros2 actions interface -------------
+    def run_action(
+        self, action_name: str, action_type: str, action_goal_args: Dict[str, Any]
+    ):
+        return self.async_action_client.run_action(
+            action_name, action_type, action_goal_args
+        )
+
+    def get_task_result(self) -> str:
+        return self.async_action_client.get_task_result()
+
+    def is_task_complete(self) -> bool:
+        return self.async_action_client.is_task_complete()
+
+    @property
+    def action_feedback(self) -> Any:
+        return self.async_action_client.action_feedback
+
+    def cancel_task(self) -> Union[str, bool]:
+        return self.async_action_client.cancel_task()
+
+    # ------------- other methods -------------
+    def spin(self):
+        executor = MultiThreadedExecutorFixed()
+        executor.add_node(self)
+        executor.spin()
+
+
+@tool
+def ros2_run_action_async(
+    node: Annotated[RaiBaseNode, InjectedToolArg],
+    action_name: str,
+    action_type: str,
+    action_goal_args: Dict[str, Any],
+) -> str:
+    """A generic tool for sending goal of ros2 action"""
+    return node.run_action(action_name, action_type, action_goal_args)
+
+
+@tool
+def ros2_is_action_complete(node: Annotated[RaiBaseNode, InjectedToolArg]) -> bool:
+    """A tool for checking the result of submitted ros2 action"""
+    return node.is_task_complete()
+
+
+@tool
+def ros2_get_action_result(node: Annotated[RaiBaseNode, InjectedToolArg]) -> str:
+    """A tool for checking the result of submitted ros2 action"""
+    return node.get_task_result()
+
+
+@tool
+def ros2_cancel_action(
+    node: Annotated[RaiBaseNode, InjectedToolArg]
+) -> Union[str, bool]:
+    """Cancel submitted ros2 action"""
+    return node.cancel_task()
+
+
+@tool
+def ros2_get_action_feedback(node: Annotated[RaiBaseNode, InjectedToolArg]) -> str:
+    """A tool for checking the feedback of submitted ros2 action"""
+    return str(node.action_feedback)

--- a/src/rai/rai/node.py
+++ b/src/rai/rai/node.py
@@ -25,7 +25,6 @@ import rclpy.subscription
 import rclpy.task
 import sensor_msgs.msg
 from langchain.tools import BaseTool
-from langchain.tools.render import render_text_description_and_args
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langgraph.graph.graph import CompiledGraph
 from rclpy.action.server import ActionServer, GoalResponse, ServerGoalHandle
@@ -34,6 +33,7 @@ from std_srvs.srv import Trigger
 
 from rai.agents.state_based import Report, State, create_state_based_agent
 from rai.messages import HumanMultimodalMessage
+from rai.tools.render import render_text_description_with_args_from_tools
 from rai.tools.ros.utils import convert_ros_img_to_base64
 from rai.utils.model_initialization import get_llm_model, get_tracing_callbacks
 from rai.utils.ros_async import get_future_result
@@ -109,7 +109,7 @@ def append_tools_text_description_to_prompt(prompt: str, tools: List[BaseTool]) 
 
     Use the tooling provided to gather information about the environment:
 
-    {render_text_description_and_args(tools)}
+    {render_text_description_with_args_from_tools(tools)}
     """
 
 

--- a/src/rai/rai/tools/render.py
+++ b/src/rai/rai/tools/render.py
@@ -1,0 +1,31 @@
+from copy import deepcopy
+
+from langchain.tools import BaseTool
+from langchain_core.tools import (
+    create_schema_from_function,
+    render_text_description_and_args,
+)
+
+
+def filter_out_injected_tool_args(tool: BaseTool) -> BaseTool:
+    """
+    Create a copy of tool with args filtered out.
+
+    The main purpose of this function is to make `langchain_core.tools.render_text_description_with_args`
+    usable for `@tool`s with `IntectedToolArg`s.
+
+    It doens't work without this modification, because implementation of StructuredTool
+    includes arguments annotated as `InjectedToolArg` in tool's `args_schema`,
+    which can cause `pydantic.errors.PydanticInvalidForJsonSchema` for arguments that
+    are not parsalbe by pydantic (like `rclpy.node.Node`)
+    """
+    new_tool = deepcopy(tool)
+    new_tool.args_schema = create_schema_from_function(
+        tool.name, tool._run, include_injected=False
+    )
+    return new_tool
+
+
+def render_text_description_with_args_from_tools(tools: list[BaseTool]) -> str:
+    tools = [filter_out_injected_tool_args(t) for t in tools]
+    return render_text_description_and_args(tools)

--- a/src/rai/rai/tools/ros/__init__.py
+++ b/src/rai/rai/tools/ros/__init__.py
@@ -21,7 +21,6 @@ from .cli import (
     ros2_service,
     ros2_topic,
 )
-from .native import Ros2BaseInput, Ros2BaseTool
 from .tools import (
     AddDescribedWaypointToDatabaseTool,
     GetCurrentPositionTool,
@@ -35,8 +34,6 @@ __all__ = [
     "ros2_topic",
     "ros2_param",
     "ros2_service",
-    "Ros2BaseTool",
-    "Ros2BaseInput",
     "AddDescribedWaypointToDatabaseTool",
     "GetOccupancyGridTool",
     "GetCurrentPositionTool",

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -16,7 +16,7 @@
 import importlib
 import json
 import time
-from typing import Any, Dict, OrderedDict, Tuple, Type
+from typing import Annotated, Any, Dict, List, OrderedDict, Tuple, Type
 
 import rclpy
 import rclpy.callback_groups
@@ -28,121 +28,95 @@ import rclpy.task
 import rosidl_runtime_py.set_message
 import rosidl_runtime_py.utilities
 import sensor_msgs.msg
-from langchain.tools import BaseTool
-from pydantic import BaseModel, Field
-from rclpy.impl.rcutils_logger import RcutilsLogger
+from langchain.tools import tool
+from langchain_core.tools import InjectedToolArg
+from rclpy.client import Client
+from rosidl_runtime_py import message_to_ordereddict
 from rosidl_runtime_py.utilities import get_namespaced_type
 
-from .utils import convert_ros_img_to_base64, import_message_from_str
+from rai.node import RaiBaseNode
+from rai.utils.ros_async import get_future_result
+
+from .utils import convert_ros_img_to_base64, get_transform, import_message_from_str
 
 
-# --------------------- Inputs ---------------------
-class Ros2BaseInput(BaseModel):
-    """Empty input for ros2 tool"""
+@tool
+def ros2_get_topics_names_and_types(
+    node: Annotated[rclpy.node.Node, InjectedToolArg]
+) -> List[Tuple[str, List[str]]]:
+    """A tool for getting all ros2 topics names and types"""
+    return node.get_topic_names_and_types()
 
 
-class Ros2MsgInterfaceInput(BaseModel):
-    """Input for the show_ros2_msg_interface tool."""
-
-    msg_name: str = Field(..., description="Ros2 message name in typical ros2 format.")
-
-
-class Ros2GetOneMsgFromTopicInput(BaseModel):
-    """Input for the get_current_position tool."""
-
-    topic: str = Field(..., description="Ros2 topic")
-    msg_type: str = Field(
-        ..., description="Type of ros2 message in typical ros2 format."
-    )
-    timeout_sec: int = Field(
-        10, description="The time in seconds to wait for a message to be received."
-    )
+@tool
+def ros2_get_robot_interfaces(
+    node: Annotated[RaiBaseNode, InjectedToolArg]
+) -> Dict[str, Any]:
+    """A tool for getting all ros2 robot interfaces: topics, services and actions"""
+    return node.ros_discovery_info.dict()
 
 
-class PubRos2MessageToolInput(BaseModel):
-    topic_name: str = Field(..., description="Ros2 topic to publish the message")
-    msg_type: str = Field(
-        ..., description="Type of ros2 message in typical ros2 format."
-    )
-    msg_args: Dict[str, Any] = Field(
-        ..., description="The arguments of the service call."
-    )
-    rate: int = Field(10, description="The rate at which to publish the message.")
-    timeout_seconds: int = Field(1, description="The timeout in seconds.")
-
-
-# --------------------- Tools ---------------------
-class Ros2BaseTool(BaseTool):
-    # TODO: Make the decision between rclpy.node.Node and RaiNode
-    node: rclpy.node.Node = Field(..., exclude=True, required=True)
-
-    args_schema: Type[Ros2BaseInput] = Ros2BaseInput
-
-    @property
-    def logger(self) -> RcutilsLogger:
-        return self.node.get_logger()
-
-
-class Ros2GetTopicsNamesAndTypesTool(Ros2BaseTool):
-    name: str = "Ros2GetTopicsNamesAndTypes"
-    description: str = "A tool for getting all ros2 topics names and types"
-
-    def _run(self):
-        return self.node.get_topic_names_and_types()
-
-
-class Ros2GetRobotInterfaces(Ros2BaseTool):
-    name: str = "ros2_robot_interfaces"
-    description: str = (
-        "A tool for getting all ros2 robot interfaces: topics, services and actions"
-    )
-
-    def _run(self):
-        return self.node.ros_discovery_info.dict()
-
-
-class Ros2ShowMsgInterfaceTool(BaseTool):
-    name: str = "Ros2ShowMsgInterface"
-    description: str = """A tool for showing ros2 message interface in json format.
-    usage:
-    ```python
-    ShowRos2MsgInterface.run({"msg_name": "geometry_msgs/msg/PoseStamped"})
-    ```
+@tool
+def ros2_show_msg_interface(msg_name: str) -> str:
     """
+    Show ros2 message interface in json format as string.
 
-    args_schema: Type[Ros2MsgInterfaceInput] = Ros2MsgInterfaceInput
+    Parameters
+    ----------
+    msg_name : str
+        The name of the message. For example "geometry_msgs/msg/PoseStamped"
+    """
+    msg_cls: Type = rosidl_runtime_py.utilities.get_interface(msg_name)
+    try:
+        msg_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
+            msg_cls()
+        )
+        return json.dumps(msg_dict)
+    except NotImplementedError:
+        # For action classes that can't be instantiated
+        goal_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
+            msg_cls.Goal()
+        )
 
-    def _run(self, msg_name: str):
-        """Show ros2 message interface in json format."""
-        msg_cls: Type = rosidl_runtime_py.utilities.get_interface(msg_name)
-        try:
-            msg_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
-                msg_cls()
-            )
-            return json.dumps(msg_dict)
-        except NotImplementedError:
-            # For action classes that can't be instantiated
-            goal_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
-                msg_cls.Goal()
-            )
+        result_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
+            msg_cls.Result()
+        )
 
-            result_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
-                msg_cls.Result()
-            )
-
-            feedback_dict: OrderedDict = (
-                rosidl_runtime_py.convert.message_to_ordereddict(msg_cls.Feedback())
-            )
-            return json.dumps(
-                {"goal": goal_dict, "result": result_dict, "feedback": feedback_dict}
-            )
+        feedback_dict: OrderedDict = rosidl_runtime_py.convert.message_to_ordereddict(
+            msg_cls.Feedback()
+        )
+        return json.dumps(
+            {"goal": goal_dict, "result": result_dict, "feedback": feedback_dict}
+        )
 
 
-class Ros2PubMessageTool(Ros2BaseTool):
-    name: str = "PubRos2MessageTool"
-    description: str = """A tool for publishing a message to a ros2 topic
+# TODO(boczekbartek): use few shot from langchain docs: https://python.langchain.com/docs/how_to/tools_few_shot/
+@tool
+def ros2_pub_msg(
+    node: Annotated[RaiBaseNode, InjectedToolArg],
+    topic_name: str,
+    msg_type: str,
+    msg_args: Dict[str, Any],
+    rate: int = 10,
+    timeout_sec: int = 1,
+) -> None:
+    """A tool for publishing a message to a ros2 topic
 
     By default 10 messages are published for 1 second. If you want to publish multiple messages, you can specify 'rate' and 'timeout_sec'.
+
+    Parameters
+    ----------
+    topic_name : str
+        The name of the topic to publish the message
+    msg_type : str
+        The type of the message
+    msg_args : Dict[str, Any]
+        The arguments of the message
+    rate : int, default=10
+        The rate at which to publish the message
+    timeout_sec : int, default=1
+        The timeout in seconds
+
     Example usage:
 
     ```python
@@ -156,135 +130,133 @@ class Ros2PubMessageTool(Ros2BaseTool):
             "timeout_sec" : 1
         }
     )
-
     ```
     """
 
-    args_schema: Type[PubRos2MessageToolInput] = PubRos2MessageToolInput
+    if "/msg/" not in msg_type:
+        raise ValueError("msg_name must contain 'msg' in the name.")
 
-    def _build_msg(
-        self, msg_type: str, msg_args: Dict[str, Any]
-    ) -> Tuple[object, Type]:
-        msg_cls: Type = import_message_from_str(msg_type)
-        msg = msg_cls()
-        rosidl_runtime_py.set_message.set_message_fields(msg, msg_args)
-        return msg, msg_cls
+    msg_cls: Type = import_message_from_str(msg_type)
+    msg = msg_cls()
+    rosidl_runtime_py.set_message.set_message_fields(msg, msg_args)
 
-    def _run(
-        self,
-        topic_name: str,
-        msg_type: str,
-        msg_args: Dict[str, Any],
-        rate: int = 10,
-        timeout_seconds: int = 1,
-    ):
-        """Publishes a message to the specified topic."""
-        if "/msg/" not in msg_type:
-            raise ValueError("msg_name must contain 'msg' in the name.")
-        msg, msg_cls = self._build_msg(msg_type, msg_args)
-
-        publisher = self.node.create_publisher(
-            msg_cls, topic_name, 10, callback_group=self.node.callback_group
-        )  # TODO(boczekbartek): infer qos profile from topic info
-
-        def callback():
-            publisher.publish(msg)
-            self.logger.info(f"Published message '{msg}' to topic '{topic_name}'")
-
-        ts = time.perf_counter()
-        timer = self.node.create_timer(
-            1.0 / rate, callback, callback_group=self.node.callback_group
-        )
-
-        while time.perf_counter() - ts < timeout_seconds:
-            time.sleep(0.1)
-
-        timer.cancel()
-        timer.destroy()
-
-        self.logger.info(
-            f"Published messages for {timeout_seconds}s to topic '{topic_name}' with rate {rate}"
-        )
-        return
-
-
-class TopicInput(Ros2BaseInput):
-    topic_name: str = Field(..., description="Ros2 topic name")
-
-
-class GetMsgFromTopic(Ros2BaseTool):
-    name: str = "get_msg_from_topic"
-    description: str = "Get message from topic"
-    args_schema: Type[TopicInput] = TopicInput
-    response_format: str = "content_and_artifact"
-
-    def _run(self, topic_name: str):
-        msg = self.node.get_raw_message_from_topic(topic_name)
-        if type(msg) is sensor_msgs.msg.Image:
-            img = convert_ros_img_to_base64(msg)
-            return "Got image", {"images": [img]}
-        else:
-            return str(msg), {}
-
-
-class Ros2GenericServiceCallerInput(BaseModel):
-    service_name: str = Field(..., description="Name of the ROS2 service to call")
-    service_type: str = Field(
-        ..., description="Type of the ROS2 service in typical ros2 format"
+    publisher = node.create_publisher(
+        msg_cls, topic_name, 10, callback_group=node.callback_group
     )
-    request_args: Dict[str, Any] = Field(
-        ..., description="Arguments for the service request"
+
+    def callback():
+        publisher.publish(msg)
+        node.get_logger().info(f"Published message '{msg}' to topic '{topic_name}'")
+
+    ts = time.perf_counter()
+    timer = node.create_timer(1.0 / rate, callback, callback_group=node.callback_group)
+
+    while time.perf_counter() - ts < timeout_sec:
+        time.sleep(0.1)
+
+    timer.cancel()
+    timer.destroy()
+
+    node.get_logger().info(
+        f"Published messages for {timeout_sec}s to topic '{topic_name}' with rate {rate}"
     )
 
 
-class Ros2GenericServiceCaller(Ros2BaseTool):
-    name: str = "Ros2GenericServiceCaller"
-    description: str = "A tool for calling any ROS2 service dynamically."
+@tool(response_format="content_and_artifact")
+def ros2_get_msg_from_topic(
+    node: Annotated[RaiBaseNode, InjectedToolArg], topic_name: str
+) -> Tuple[str, Dict[str, Any]]:
+    """A tool for getting a message from a ros2 topic
 
-    args_schema: Type[Ros2GenericServiceCallerInput] = Ros2GenericServiceCallerInput
+    Parameters
+    ----------
+    topic_name : str
+        The name of the topic to get the message from
+    """
+    msg = node.get_raw_message_from_topic(topic_name)
 
-    def _build_request(self, service_type: str, request_args: Dict[str, Any]) -> Any:
+    if type(msg) is sensor_msgs.msg.Image:
+        img = convert_ros_img_to_base64(msg)
+        return "Got image", {"images": [img]}
+    else:
+        return str(msg), {}
+
+
+@tool
+def ros2_service_caller(
+    node: Annotated[rclpy.node.Node, InjectedToolArg],
+    service_name: str,
+    service_type: str,
+    request_args: Dict[str, Any],
+    timeout_sec: int = 1,
+) -> str:
+    """A tool for calling any ROS2 service dynamically
+
+    Parameters
+    ----------
+    service_name : str
+        The name of the service to call
+    service_type : str
+        The type of the service in typical ros2 format
+    request_args : Dict[str, Any]
+        The arguments for the service request
+    timeout_sec : int, default=1
+        Request timeout.
+    """
+    if not service_name.startswith("/"):
+        service_name = f"/{service_name}"
+
+    try:
         srv_module, _, srv_name = service_type.split("/")
         srv_class = getattr(importlib.import_module(f"{srv_module}.srv"), srv_name)
         request = srv_class.Request()
         rosidl_runtime_py.set_message.set_message_fields(request, request_args)
-        return request
+    except Exception as e:
+        return f"Failed to build service request: {e}"
 
-    def _run(self, service_name: str, service_type: str, request_args: Dict[str, Any]):
-        if not service_name.startswith("/"):
-            service_name = f"/{service_name}"
+    namespaced_type = get_namespaced_type(service_type)
+    client: Client = node.create_client(
+        rosidl_runtime_py.import_message.import_message_from_namespaced_type(
+            namespaced_type
+        ),
+        service_name,
+    )
 
-        try:
-            request = self._build_request(service_type, request_args)
-        except Exception as e:
-            return f"Failed to build service request: {e}"
-        namespaced_type = get_namespaced_type(service_type)
-        client = self.node.create_client(
-            rosidl_runtime_py.import_message.import_message_from_namespaced_type(
-                namespaced_type
-            ),
-            service_name,
-        )
+    if not client.wait_for_service(timeout_sec=1.0):
+        return f"Service '{service_name}' is not available"
 
-        if not client.wait_for_service(timeout_sec=1.0):
-            return f"Service '{service_name}' is not available"
+    future = client.call_async(request)
+    result = get_future_result(future, timeout_sec=timeout_sec)
 
-        future = client.call_async(request)
-        rclpy.spin_until_future_complete(self.node, future)
+    client.destroy()
 
-        if future.result() is not None:
-            return str(future.result())
-        else:
-            return f"Service call to '{service_name}' failed"
+    if result is not None:
+        return str(result)
+    else:
+        return f"Service call to '{service_name}' failed"
 
 
-class GetCameraImage(Ros2BaseTool):
-    name: str = "get_camera_image"
-    description: str = "get image from robots camera"
-    response_format: str = "content_and_artifact"
-    args_schema: Type[TopicInput] = TopicInput
+@tool(response_format="content_and_artifact")
+def ros2_get_camera_image(
+    node: Annotated[RaiBaseNode, InjectedToolArg], topic_name: str
+) -> Tuple[str, Dict[str, Any]]:
+    """A tool for getting an image from a ros2 camera
 
-    def _run(self, topic_name: str):
-        msg = self.node.get_raw_message_from_topic(topic_name)
-        img = convert_ros_img_to_base64(msg)
-        return "Got image", {"images": [img]}
+    Parameters
+    ----------
+    topic_name : str
+        The name of the topic to get the image from
+    """
+    msg = node.get_raw_message_from_topic(topic_name)
+    img = convert_ros_img_to_base64(msg)
+    return "Got image", {"images": [img]}
+
+
+@tool
+def ros2_get_transform(
+    node: Annotated[rclpy.node.Node, InjectedToolArg],
+    target_frame: str = "map",
+    source_frame: str = "body_link",
+) -> dict:
+    """Get tf from source_frame to target_frame"""
+    return message_to_ordereddict(get_transform(node, target_frame, source_frame))

--- a/src/rai/rai/tools/ros/tools.py
+++ b/src/rai/rai/tools/ros/tools.py
@@ -30,8 +30,6 @@ from tf_transformations import euler_from_quaternion
 from rai.tools.ros.deprecated import SingleMessageGrabber
 from rai.tools.utils import TF2TransformFetcher
 
-from .native import TopicInput
-
 logger = logging.getLogger(__name__)
 
 
@@ -45,6 +43,12 @@ class AddDescribedWaypointToDatabaseToolInput(BaseModel):
         ...,
         description="Text to display on the waypoint (very short, one or two words)",
     )
+
+
+class TopicInput(BaseModel):
+    """Input for the topic tool."""
+
+    topic_name: str = Field(..., description="The name of the topic")
 
 
 class AddDescribedWaypointToDatabaseTool(BaseTool):
@@ -220,10 +224,17 @@ class GetOccupancyGridTool(BaseTool):
             cv2.imwrite("map.png", image)
         return base64.b64encode(buffer.tobytes()).decode("utf-8")
 
-    def _run(self, topic_name: str):
+    def _run(
+        self,
+        topic_name: str,
+        source_frame: str = "base_link",
+        target_frame: str = "map",
+    ):
         """Gets the current map from the specified topic."""
         map_grabber = SingleMessageGrabber(topic_name, OccupancyGrid, timeout_sec=10)
-        tf_grabber = TF2TransformFetcher(target_frame="map", source_frame="base_link")
+        tf_grabber = TF2TransformFetcher(
+            target_frame=target_frame, source_frame=source_frame
+        )
 
         map_msg = map_grabber.get_data()
         transform = tf_grabber.get_data()

--- a/src/rai/rai/tools/time.py
+++ b/src/rai/rai/tools/time.py
@@ -14,34 +14,23 @@
 
 
 import time
-from typing import Type
 
-from langchain_core.tools import BaseTool
-from pydantic import BaseModel, Field
+from langchain.tools import tool
 
 
-class WaitForSecondsToolInput(BaseModel):
-    """Input for the WaitForSecondsTool tool."""
+@tool
+def wait_for_seconds(seconds: int):
+    """
+    Wait for a specified number of seconds. Useful for pausing execution for a
+    specified number of seconds.
 
-    seconds: int = Field(..., description="The number of seconds to wait")
-
-
-class WaitForSecondsTool(BaseTool):
-    """Wait for a specified number of seconds"""
-
-    name: str = "WaitForSecondsTool"
-    description: str = (
-        "A tool for waiting. "
-        "Useful for pausing execution for a specified number of seconds. "
-        "Input should be the number of seconds to wait."
-        "Maximum allowed time is 10 seconds"
-    )
-
-    args_schema: Type[WaitForSecondsToolInput] = WaitForSecondsToolInput
-
-    def _run(self, seconds: int):
-        """Waits for the specified number of seconds."""
-        if seconds > 10:
-            seconds = 10
-        time.sleep(seconds)
-        return f"Waited for {seconds} seconds."
+    Parameters
+    ----------
+    seconds: int
+        The number of seconds to wait. When number is greater than 10, it will be
+        clipped to 10.
+    """
+    if seconds > 10:
+        seconds = 10
+    time.sleep(seconds)
+    return f"Waited for {seconds} seconds."

--- a/tests/core/test_ros2_tools.py
+++ b/tests/core/test_ros2_tools.py
@@ -24,6 +24,7 @@ from rclpy.node import Node
 from std_msgs.msg import String
 
 from rai.agents.state_based import create_state_based_agent
+from rai.tools.render import render_text_description_with_args_from_tools
 from rai.tools.ros.native import Ros2PubMessageTool
 
 
@@ -83,7 +84,7 @@ def test_ros2_pub_message_tool_llm(
     t = threading.Thread(target=executor.spin)
 
     system = SystemMessage(
-        "You are a ros2 agent that can run tools: {render_text_description_and_args(tools)}"
+        f"You are a ros2 agent that can run tools: {render_text_description_with_args_from_tools(tools)}"
     )
     query = HumanMessage(
         f"Publish a std_msgs/msg/String '{test_message}' to the topic '{topic}'"


### PR DESCRIPTION
## Purpose

- This PR simplify ros2 tools by using `InjectedToolArg` to pass ros2 node to langchaing tools.
- Previously the tools required implementing advanced pydantic typing and writing a lot of boilerplate code


## Proposed Changes

- simplify ros2-based langchaing tools in `rai`
- further refactor ros2 API (making it easier to merge with with https://github.com/RobotecAI/rai/pull/360)
- fix circular import issue, when typing in tools made it hard to add tools to `RaiStateBasedLlmNode`

TODOs:
- [ ] refactor open-set vision tools
- [ ] add open-set vision tools to rosbot example

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
