### PR TITLE
feat: migrating ros2 tools

### DIFF
--- a/src/rai/rai/communication/ros2/connectors.py
+++ b/src/rai/rai/communication/ros2/connectors.py
@@ -14,7 +14,7 @@
 
 import threading
 import uuid
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
@@ -42,6 +42,9 @@ class ROS2ARIConnector(ARIConnector[ROS2ARIMessage]):
         self._executor.add_node(self._node)
         self._thread = threading.Thread(target=self._executor.spin)
         self._thread.start()
+
+    def get_topics_names_and_types(self) -> List[Tuple[str, List[str]]]:
+        return self._topic_api.get_topic_names_and_types()
 
     def send_message(self, message: ROS2ARIMessage, target: str):
         auto_qos_matching = message.metadata.get("auto_qos_matching", True)

--- a/src/rai/rai/tools/ros2/__init__.py
+++ b/src/rai/rai/tools/ros2/__init__.py
@@ -16,6 +16,7 @@ from .actions import CancelROS2ActionTool, StartROS2ActionTool
 from .services import CallROS2ServiceTool
 from .topics import (
     GetROS2ImageTool,
+    GetROS2MessageInterfaceTool,
     GetROS2TopicsNamesAndTypesTool,
     PublishROS2MessageTool,
     ReceiveROS2MessageTool,
@@ -29,4 +30,5 @@ __all__ = [
     "CallROS2ServiceTool",
     "CancelROS2ActionTool",
     "GetROS2TopicsNamesAndTypesTool",
+    "GetROS2MessageInterfaceTool",
 ]

--- a/src/rai/rai/tools/ros2/__init__.py
+++ b/src/rai/rai/tools/ros2/__init__.py
@@ -18,6 +18,7 @@ from .topics import (
     GetROS2ImageTool,
     GetROS2MessageInterfaceTool,
     GetROS2TopicsNamesAndTypesTool,
+    GetROS2TransformTool,
     PublishROS2MessageTool,
     ReceiveROS2MessageTool,
 )
@@ -31,4 +32,5 @@ __all__ = [
     "CancelROS2ActionTool",
     "GetROS2TopicsNamesAndTypesTool",
     "GetROS2MessageInterfaceTool",
+    "GetROS2TransformTool",
 ]

--- a/src/rai/rai/tools/ros2/__init__.py
+++ b/src/rai/rai/tools/ros2/__init__.py
@@ -14,7 +14,12 @@
 
 from .actions import CancelROS2ActionTool, StartROS2ActionTool
 from .services import CallROS2ServiceTool
-from .topics import GetROS2ImageTool, PublishROS2MessageTool, ReceiveROS2MessageTool
+from .topics import (
+    GetROS2ImageTool,
+    GetROS2TopicsNamesAndTypesTool,
+    PublishROS2MessageTool,
+    ReceiveROS2MessageTool,
+)
 
 __all__ = [
     "StartROS2ActionTool",
@@ -23,4 +28,5 @@ __all__ = [
     "ReceiveROS2MessageTool",
     "CallROS2ServiceTool",
     "CancelROS2ActionTool",
+    "GetROS2TopicsNamesAndTypesTool",
 ]

--- a/src/rai/rai/tools/ros2/__init__.py
+++ b/src/rai/rai/tools/ros2/__init__.py
@@ -14,11 +14,11 @@
 
 from .actions import CancelROS2ActionTool, StartROS2ActionTool
 from .services import CallROS2ServiceTool
-from .topics import GetImageTool, PublishROS2MessageTool, ReceiveROS2MessageTool
+from .topics import GetROS2ImageTool, PublishROS2MessageTool, ReceiveROS2MessageTool
 
 __all__ = [
     "StartROS2ActionTool",
-    "GetImageTool",
+    "GetROS2ImageTool",
     "PublishROS2MessageTool",
     "ReceiveROS2MessageTool",
     "CallROS2ServiceTool",

--- a/src/rai/rai/tools/ros2/topics.py
+++ b/src/rai/rai/tools/ros2/topics.py
@@ -181,4 +181,4 @@ class GetROS2TransformTool(BaseTool):
             source_frame=tool_input.source_frame,
             timeout_sec=tool_input.timeout_sec,
         )
-        return str(transform)
+        return stringify_dict(ros2_message_to_dict(transform))

--- a/src/rai/rai/tools/ros2/topics.py
+++ b/src/rai/rai/tools/ros2/topics.py
@@ -70,19 +70,19 @@ class ReceiveROS2MessageTool(BaseTool):
         return str({"payload": message.payload, "metadata": message.metadata})
 
 
-class GetImageToolInput(BaseModel):
+class GetROS2ImageToolInput(BaseModel):
     topic: str = Field(..., description="The topic to receive the image from")
 
 
-class GetImageTool(BaseTool):
+class GetROS2ImageTool(BaseTool):
     connector: ROS2ARIConnector
     name: str = "get_ros2_image"
     description: str = "Get an image from a ROS2 topic"
-    args_schema: Type[GetImageToolInput] = GetImageToolInput
+    args_schema: Type[GetROS2ImageToolInput] = GetROS2ImageToolInput
     response_format: Literal["content", "content_and_artifact"] = "content_and_artifact"
 
     @wrap_tool_input
-    def _run(self, tool_input: GetImageToolInput) -> Tuple[str, MultimodalArtifact]:
+    def _run(self, tool_input: GetROS2ImageToolInput) -> Tuple[str, MultimodalArtifact]:
         message = self.connector.receive_message(tool_input.topic)
         msg_type = type(message.payload)
         if msg_type == Image:

--- a/src/rai/rai/tools/ros2/topics.py
+++ b/src/rai/rai/tools/ros2/topics.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Literal, Tuple, Type
 
 from cv_bridge import CvBridge
 from langchain_core.tools import BaseTool
+from langchain_core.utils import stringify_dict
 from pydantic import BaseModel, Field
 from sensor_msgs.msg import CompressedImage, Image
 
@@ -98,3 +99,25 @@ class GetROS2ImageTool(BaseTool):
                 f"Unsupported message type: {message.metadata['msg_type']}"
             )
         return "Image received successfully", MultimodalArtifact(images=[preprocess_image(image)])  # type: ignore
+
+
+class GetROS2TopicsNamesAndTypesToolInput(BaseModel):
+    pass
+
+
+class GetROS2TopicsNamesAndTypesTool(BaseTool):
+    connector: ROS2ARIConnector
+    name: str = "get_ros2_topics_names_and_types"
+    description: str = "Get the names and types of all ROS2 topics"
+    args_schema: Type[GetROS2TopicsNamesAndTypesToolInput] = (
+        GetROS2TopicsNamesAndTypesToolInput
+    )
+
+    @wrap_tool_input
+    def _run(self, tool_input: GetROS2TopicsNamesAndTypesToolInput) -> str:
+        topics_and_types = self.connector.get_topics_names_and_types()
+        response = [
+            stringify_dict({"topic": topic, "type": type})
+            for topic, type in topics_and_types
+        ]
+        return "\n".join(response)

--- a/src/rai/rai/tools/ros2/topics.py
+++ b/src/rai/rai/tools/ros2/topics.py
@@ -167,3 +167,25 @@ class GetROS2MessageInterfaceTool(BaseTool):
             return json.dumps(
                 {"goal": goal_dict, "result": result_dict, "feedback": feedback_dict}
             )
+
+
+class GetROS2TransformToolInput(BaseModel):
+    target_frame: str = Field(..., description="The target frame")
+    source_frame: str = Field(..., description="The source frame")
+    timeout_sec: float = Field(default=5.0, description="The timeout in seconds")
+
+
+class GetROS2TransformTool(BaseTool):
+    connector: ROS2ARIConnector
+    name: str = "get_ros2_transform"
+    description: str = "Get the transform between two frames"
+    args_schema: Type[GetROS2TransformToolInput] = GetROS2TransformToolInput
+
+    @wrap_tool_input
+    def _run(self, tool_input: GetROS2TransformToolInput) -> str:
+        transform = self.connector.get_transform(
+            target_frame=tool_input.target_frame,
+            source_frame=tool_input.source_frame,
+            timeout_sec=tool_input.timeout_sec,
+        )
+        return str(transform)

--- a/src/rai/rai/tools/ros2/topics.py
+++ b/src/rai/rai/tools/ros2/topics.py
@@ -20,7 +20,7 @@ except ImportError:
     )
 
 import json
-from typing import Any, Dict, Literal, OrderedDict, Tuple, Type
+from typing import Any, Dict, Literal, Tuple, Type
 
 import rosidl_runtime_py.set_message
 import rosidl_runtime_py.utilities
@@ -33,6 +33,7 @@ from sensor_msgs.msg import CompressedImage, Image
 from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
 from rai.messages.multimodal import MultimodalArtifact
 from rai.messages.utils import preprocess_image
+from rai.tools.ros2.utils import ros2_message_to_dict
 from rai.tools.utils import wrap_tool_input  # type: ignore
 
 
@@ -147,23 +148,15 @@ class GetROS2MessageInterfaceTool(BaseTool):
             tool_input.msg_type
         )
         try:
-            msg_dict: OrderedDict[str, Any] = (
-                rosidl_runtime_py.convert.message_to_ordereddict(msg_cls())  # type: ignore
-            )
+            msg_dict = ros2_message_to_dict(msg_cls())  # type: ignore
             return json.dumps(msg_dict)
         except NotImplementedError:
             # For action classes that can't be instantiated
-            goal_dict: OrderedDict[str, Any] = (
-                rosidl_runtime_py.convert.message_to_ordereddict(msg_cls.Goal())  # type: ignore
-            )
+            goal_dict = ros2_message_to_dict(msg_cls.Goal())  # type: ignore
 
-            result_dict: OrderedDict[str, Any] = (
-                rosidl_runtime_py.convert.message_to_ordereddict(msg_cls.Result())  # type: ignore
-            )
+            result_dict = ros2_message_to_dict(msg_cls.Result())  # type: ignore
 
-            feedback_dict: OrderedDict[str, Any] = (
-                rosidl_runtime_py.convert.message_to_ordereddict(msg_cls.Feedback())  # type: ignore
-            )
+            feedback_dict = ros2_message_to_dict(msg_cls.Feedback())  # type: ignore
             return json.dumps(
                 {"goal": goal_dict, "result": result_dict, "feedback": feedback_dict}
             )

--- a/src/rai/rai/tools/ros2/utils.py
+++ b/src/rai/rai/tools/ros2/utils.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, OrderedDict
+
+import rosidl_runtime_py.convert
+import rosidl_runtime_py.set_message
+import rosidl_runtime_py.utilities
+
+
+def ros2_message_to_dict(message: Any) -> OrderedDict[str, Any]:
+    """Convert any ROS2 message into a dictionary.
+
+    Args:
+        message: A ROS2 message instance
+
+    Returns:
+        A dictionary representation of the message
+
+    Raises:
+        TypeError: If the input is not a valid ROS2 message
+    """
+    msg_dict: OrderedDict[str, Any] = rosidl_runtime_py.convert.message_to_ordereddict(
+        message
+    )  # type: ignore
+    return msg_dict

--- a/tests/communication/ros2/helpers.py
+++ b/tests/communication/ros2/helpers.py
@@ -28,6 +28,7 @@ from rclpy.node import Node
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
 from std_srvs.srv import SetBool
+from tf2_ros import TransformBroadcaster, TransformStamped
 
 
 class ServiceServer(Node):
@@ -126,6 +127,29 @@ class MessagePublisher(Node):
         msg = String()
         msg.data = "Hello, ROS2!"
         self.publisher.publish(msg)
+
+
+class TransformPublisher(Node):
+    def __init__(self, topic: str):
+        super().__init__("test_transform_publisher")
+        self.tf_broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(0.1, self.publish_transform)
+        self.frame_id = "base_link"
+        self.child_frame_id = "map"
+
+    def publish_transform(self) -> None:
+        msg = TransformStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()  # type: ignore
+        msg.header.frame_id = self.frame_id  # type: ignore
+        msg.child_frame_id = self.child_frame_id  # type: ignore
+        msg.transform.translation.x = 1.0  # type: ignore
+        msg.transform.translation.y = 2.0  # type: ignore
+        msg.transform.translation.z = 3.0  # type: ignore
+        msg.transform.rotation.x = 0.0  # type: ignore
+        msg.transform.rotation.y = 0.0  # type: ignore
+        msg.transform.rotation.z = 0.0  # type: ignore
+        msg.transform.rotation.w = 1.0  # type: ignore
+        self.tf_broadcaster.sendTransform(msg)
 
 
 def multi_threaded_spinner(

--- a/tests/tools/ros2/test_topic_tools.py
+++ b/tests/tools/ros2/test_topic_tools.py
@@ -28,7 +28,11 @@ import time
 from PIL import Image
 
 from rai.communication.ros2.connectors import ROS2ARIConnector
-from rai.tools.ros2 import GetImageTool, PublishROS2MessageTool, ReceiveROS2MessageTool
+from rai.tools.ros2 import (
+    GetROS2ImageTool,
+    PublishROS2MessageTool,
+    ReceiveROS2MessageTool,
+)
 from tests.communication.ros2.helpers import (
     ImagePublisher,
     MessagePublisher,
@@ -92,7 +96,7 @@ def test_receive_image_tool(ros_setup: None, request: pytest.FixtureRequest) -> 
     connector = ROS2ARIConnector()
     publisher = ImagePublisher(topic=topic_name)
     executors, threads = multi_threaded_spinner([publisher])
-    tool = GetImageTool(connector=connector)
+    tool = GetROS2ImageTool(connector=connector)
     time.sleep(1)
     try:
         _, artifact_dict = tool._run(topic=topic_name)  # type: ignore

--- a/tests/tools/ros2/test_topic_tools.py
+++ b/tests/tools/ros2/test_topic_tools.py
@@ -30,6 +30,7 @@ from PIL import Image
 from rai.communication.ros2.connectors import ROS2ARIConnector
 from rai.tools.ros2 import (
     GetROS2ImageTool,
+    GetROS2MessageInterfaceTool,
     GetROS2TopicsNamesAndTypesTool,
     PublishROS2MessageTool,
     ReceiveROS2MessageTool,
@@ -117,3 +118,16 @@ def test_get_topics_names_and_types_tool(
     tool = GetROS2TopicsNamesAndTypesTool(connector=connector)
     response = tool._run()
     assert response != ""
+
+
+def test_get_message_interface_tool(
+    ros_setup: None, request: pytest.FixtureRequest
+) -> None:
+    connector = ROS2ARIConnector()
+    tool = GetROS2MessageInterfaceTool(connector=connector)
+    response = tool._run(msg_type="nav2_msgs/action/NavigateToPose")  # type: ignore
+    assert "goal" in response
+    assert "result" in response
+    assert "feedback" in response
+    response = tool._run(msg_type="std_msgs/msg/String")  # type: ignore
+    assert "data" in response

--- a/tests/tools/ros2/test_topic_tools.py
+++ b/tests/tools/ros2/test_topic_tools.py
@@ -30,6 +30,7 @@ from PIL import Image
 from rai.communication.ros2.connectors import ROS2ARIConnector
 from rai.tools.ros2 import (
     GetROS2ImageTool,
+    GetROS2TopicsNamesAndTypesTool,
     PublishROS2MessageTool,
     ReceiveROS2MessageTool,
 )
@@ -107,3 +108,12 @@ def test_receive_image_tool(ros_setup: None, request: pytest.FixtureRequest) -> 
         assert image.size == (100, 100)
     finally:
         shutdown_executors_and_threads(executors, threads)
+
+
+def test_get_topics_names_and_types_tool(
+    ros_setup: None, request: pytest.FixtureRequest
+) -> None:
+    connector = ROS2ARIConnector()
+    tool = GetROS2TopicsNamesAndTypesTool(connector=connector)
+    response = tool._run()
+    assert response != ""

--- a/tests/tools/test_tool_utils.py
+++ b/tests/tools/test_tool_utils.py
@@ -16,7 +16,7 @@ import logging
 from typing import Any, Dict, List, Type
 
 import pytest
-from geometry_msgs.msg import Point
+from geometry_msgs.msg import Point, TransformStamped
 from langchain_core.messages import AIMessage, ToolCall
 from langchain_core.tools import BaseTool
 from nav2_msgs.action import NavigateToPose
@@ -72,6 +72,7 @@ def test_wrap_tool_input():
         Point(),
         Image(),
         TFMessage(),
+        TransformStamped(),
         NavigateToPose.Goal(),
         NavigateToPose.Result(),
         NavigateToPose.Feedback(),

--- a/tests/tools/test_tool_utils.py
+++ b/tests/tools/test_tool_utils.py
@@ -65,7 +65,7 @@ def test_wrap_tool_input():
     )
 
 
-# TODO: Add custom RAI messages?
+# TODO(`maciejmajek`): Add custom RAI messages?
 @pytest.mark.parametrize(
     "message",
     [

--- a/tests/tools/test_tool_utils.py
+++ b/tests/tools/test_tool_utils.py
@@ -15,11 +15,17 @@
 import logging
 from typing import Any, Dict, List, Type
 
+import pytest
+from geometry_msgs.msg import Point
 from langchain_core.messages import AIMessage, ToolCall
 from langchain_core.tools import BaseTool
+from nav2_msgs.action import NavigateToPose
 from pydantic import BaseModel, Field
+from sensor_msgs.msg import Image
+from tf2_msgs.msg import TFMessage
 
 from rai.agents.tool_runner import ToolRunner
+from rai.tools.ros2.utils import ros2_message_to_dict
 from rai.tools.utils import wrap_tool_input
 
 
@@ -57,3 +63,20 @@ def test_wrap_tool_input():
     _ = runner.invoke(
         {"messages": [AIMessage(content="Hello, how are you?", tool_calls=[tool_call])]}
     )
+
+
+# TODO: Add custom RAI messages?
+@pytest.mark.parametrize(
+    "message",
+    [
+        Point(),
+        Image(),
+        TFMessage(),
+        NavigateToPose.Goal(),
+        NavigateToPose.Result(),
+        NavigateToPose.Feedback(),
+    ],
+    ids=lambda x: x.__class__.__name__,
+)
+def test_ros2_message_to_dict(message):
+    assert ros2_message_to_dict(message)


### PR DESCRIPTION
## Purpose

Our new BaseConnector API requires changes to be made to the langchain tools.

## Proposed Changes

Recreating existing tools using the new api

## Testing

- new tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added methods to retrieve ROS2 topic names and types
	- Introduced tools for getting ROS2 message interfaces
	- Added functionality to retrieve ROS2 transformations
	- Created utility to convert ROS2 messages to dictionaries

- **Improvements**
	- Enhanced ROS2 communication connector with new methods
	- Updated import statements and tool definitions
	- Improved type annotations for ROS2-related functions

- **Testing**
	- Added new test cases for ROS2 message and transformation tools
	- Expanded test coverage for ROS2 communication utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->