### PR TITLE
chore: remove langchain _run method wrapper

### DIFF
--- a/src/rai/rai/tools/ros/manipulation.py
+++ b/src/rai/rai/tools/ros/manipulation.py
@@ -87,7 +87,7 @@ class MoveToPointTool(BaseTool):
         x: float,
         y: float,
         z: float,
-        task: Literal["grab", "place"],
+        task: Literal["grab", "drop"],
     ) -> str:
         pose_stamped = PoseStamped()
         pose_stamped.header.frame_id = self.manipulator_frame
@@ -96,7 +96,7 @@ class MoveToPointTool(BaseTool):
             orientation=self.quaternion,
         )
 
-        if task == "place":
+        if task == "drop":
             pose_stamped.pose.position.z += self.additional_height
 
         pose_stamped.pose.position.x += self.calibration_x

--- a/src/rai/rai/tools/ros/native.py
+++ b/src/rai/rai/tools/ros/native.py
@@ -33,7 +33,7 @@ from pydantic import BaseModel, Field
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rosidl_runtime_py.utilities import get_namespaced_type
 
-from .utils import convert_ros_img_to_base64, import_message_from_str
+from rai.tools.ros.utils import convert_ros_img_to_base64, import_message_from_str
 
 
 # --------------------- Inputs ---------------------

--- a/src/rai/rai/tools/ros/native_actions.py
+++ b/src/rai/rai/tools/ros/native_actions.py
@@ -21,8 +21,8 @@ from pydantic import BaseModel, Field
 from rclpy.action.client import ActionClient
 from rosidl_runtime_py import message_to_ordereddict
 
-from .native import Ros2BaseInput, Ros2BaseTool
-from .utils import get_transform
+from rai.tools.ros.native import Ros2BaseInput, Ros2BaseTool
+from rai.tools.ros.utils import get_transform
 
 
 # --------------------- Inputs ---------------------
@@ -197,7 +197,7 @@ class GetTransformTool(Ros2BaseActionTool):
 
     args_schema: Type[GetTransformInput] = GetTransformInput
 
-    def _run(self, target_frame="map", source_frame="body_link") -> dict:
+    def _run(self, target_frame: str = "map", source_frame: str = "body_link") -> dict:
         return message_to_ordereddict(
             get_transform(self.node, target_frame, source_frame)
         )

--- a/src/rai/rai/tools/ros/tools.py
+++ b/src/rai/rai/tools/ros/tools.py
@@ -28,9 +28,8 @@ from pydantic import BaseModel, Field
 from tf_transformations import euler_from_quaternion
 
 from rai.tools.ros.deprecated import SingleMessageGrabber
+from rai.tools.ros.native import TopicInput
 from rai.tools.utils import TF2TransformFetcher
-
-from .native import TopicInput
 
 logger = logging.getLogger(__name__)
 

--- a/src/rai/rai/tools/ros2/services.py
+++ b/src/rai/rai/tools/ros2/services.py
@@ -25,13 +25,12 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
-from rai.tools.utils import wrap_tool_input  # type: ignore
 
 
 class CallROS2ServiceToolInput(BaseModel):
     service_name: str = Field(..., description="The service to call")
     service_type: str = Field(..., description="The type of the service")
-    args: Dict[str, Any] = Field(
+    service_args: Dict[str, Any] = Field(
         ..., description="The arguments to pass to the service"
     )
 
@@ -42,11 +41,12 @@ class CallROS2ServiceTool(BaseTool):
     description: str = "Call a ROS2 service"
     args_schema: Type[CallROS2ServiceToolInput] = CallROS2ServiceToolInput
 
-    @wrap_tool_input
-    def _run(self, tool_input: CallROS2ServiceToolInput) -> str:
-        message = ROS2ARIMessage(payload=tool_input.args)
+    def _run(
+        self, service_name: str, service_type: str, service_args: Dict[str, Any]
+    ) -> str:
+        message = ROS2ARIMessage(payload=service_args)
         response = self.connector.service_call(
-            message, tool_input.service_name, msg_type=tool_input.service_type
+            message, service_name, msg_type=service_type
         )
         return str(
             {

--- a/src/rai/rai/tools/utils.py
+++ b/src/rai/rai/tools/utils.py
@@ -16,7 +16,6 @@
 import base64
 import logging
 import subprocess
-from functools import wraps
 from typing import Any, Callable, Dict, List, Literal, Sequence, Union, cast
 
 import cv2
@@ -42,14 +41,6 @@ from sensor_msgs.msg import Image
 from tf2_ros import Buffer, TransformListener
 
 from rai.messages import ToolMultimodalMessage
-
-
-def wrap_tool_input(func):  # type: ignore
-    @wraps(func)  # type: ignore
-    def wrapped(self: BaseTool, **kwargs):  # type: ignore
-        return func(self, self.args_schema(**kwargs))  # type: ignore
-
-    return wrapped  # type: ignore
 
 
 # Copied from https://github.com/ros2/rclpy/blob/jazzy/rclpy/rclpy/wait_for_message.py, to support humble

--- a/tests/tools/ros2/test_action_tools.py
+++ b/tests/tools/ros2/test_action_tools.py
@@ -44,7 +44,7 @@ def test_action_call_tool(ros_setup: None, request: pytest.FixtureRequest) -> No
         response = tool._run(  # type: ignore
             action_name=action_name,
             action_type="nav2_msgs/action/NavigateToPose",
-            args={},
+            action_args={},
         )
         assert "Action started with ID:" in response
 

--- a/tests/tools/ros2/test_service_tools.py
+++ b/tests/tools/ros2/test_service_tools.py
@@ -44,7 +44,7 @@ def test_service_call_tool(ros_setup: None, request: pytest.FixtureRequest) -> N
         response = tool._run(  # type: ignore
             service_name=service_name,
             service_type="std_srvs/srv/SetBool",
-            args={},
+            service_args={},
         )
         assert "Test service called" in response
         assert "success=True" in response

--- a/tests/tools/test_tool_input_args_compatibility.py
+++ b/tests/tools/test_tool_input_args_compatibility.py
@@ -1,4 +1,16 @@
-# find all python classes that inherit from pydantic.BaseTool in src/ catalog
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import importlib.util
 import inspect

--- a/tests/tools/test_tool_input_args_compatibility.py
+++ b/tests/tools/test_tool_input_args_compatibility.py
@@ -53,25 +53,24 @@ def get_all_tool_classes() -> set[BaseTool]:
     return set(tools)
 
 
-@pytest.mark.parametrize("tool_class", get_all_tool_classes())
-def test_tool_input_args_compatibility(tool_class: BaseTool):
-    tool = tool_class
+@pytest.mark.parametrize("tool", get_all_tool_classes())
+def test_tool_input_args_compatibility(tool: BaseTool):
     tool_run_annotations = tool._run.__annotations__
     if "return" in tool_run_annotations:
         tool_run_annotations.pop("return")
     if "args" in tool_run_annotations and "kwargs" in tool_run_annotations:
         print(
-            f"Tool {tool_class} has *args or **kwargs, the _run method is most likely still an abstractmethod"
+            f"Tool {tool} has *args or **kwargs, the _run method is most likely still an abstractmethod"
         )
         pytest.xfail(
             reason="Tool has *args or **kwargs, the _run method is most likely still an abstractmethod"
         )
     if "args_schema" not in tool.__annotations__:
-        print(f"Tool {tool_class} has no args_schema")
+        print(f"Tool {tool} has no args_schema")
         pytest.xfail(reason="Tool has no args_schema")
 
     if len(tool.__annotations__["args_schema"].__args__) != 1:
-        raise NotImplementedError(f"Tool {tool_class} has ambiguous args_schema")
+        raise NotImplementedError(f"Tool {tool} has ambiguous args_schema")
 
     tool_input_annotations = (
         tool.__annotations__["args_schema"].__args__[0].__annotations__

--- a/tests/tools/test_tool_input_args_compatibility.py
+++ b/tests/tools/test_tool_input_args_compatibility.py
@@ -1,0 +1,67 @@
+# find all python classes that inherit from pydantic.BaseTool in src/ catalog
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+from langchain_core.tools import BaseTool
+
+
+def get_all_tool_classes() -> set[BaseTool]:
+    """Recursively find all classes that inherit from pydantic.BaseModel in src/rai/rai/tools"""
+    tools = []
+    tools_path = Path("src/rai/rai/tools")
+
+    # Recursively find all .py files
+    for py_file in tools_path.rglob("*.py"):
+        if py_file.name.startswith("_"):  # Skip __init__.py and similar
+            continue
+
+        try:
+            # Manual module loading since files aren't in __init__
+            module_name = py_file.stem
+            spec = importlib.util.spec_from_file_location(module_name, py_file)
+            if spec is None or spec.loader is None:
+                continue
+
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            for name, obj in inspect.getmembers(module):
+                if (
+                    inspect.isclass(obj)
+                    and issubclass(obj, BaseTool)
+                    and obj != BaseTool
+                ):
+                    tools.append(obj)
+        except Exception as e:
+            print(f"Failed to process {py_file}: {e}")
+
+    return set(tools)
+
+
+@pytest.mark.parametrize("tool_class", get_all_tool_classes())
+def test_tool_input_args_compatibility(tool_class: BaseTool):
+    tool = tool_class
+    tool_run_annotations = tool._run.__annotations__
+    if "return" in tool_run_annotations:
+        tool_run_annotations.pop("return")
+    if "args" in tool_run_annotations and "kwargs" in tool_run_annotations:
+        print(
+            f"Tool {tool_class} has *args or **kwargs, the _run method is most likely still an abstractmethod"
+        )
+        pytest.xfail(
+            reason="Tool has *args or **kwargs, the _run method is most likely still an abstractmethod"
+        )
+    if "args_schema" not in tool.__annotations__:
+        print(f"Tool {tool_class} has no args_schema")
+        pytest.xfail(reason="Tool has no args_schema")
+
+    if len(tool.__annotations__["args_schema"].__args__) != 1:
+        raise NotImplementedError(f"Tool {tool_class} has ambiguous args_schema")
+
+    tool_input_annotations = (
+        tool.__annotations__["args_schema"].__args__[0].__annotations__
+    )
+    assert tool_run_annotations == tool_input_annotations

--- a/tests/tools/test_tool_utils.py
+++ b/tests/tools/test_tool_utils.py
@@ -12,57 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from typing import Any, Dict, List, Type
 
 import pytest
 from geometry_msgs.msg import Point, TransformStamped
-from langchain_core.messages import AIMessage, ToolCall
-from langchain_core.tools import BaseTool
 from nav2_msgs.action import NavigateToPose
-from pydantic import BaseModel, Field
 from sensor_msgs.msg import Image
 from tf2_msgs.msg import TFMessage
 
-from rai.agents.tool_runner import ToolRunner
 from rai.tools.ros2.utils import ros2_message_to_dict
-from rai.tools.utils import wrap_tool_input
-
-
-def test_wrap_tool_input():
-    class TestToolInput(BaseModel):
-        a: int = Field(..., description="The number")
-        b: str = Field(..., description="The string")
-        c: Dict[str, Any] = Field(..., description="The dictionary")
-        d: List[int] = Field(..., description="The list of numbers")
-        e: bytes = Field(..., description="The bytes")
-
-    class TestTool(BaseTool):
-        name: str = "test_tool"
-        description: str = "This is a test tool"
-        args_schema: Type[TestToolInput] = TestToolInput
-
-        @wrap_tool_input
-        def _run(self, tool_input: TestToolInput) -> str:
-            assert tool_input.a == 1
-            assert tool_input.b == "test"
-            assert tool_input.c == {"a": 1, "b": 2}
-            assert tool_input.d == [1, 2, 3]
-            assert tool_input.e == b"test"
-            return "done"
-
-    tool = TestTool()
-    logger = logging.getLogger(__name__)
-    runner = ToolRunner(tools=[tool], logger=logger)
-    tool_call = ToolCall(
-        name="test_tool",
-        args={"a": 1, "b": "test", "c": {"a": 1, "b": 2}, "d": [1, 2, 3], "e": b"test"},
-        id="123",
-    )
-
-    _ = runner.invoke(
-        {"messages": [AIMessage(content="Hello, how are you?", tool_calls=[tool_call])]}
-    )
 
 
 # TODO(`maciejmajek`): Add custom RAI messages?


### PR DESCRIPTION
## Purpose

Removing ._run method wrapper due to lsp typing problem.- wrong type annotations were shown for ._run methods using the wrapper.

## Proposed Changes

- Removes the wrapper,
- Add test which searches for tools based on BaseTool and checks for mismatch between BaseTool.args_schema annotations and BaseTool._run annotations.
- Fixes for bad annotations.

## Testing

- New CI test
