### PR TITLE
chore: remove skipped test

### DIFF
--- a/tests/communication/ros2/test_connectors.py
+++ b/tests/communication/ros2/test_connectors.py
@@ -163,32 +163,3 @@ def test_ros2ari_connector_send_goal_erronous_callback(
     finally:
         connector.shutdown()
         shutdown_executors_and_threads(executors, threads)
-
-
-@pytest.mark.skip(
-    reason="""
-                  This test does not allow pytest to exit.
-                  TODO: Decide whether still working callbacks should
-                  be cancelled when shutting down"""
-)
-def test_ros2ari_connector_send_goal_blocking_callback(
-    ros_setup: None, request: pytest.FixtureRequest
-):
-    action_name = f"{request.node.originalname}_action"  # type: ignore
-    action_server = ActionServer(action_name)
-    executors, threads = multi_threaded_spinner([action_server])
-    connector = ROS2ARIConnector()
-    try:
-        message = ROS2ARIMessage(
-            payload={},
-            metadata={"msg_type": "nav2_msgs/action/NavigateToPose"},
-        )
-        handle = connector.start_action(
-            action_data=message,
-            target=action_name,
-            on_feedback=lambda feedback: time.sleep(100),
-        )
-        assert handle is not None
-    finally:
-        connector.shutdown()
-        shutdown_executors_and_threads(executors, threads)


### PR DESCRIPTION
## Purpose

The test checks is skipped, because it was added to decide what is the expected behaviour if callback terminates after the action which called it. The expected behaviour doesn't require testing. The test should be removed.

## Proposed Changes

Removes the test in question.

## Issues
https://github.com/RobotecAI/rai/issues/381

## Testing

N/A
