### PR TITLE
fix(`manipuation_demo`): remove manual qos profile setting and spin the node

### DIFF
--- a/examples/manipulation-demo.py
+++ b/examples/manipulation-demo.py
@@ -12,6 +12,8 @@
 # See the License for the specific language goveself.rning permissions and
 # limitations under the License.
 
+import threading
+
 import rclpy
 import rclpy.qos
 from langchain_core.messages import HumanMessage
@@ -27,7 +29,8 @@ def create_agent():
     rclpy.init()
     node = RaiBaseNode(node_name="manipulation_demo")
     node.declare_parameter("conversion_ratio", 1.0)
-    node.qos_profile.reliability = rclpy.qos.ReliabilityPolicy.RELIABLE
+
+    threading.Thread(target=node.spin).start()
 
     tools = [
         GetObjectPositionsTool(


### PR DESCRIPTION
## Purpose

- Fix `AttributeError` with missing `qos_profile` in `manipulation_demo`.

![image](https://github.com/user-attachments/assets/f748e2e7-ffa1-413a-b825-db9ce4f20146)

## Proposed Changes

- Spin the `RaiBaseNode` to get the message from topic according to refactor done in https://github.com/RobotecAI/rai/pull/335
- remove manual QoS setting, because QoS matching is currently used in the `RaiBaseNode` since https://github.com/RobotecAI/rai/pull/353

## Issues

## Testing

Terminal 1:

```bash
ros2 launch examples/manipulation-demo.launch.py game_launcher:=/home/bboczek/Downloads/RAIManipulationDemoGamePackage/RAIManipulationDemo.GameLauncher
```

Terminal 1:
```bash
streamlit run examples/manipulation-demo-streamlit.py
```

In streamlit:
- "take a corn"
- "put it to the side of the table"

