### PR TITLE
chore: update default openai model

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ region_name = "us-east-1"
 
 [openai]
 simple_model = "gpt-4o-mini"
-complex_model = "gpt-4o-2024-08-06"
+complex_model = "gpt-4o"
 embeddings_model = "text-embedding-ada-002"
 base_url = "https://api.openai.com/v1/" # for openai compatible apis
 


### PR DESCRIPTION
## Purpose

Changing the default model to standard gpt-4o. Previous changes was done to reduce costs as the specific model was offered at a 50% reduced price but was supposed to became the default much later.

## Proposed Changes

Updates the default complex model for openai.
