### PR TITLE
feat: make HRIConnector and ARIConnector classes generic

### DIFF
--- a/src/rai/rai/communication/ari_connector.py
+++ b/src/rai/rai/communication/ari_connector.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Generic, Optional, TypeVar
 
 from pydantic import Field
 
@@ -37,7 +37,10 @@ class ROS2RRIMessage(ARIMessage):
     )
 
 
-class ARIConnector(BaseConnector[ARIMessage]):
+T = TypeVar("T", bound=ARIMessage)
+
+
+class ARIConnector(Generic[T], BaseConnector[T]):
     """
     Base class for Agent-Robot Interface (ARI) connectors.
 

--- a/src/rai/rai/communication/base_connector.py
+++ b/src/rai/rai/communication/base_connector.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from typing import Any, Callable, Generic, Optional, TypeVar
+from abc import abstractmethod
+from typing import Any, Callable, Generic, Optional, Protocol, TypeVar
 from uuid import uuid4
 
 
-class BaseMessage(ABC):
+class BaseMessage(Protocol):
+    payload: Any
+
     def __init__(self, payload: Any, *args, **kwargs):
         self.payload = payload
 

--- a/src/rai/rai/communication/sound_device_connector.py
+++ b/src/rai/rai/communication/sound_device_connector.py
@@ -62,7 +62,7 @@ class ConfiguredAudioInputDevice:
         self.dtype = config["dtype"]
 
 
-class StreamingAudioInputDevice(HRIConnector):
+class StreamingAudioInputDevice(HRIConnector[HRIMessage]):
     """Audio input device connector implementing the Human-Robot Interface.
 
     This class provides audio streaming capabilities while conforming to the


### PR DESCRIPTION
## Purpose

Currently when creating a connector derived from `HRI/ARIConnector` additional type checking is required e.g.:

```
def send_message(self, message: ARIMessage. target: str):
    if not is instance(message, ROS2ARIMessage):
         raise ValueError("Message must be of type ROS2ARIMessage")
    ....
```

This could get tedious for SDK users, a call signature like:

```
def send_message(self, message: ROS2ARIMessage. target: str):
```
would be preferable.

## Proposed Changes

This PR makes `HRI/ARIConnector` classes generic, allowing for specifying message type on creation of a derived connector like so (example):

```
class ROS2ARIConnector[ROS2ARIMessage](ARIConnector):
```

which will cause all method signatures to automatically use `ROS2ARIMessage` as the type hint.

## Issues

- Links to relevant issues

## Testing

Tests pertaining to sound device connector check this functionality adequately.
