### PR TITLE
fix: order of shutdowns in `connector.shutdown()`

### DIFF
--- a/src/rai_core/rai/communication/ros2/connectors.py
+++ b/src/rai_core/rai/communication/ros2/connectors.py
@@ -201,11 +201,11 @@ class ROS2ARIConnector(ARIConnector[ROS2ARIMessage]):
         self._actions_api.terminate_goal(action_handle)
 
     def shutdown(self):
-        self._executor.shutdown()
-        self._thread.join()
+        self._node.destroy_node()
         self._actions_api.shutdown()
         self._topic_api.shutdown()
-        self._node.destroy_node()
+        self._executor.shutdown()
+        self._thread.join()
 
 
 class ROS2HRIMessage(HRIMessage):


### PR DESCRIPTION
## Purpose

- fix exception in `Ros2ARIConnector.shotdown()`

```
Exception in thread Thread-1 (spin):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 294, in spin
    self.spin_once()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 794, in spin_once
    self._spin_once_impl(timeout_sec)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 786, in _spin_once_impl
    self._executor.submit(handler)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 167, in submit
    raise RuntimeError('cannot schedule new futures after shutdown')
RuntimeError: cannot schedule new futures after shutdown
```

## Proposed Changes

- change order of shutdowns

## Issues

## Testing

1. Launch this demo:
https://github.com/RobotecAI/rai/blob/main/docs/demos/manipulation.md

2. Run script:
```
import time
import rclpy
import rclpy.qos
from rai.tools.ros.manipulation import GetObjectPositionsTool
from rai.communication.ros2.connectors import ROS2ARIConnector
from rai_open_set_vision.tools import GetGrabbingPointTool

rclpy.init()
connector = ROS2ARIConnector(node_name="my_node")
node = connector.node
node.declare_parameter("conversion_ratio", 1.0)

tool = GetObjectPositionsTool(
    connector=connector,
    target_frame="panda_link0",
    source_frame="RGBDCamera5",
    camera_topic="/color_image5",
    depth_topic="/depth_image5",
    camera_info_topic="/color_camera_info5",
    get_grabbing_point_tool=GetGrabbingPointTool(connector=connector),
)

response = tool._run(object_name="carrot")
time.sleep(10)
print(response)
connector.shutdown()
```
