### PR TITLE
test: rai_sim tests

### DIFF
--- a/setup_shell.sh
+++ b/setup_shell.sh
@@ -33,3 +33,5 @@ PYTHONPATH="$(dirname "$(dirname "$(poetry run which python)")")/lib/python$(poe
 PYTHONPATH="src/rai_core:$PYTHONPATH"
 PYTHONPATH="src/rai_asr:$PYTHONPATH"
 PYTHONPATH="src/rai_tts:$PYTHONPATH"
+PYTHONPATH="src/rai_sim:$PYTHONPATH"
+PYTHONPATH="src/rai_bench:$PYTHONPATH"

--- a/src/rai_bench/rai_bench/benchmark_model.py
+++ b/src/rai_bench/rai_bench/benchmark_model.py
@@ -23,7 +23,7 @@ from rai.messages import HumanMultimodalMessage
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 from rai_sim.simulation_bridge import (
-    PoseModel,
+    Pose,
     SimulationBridge,
     SimulationConfig,
     SimulationConfigT,
@@ -88,7 +88,7 @@ class Task(ABC):
         """Filter and return only these entities that match provided prefab types"""
         return [ent for ent in entities if ent.prefab_name in prefab_types]
 
-    def euclidean_distance(self, pos1: PoseModel, pos2: PoseModel) -> float:
+    def euclidean_distance(self, pos1: Pose, pos2: Pose) -> float:
         """Calculate euclidean distance between 2 positions"""
         return (
             (pos1.translation.x - pos2.translation.x) ** 2
@@ -96,7 +96,7 @@ class Task(ABC):
             + (pos1.translation.z - pos2.translation.z) ** 2
         ) ** 0.5
 
-    def is_adjacent(self, pos1: PoseModel, pos2: PoseModel, threshold_distance: float):
+    def is_adjacent(self, pos1: Pose, pos2: Pose, threshold_distance: float):
         """
         Check if positions are adjacent to each other, the threshold_distance is a distance
         in simulation, refering to how close they have to be to classify them as adjacent
@@ -107,7 +107,7 @@ class Task(ABC):
         return self.euclidean_distance(pos1, pos2) < threshold_distance
 
     def is_adjacent_to_any(
-        self, pos1: PoseModel, positions: List[PoseModel], threshold_distance: float
+        self, pos1: Pose, positions: List[Pose], threshold_distance: float
     ) -> bool:
         """
         Check if given position is adjacent to any position in the given list.
@@ -117,9 +117,7 @@ class Task(ABC):
             self.is_adjacent(pos1, pos2, threshold_distance) for pos2 in positions
         )
 
-    def count_adjacent(
-        self, positions: List[PoseModel], threshold_distance: float
-    ) -> int:
+    def count_adjacent(self, positions: List[Pose], threshold_distance: float) -> int:
         """
         Count how many adjacent positions are in the given list.
         Note that position has to be adjacent to only 1 other position

--- a/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
+++ b/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
@@ -32,7 +32,7 @@ from rai_bench.o3de_test_bench.tasks import GrabCarrotTask, PlaceCubesTask
 from rai_sim.o3de.o3de_bridge import (
     O3DEngineArmManipulationBridge,
     O3DExROS2SimulationConfig,
-    PoseModel,
+    Pose,
 )
 from rai_sim.simulation_bridge import Rotation, Translation
 
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     )
 
     # custom request to arm
-    base_arm_pose = PoseModel(
+    base_arm_pose = Pose(
         translation=Translation(x=0.5, y=0.1, z=0.3),
         rotation=Rotation(x=1.0, y=0.0, z=0.0, w=0.0),
     )

--- a/src/rai_sim/README.md
+++ b/src/rai_sim/README.md
@@ -6,12 +6,13 @@ The RAI Sim is a package providing interface to implement connection with a spec
 
 ### Components
 
-- `SimulationConnector` - An interface for connecting with a specific simulation. It manages scene setup, spawning, despawning objects, getting current state of the scene.
+- `SimulationBridge` - An interface for connecting with a specific simulation. It manages scene setup, spawning, despawning objects, getting current state of the scene.
 
-- `SimulationConfig` - base config class to specify the entities to be spawned. For each simulation connector there should be specified custom simulation config specifying additional parameters needed to run and connect with the simulation.
+- `SimulationConfig` - base config class to specify the entities to be spawned. For each simulation bridge there should be specified custom simulation config specifying additional parameters needed to run and connect with the simulation.
 
 - `SceneState` - stores the current info about spawned entities
 
 ### Example implementation
 
-- `O3DExROS2Connector` - An implementation of SimulationConnector for working with simulation based on O3DE and ROS2.
+- `O3DExROS2Bridge` - An implementation of SimulationBridge for working with simulation based on O3DE and ROS2.
+- `O3DExROS2SimulationConfig` - config class for `O3DExROS2Bridge`

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -111,13 +111,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
             target="get_available_spawnable_names",
             msg_type="gazebo_msgs/srv/GetWorldProperties",
         )
-        # NOTE (mkotynia) There is a bug in the gazebo_msgs/srv/GetWorldProperties service - payload.success is not set to True even if the service call is successful. It was reported to Kacper Dąbrowski and he is going to fix it.
-        # PR fixing the bug: https://github.com/o3de/o3de-extras/pull/828
-        # TODO (mkotynia) uncomment check if response.payload.success when the bug is fixed and remove workaround check if response.payload.model_names.
-
-        # if response.payload.success:
-        #     return response.payload.model_names
-        if response.payload.model_names:
+        if response.payload.success:
             return response.payload.model_names
         else:
             raise RuntimeError(

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -125,7 +125,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
 
     def _spawn_entity(self, entity: Entity):
         pose = do_transform_pose(
-            self.to_ros2_pose(entity.pose),
+            self._to_ros2_pose(entity.pose),
             self.connector.get_transform("odom", "world"),
         )
 
@@ -181,10 +181,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         ros2_pose = do_transform_pose(
             Pose(), self.connector.get_transform(object_frame + "odom", object_frame)
         )
-        ros2_pose = do_transform_pose(
-            ros2_pose, self.connector.get_transform("world", "odom")
-        )
-        return self.from_ros2_pose(ros2_pose)
+        return self._from_ros2_pose(ros2_pose)
 
     def get_scene_state(self) -> SceneState:
         """
@@ -303,7 +300,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         return response  # type: ignore
 
     # NOTE (mkotynia) probably to be refactored, other bridges may also want to use pose conversion to/from ROS2 format
-    def to_ros2_pose(self, pose: PoseModel) -> Pose:
+    def _to_ros2_pose(self, pose: PoseModel) -> Pose:
         """
         Converts pose in PoseModel format to pose in ROS2 Pose format.
         """
@@ -325,7 +322,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
 
         return ros2_pose
 
-    def from_ros2_pose(self, pose: Pose) -> PoseModel:
+    def _from_ros2_pose(self, pose: Pose) -> PoseModel:
         """
         Converts ROS2 pose to PoseModel format
         """

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -211,7 +211,6 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
             for service in available_services_names:
                 if "/_action" in service:
                     action_name = service.split("/_action")[0]
-                    print("action_name:   ", action_name)
                     available_actions_names.add(action_name)
 
             required_services = required_ros2_stack["services"]
@@ -239,16 +238,19 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
             ]
 
             if missing_services:
-                for service in missing_services:
-                    self.logger.warning(f"Waiting for service: {service}")
+                self.logger.warning(
+                    f"Waiting for missing services {missing_services} out of required services: {required_services}"
+                )
 
             if missing_topics:
-                for topic in missing_topics:
-                    self.logger.warning(f"Waiting for topic: {topic}")
+                self.logger.warning(
+                    f"Waiting for missing topics: {missing_topics} out of required topics: {required_topics}"
+                )
 
             if missing_actions:
-                for action in missing_actions:
-                    self.logger.warning(f"Waiting for action: {action}")
+                self.logger.warning(
+                    f"Waiting for missing actions: {missing_actions} out of required actions: {required_actions}"
+                )
 
             if not (missing_services or missing_topics or missing_actions):
                 self.logger.info("All required ROS2 stack components are available.")

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -335,7 +335,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
     # NOTE (mkotynia) probably to be refactored, other bridges may also want to use pose conversion to/from ROS2 format
     def _to_ros2_pose(self, pose: Pose) -> ROS2Pose:
         """
-        Converts pose in PoseModel format to pose in ROS2 Pose format.
+        Converts pose to pose in ROS2 Pose format.
         """
         position = Point(
             x=pose.translation.x, y=pose.translation.y, z=pose.translation.z
@@ -357,7 +357,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
 
     def _from_ros2_pose(self, pose: ROS2Pose) -> Pose:
         """
-        Converts ROS2 pose to PoseModel format
+        Converts ROS2Pose to Pose
         """
 
         translation = Translation(
@@ -387,7 +387,7 @@ class O3DEngineArmManipulationBridge(O3DExROS2Bridge):
         """Moves arm to a given position
 
         Args:
-            pose (PoseModel): where to move arm
+            pose (Pose): where to move arm
             initial_gripper_state (bool): False means closed grip, True means open grip
             final_gripper_state (bool): False means closed grip, True means open grip
             frame_id (str): reference frame

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -44,8 +44,8 @@ from rai_sim.simulation_bridge import (
 class O3DExROS2SimulationConfig(SimulationConfig):
     binary_path: Path
     robotic_stack_command: str
-    required_binary_ros2_stack: dict[str, List[str]]
-    required_robotic_ros2_stack: dict[str, List[str]]
+    required_simulation_ros2_interfaces: dict[str, List[str]]
+    required_robotic_ros2_interfaces: dict[str, List[str]]
 
     @classmethod
     def load_config(
@@ -285,7 +285,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         if not self._has_process_started(process=self.current_sim_process):
             raise RuntimeError("Process did not start in time.")
         if not self._is_ros2_stack_ready(
-            required_ros2_stack=simulation_config.required_binary_ros2_stack
+            required_ros2_stack=simulation_config.required_simulation_ros2_interfaces
         ):
             raise RuntimeError("ROS2 stack is not ready in time.")
 
@@ -298,7 +298,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         if not self._has_process_started(self.current_robotic_stack_process):
             raise RuntimeError("Process did not start in time.")
         if not self._is_ros2_stack_ready(
-            required_ros2_stack=simulation_config.required_robotic_ros2_stack
+            required_ros2_stack=simulation_config.required_robotic_ros2_interfaces
         ):
             raise RuntimeError("ROS2 stack is not ready in time.")
 

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -43,7 +43,7 @@ class Rotation(BaseModel):
     w: float = Field(description="W component of the quaternion")
 
 
-class PoseModel(BaseModel):
+class Pose(BaseModel):
     """
     Represents the complete pose (position and orientation) of an object.
     """
@@ -66,7 +66,7 @@ class Entity(BaseModel):
     prefab_name: str = Field(
         description="Name of the prefab resource to use for spawning this entity"
     )
-    pose: PoseModel = Field(description="Initial pose of the entity")
+    pose: Pose = Field(description="Initial pose of the entity")
 
 
 class SpawnedEntity(Entity):
@@ -233,7 +233,7 @@ class SimulationBridge(ABC, Generic[SimulationConfigT]):
         pass
 
     @abstractmethod
-    def get_object_pose(self, entity: SpawnedEntity) -> PoseModel:
+    def get_object_pose(self, entity: SpawnedEntity) -> Pose:
         """
         Gets the current pose of a spawned entity.
 

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -52,7 +52,8 @@ class PoseModel(BaseModel):
         description="The position of the object in 3D space"
     )
     rotation: Optional[Rotation] = Field(
-        description="The orientation of the object as a quaternion. Optional if orientation is not needed and default orientation is handled by the bridge"
+        default=None,
+        description="The orientation of the object as a quaternion. Optional if orientation is not needed and default orientation is handled by the bridge",
     )
 
 

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -246,7 +246,7 @@ class SimulationBridge(ABC, Generic[SimulationConfigT]):
 
         Returns
         -------
-        PoseModel
+        Pose
             Object containing the entity's current pose.
         """
         pass

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -18,48 +18,102 @@ from pathlib import Path
 from typing import Generic, List, Optional, TypeVar
 
 import yaml
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class Translation(BaseModel):
-    x: float
-    y: float
-    z: float
+    """
+    Represents the position of an object in 3D space using
+    x, y, and z coordinates.
+    """
+
+    x: float = Field(description="X coordinate in meters")
+    y: float = Field(description="Y coordinate in meters")
+    z: float = Field(description="Z coordinate in meters")
 
 
 class Rotation(BaseModel):
-    x: float
-    y: float
-    z: float
-    w: float
+    """
+    Represents a 3D rotation using quaternion representation.
+    """
+
+    x: float = Field(description="X component of the quaternion")
+    y: float = Field(description="Y component of the quaternion")
+    z: float = Field(description="Z component of the quaternion")
+    w: float = Field(description="W component of the quaternion")
 
 
 class PoseModel(BaseModel):
-    translation: Translation
-    rotation: Optional[Rotation] = None
+    """
+    Represents the complete pose (position and orientation) of an object.
+    """
+
+    translation: Translation = Field(
+        description="The position of the object in 3D space"
+    )
+    rotation: Optional[Rotation] = Field(
+        description="The orientation of the object as a quaternion. Optional if orientation is not needed and default orientation is handled by the bridge"
+    )
 
 
 class Entity(BaseModel):
-    name: str
-    prefab_name: str
-    pose: PoseModel
+    """
+    Entity that can be spawned in the simulation environment.
+    """
+
+    name: str = Field(description="Unique name for the entity")
+    prefab_name: str = Field(
+        description="Name of the prefab resource to use for spawning this entity"
+    )
+    pose: PoseModel = Field(description="Initial pose of the entity")
 
 
 class SpawnedEntity(Entity):
-    id: str
+    """
+    Entity that has been spawned in the simulation environment.
+    """
+
+    id: str = Field(
+        description="Unique identifier assigned to the spawned entity instance"
+    )
 
 
 class SimulationConfig(BaseModel):
     """
-    Setup of simulation - arrangemenet of objects in the environment.
+    Setup of simulation - arrangement of objects in the environment.
+
+    Attributes
+    ----------
+    entities : List[Entity]
+        List of entities to be spawned in the simulation.
     """
 
     # NOTE (mkotynia) can be extended by other attributes
-    entities: List[Entity]
+    entities: List[Entity] = Field(
+        description="List of entities to be spawned in the simulation environment"
+    )
 
     @field_validator("entities")
     @classmethod
     def check_unique_names(cls, entities: List[Entity]) -> List[Entity]:
+        """
+        Validates that all entity names in the configuration are unique.
+
+        Parameters
+        ----------
+        entities : List[Entity]
+            List of entities to validate.
+
+        Returns
+        -------
+        List[Entity]
+            The validated list of entities.
+
+        Raises
+        ------
+        ValueError
+            If any entity names are duplicated.
+        """
         names = [entity.name for entity in entities]
         if len(names) != len(set(names)):
             raise ValueError("Each entity must have a unique name.")
@@ -67,6 +121,19 @@ class SimulationConfig(BaseModel):
 
     @classmethod
     def load_base_config(cls, base_config_path: Path) -> "SimulationConfig":
+        """
+        Loads a simulation configuration from a YAML file.
+
+        Parameters
+        ----------
+        base_config_path : Path
+            Path to the YAML configuration file.
+
+        Returns
+        -------
+        SimulationConfig
+            The loaded simulation configuration.
+        """
         with open(base_config_path) as f:
             content = yaml.safe_load(f)
         return cls(**content)
@@ -74,11 +141,18 @@ class SimulationConfig(BaseModel):
 
 class SceneState(BaseModel):
     """
-    Info about current entities' state in the scene.
+    Info about current state of the scene.
+
+    Attributes
+    ----------
+    entities : List[SpawnedEntity]
+        List of all entities currently present in the scene.
     """
 
     # NOTE (mkotynia) can be extended by other attributes
-    entities: List[SpawnedEntity]
+    entities: List[SpawnedEntity] = Field(
+        description="List of all entities currently spawned in the scene with their current poses"
+    )
 
 
 SimulationConfigT = TypeVar("SimulationConfigT", bound=SimulationConfig)
@@ -100,20 +174,100 @@ class SimulationBridge(ABC, Generic[SimulationConfigT]):
 
     @abstractmethod
     def setup_scene(self, simulation_config: SimulationConfigT):
+        """
+        Runs and sets up the simulation scene according to the provided configuration.
+
+        Parameters
+        ----------
+        simulation_config : SimulationConfigT
+            Configuration containing the simulation initialization and setup details including
+            entities to be spawned and their initial poses.
+
+        Returns
+        -------
+        None
+        """
         pass
 
     @abstractmethod
     def _spawn_entity(self, entity: Entity):
+        """
+        Spawns a single entity in the simulation environment.
+
+        Parameters
+        ----------
+        entity : Entity
+            Entity object containing the entity's properties
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        The spawned entity should be added to the spawned_entities list maintained
+        by the simulation bridge.
+        """
         pass
 
     @abstractmethod
     def _despawn_entity(self, entity: SpawnedEntity):
+        """
+        Removes a previously spawned entity from the simulation environment.
+
+        Parameters
+        ----------
+        entity : SpawnedEntity
+            Entity object representing the spawned entity to be removed.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Despawned entity should be removed from the spawned_entities list maintained
+        by the simulation bridge.
+        """
         pass
 
     @abstractmethod
     def get_object_pose(self, entity: SpawnedEntity) -> PoseModel:
+        """
+        Gets the current pose of a spawned entity.
+
+        This method queries the simulation to get the current position and
+        orientation of a specific entity.
+
+        Parameters
+        ----------
+        entity : SpawnedEntity
+            Entity object representing the spawned entity whose pose is
+            to be retrieved.
+
+        Returns
+        -------
+        PoseModel
+            Object containing the entity's current pose.
+        """
         pass
 
     @abstractmethod
     def get_scene_state(self) -> SceneState:
+        """
+        Gets the current state of the simulation scene.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        SceneState
+            Object containing the current state of the scene.
+
+        Notes
+        -----
+        SceneState should contain the current poses of spawned_entities.
+        """
         pass

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -89,7 +89,6 @@ class SimulationConfig(BaseModel):
         List of entities to be spawned in the simulation.
     """
 
-    # NOTE (mkotynia) can be extended by other attributes
     entities: List[Entity] = Field(
         description="List of entities to be spawned in the simulation environment"
     )
@@ -150,7 +149,6 @@ class SceneState(BaseModel):
         List of all entities currently present in the scene.
     """
 
-    # NOTE (mkotynia) can be extended by other attributes
     entities: List[SpawnedEntity] = Field(
         description="List of all entities currently spawned in the scene with their current poses"
     )

--- a/tests/rai_sim/conftest.py
+++ b/tests/rai_sim/conftest.py
@@ -52,6 +52,9 @@ def sample_o3dexros2_config(tmp_path: Path) -> Path:
     yaml_content = """
     binary_path: /path/to/binary
     robotic_stack_command: "ros2 launch robotic_stack.launch.py"
+    required_services: []
+    required_topics: []
+    required_actions: []
     """
     file_path = tmp_path / "test_o3dexros2_config.yaml"
     file_path.write_text(yaml_content)

--- a/tests/rai_sim/conftest.py
+++ b/tests/rai_sim/conftest.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def sample_base_yaml_config(tmp_path: Path) -> Path:
+    yaml_content = """
+    entities:
+      - name: entity1
+        prefab_name: cube
+        pose:
+          translation:
+            x: 1.0
+            y: 2.0
+            z: 3.0
+
+      - name: entity2
+        prefab_name: carrot
+        pose:
+          translation:
+            x: 1.0
+            y: 2.0
+            z: 3.0
+          rotation:
+            x: 0.1
+            y: 0.2
+            z: 0.3
+            w: 0.4
+    """
+    file_path = tmp_path / "test_config.yaml"
+    file_path.write_text(yaml_content)
+    return file_path
+
+
+@pytest.fixture
+def sample_o3dexros2_config(tmp_path: Path) -> Path:
+    yaml_content = """
+    binary_path: /path/to/binary
+    robotic_stack_command: "ros2 launch robotic_stack.launch.py"
+    """
+    file_path = tmp_path / "test_o3dexros2_config.yaml"
+    file_path.write_text(yaml_content)
+    return file_path

--- a/tests/rai_sim/conftest.py
+++ b/tests/rai_sim/conftest.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 
 import pytest

--- a/tests/rai_sim/conftest.py
+++ b/tests/rai_sim/conftest.py
@@ -52,9 +52,23 @@ def sample_o3dexros2_config(tmp_path: Path) -> Path:
     yaml_content = """
     binary_path: /path/to/binary
     robotic_stack_command: "ros2 launch robotic_stack.launch.py"
-    required_services: []
-    required_topics: []
-    required_actions: []
+    required_binary_ros2_stack:
+      services:
+        - /spawn_entity
+        - /delete_entity
+      topics:
+        - /color_image5
+        - /depth_image5
+        - /color_camera_info5
+      actions: []
+    required_robotic_ros2_stack:
+      services:
+        - /grounding_dino_classify
+        - /grounded_sam_segment
+        - /manipulator_move_to
+      topics: []
+      actions:
+        - /execute_trajectory
     """
     file_path = tmp_path / "test_o3dexros2_config.yaml"
     file_path.write_text(yaml_content)

--- a/tests/rai_sim/conftest.py
+++ b/tests/rai_sim/conftest.py
@@ -52,7 +52,7 @@ def sample_o3dexros2_config(tmp_path: Path) -> Path:
     yaml_content = """
     binary_path: /path/to/binary
     robotic_stack_command: "ros2 launch robotic_stack.launch.py"
-    required_binary_ros2_stack:
+    required_simulation_ros2_interfaces:
       services:
         - /spawn_entity
         - /delete_entity
@@ -61,7 +61,7 @@ def sample_o3dexros2_config(tmp_path: Path) -> Path:
         - /depth_image5
         - /color_camera_info5
       actions: []
-    required_robotic_ros2_stack:
+    required_robotic_ros2_interfaces:
       services:
         - /grounding_dino_classify
         - /grounded_sam_segment

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -226,8 +226,8 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
             "get_topics_names_and_types method is missing",
         )
         self.assertTrue(
-            hasattr(connector, "get_service_names_and_types"),
-            "get_service_names_and_types method is missing",
+            hasattr(connector, "node"),
+            "node property is missing",
         )
 
     def test_get_transform_signature(self):

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -1,10 +1,16 @@
+import inspect
 import signal
+import typing
 import unittest
 from pathlib import Path
+from typing import Optional, get_args, get_origin
 from unittest.mock import MagicMock, patch
 
-from geometry_msgs.msg import Point, Pose, Quaternion
-from rai.communication.ros2.connectors import ROS2ARIConnector
+import rclpy
+import rclpy.qos
+from geometry_msgs.msg import Point, Pose, Quaternion, TransformStamped
+from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
+from rclpy.qos import QoSProfile
 
 from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
 from rai_sim.simulation_bridge import (
@@ -168,3 +174,134 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         self.assertEqual(pose.rotation.y, 0.2)
         self.assertEqual(pose.rotation.z, 0.3)
         self.assertEqual(pose.rotation.w, 0.4)
+
+
+class TestROS2ARIConnectorInterface(unittest.TestCase):
+    """Tests to ensure the ROS2ARIConnector interface meets the expectations of O3DExROS2Bridge."""
+
+    def setUp(self):
+        rclpy.init()
+        self.connector = ROS2ARIConnector()
+
+    def tearDown(self):
+        rclpy.shutdown()
+
+    def test_connector_required_methods_exist(self):
+        """Test that all required methods exist on the ROS2ARIConnector."""
+        connector = ROS2ARIConnector()
+
+        # Check that all required methods exist
+        self.assertTrue(
+            hasattr(connector, "service_call"), "service_call method is missing"
+        )
+        self.assertTrue(
+            hasattr(connector, "get_transform"), "get_transform method is missing"
+        )
+        self.assertTrue(
+            hasattr(connector, "send_message"), "send_message method is missing"
+        )
+        self.assertTrue(
+            hasattr(connector, "receive_message"), "receive_message method is missing"
+        )
+        self.assertTrue(hasattr(connector, "shutdown"), "shutdown method is missing")
+
+    def test_get_transform_signature(self):
+        signature = inspect.signature(self.connector.get_transform)
+        parameters = signature.parameters
+
+        expected_params: dict[str, type] = {
+            "target_frame": str,
+            "source_frame": str,
+            "timeout_sec": float,
+        }
+
+        assert list(parameters.keys()) == list(expected_params.keys()), (
+            f"Parameter names do not match, expected: {list(expected_params.keys())}, got: {list(parameters.keys())}"
+        )
+
+        for param_name, expected_type in expected_params.items():
+            param = parameters[param_name]
+            assert param.annotation is expected_type, (
+                f"Parameter '{param_name}' has incorrect type annotation, expected: {expected_type}, got: {param.annotation}"
+            )
+
+        # Check return type explicitly
+        assert signature.return_annotation is TransformStamped, (
+            f"Return type is incorrect, expected: TransformStamped, got: {signature.return_annotation}"
+        )
+
+    def test_send_message_signature(self):
+        def resolve_annotation(annotation: type):
+            """Helper function to unwrap Optional types. Workaround for problem with asserting Optional[QoSProfile] type."""
+            if get_origin(annotation) is typing.Optional:
+                return get_args(annotation)[0]
+            return annotation
+
+        signature = inspect.signature(self.connector.send_message)
+        parameters = signature.parameters
+
+        expected_params: dict[str, type] = {
+            "message": ROS2ARIMessage,
+            "target": str,
+            "msg_type": str,
+            "auto_qos_matching": bool,
+            "qos_profile": Optional[QoSProfile],
+        }
+
+        self.assertListEqual(
+            list(parameters.keys())[: len(expected_params)],
+            list(expected_params.keys()),
+            f"Parameter names do not match, expected: {list(expected_params.keys())}, got: {list(parameters.keys())}",
+        )
+
+        for param_name, expected_type in expected_params.items():
+            param = parameters[param_name]
+            self.assertEqual(
+                resolve_annotation(param.annotation),
+                resolve_annotation(expected_type),
+                f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
+            )
+
+        self.assertIs(
+            signature.return_annotation,
+            inspect.Signature.empty,
+            "send_message should have no return value",
+        )
+
+    def test_receive_message_signature(self):
+        signature = inspect.signature(self.connector.receive_message)
+        parameters = signature.parameters
+
+        expected_params: dict[str, type] = {
+            "source": str,
+            "timeout_sec": float,
+            "msg_type": Optional[str],
+            "auto_topic_type": bool,
+        }
+
+        self.assertListEqual(
+            list(parameters.keys())[: len(expected_params)],
+            list(expected_params.keys()),
+            f"Parameter names do not match, expected: {list(expected_params.keys())}, got: {list(parameters.keys())}",
+        )
+
+        for param_name, expected_type in expected_params.items():
+            param = parameters[param_name]
+            if isinstance(expected_type, tuple):
+                self.assertIn(
+                    param.annotation,
+                    expected_type,
+                    f"Parameter '{param_name}' has incorrect type, expected one of {expected_type}, got: {param.annotation}",
+                )
+            else:
+                self.assertIs(
+                    param.annotation,
+                    expected_type,
+                    f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
+                )
+
+        self.assertIs(
+            signature.return_annotation,
+            ROS2ARIMessage,
+            f"Return type is incorrect, expected: ROS2ARIMessage, got: {signature.return_annotation}",
+        )

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -221,6 +221,14 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
             hasattr(connector, "receive_message"), "receive_message method is missing"
         )
         self.assertTrue(hasattr(connector, "shutdown"), "shutdown method is missing")
+        self.assertTrue(
+            hasattr(connector, "get_topics_names_and_types"),
+            "get_topics_names_and_types method is missing",
+        )
+        self.assertTrue(
+            hasattr(connector, "get_service_names_and_types"),
+            "get_service_names_and_types method is missing",
+        )
 
     def test_get_transform_signature(self):
         signature = inspect.signature(self.connector.get_transform)

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import inspect
 import signal
 import typing

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -313,18 +313,11 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
 
         for param_name, expected_type in expected_params.items():
             param = parameters[param_name]
-            if isinstance(expected_type, tuple):
-                self.assertIn(
-                    param.annotation,
-                    expected_type,
-                    f"Parameter '{param_name}' has incorrect type, expected one of {expected_type}, got: {param.annotation}",
-                )
-            else:
-                self.assertIs(
-                    param.annotation,
-                    expected_type,
-                    f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
-                )
+            self.assertIs(
+                param.annotation,
+                expected_type,
+                f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
+            )
 
         self.assertIs(
             signature.return_annotation,

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -192,7 +192,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         orientation = Quaternion(x=0.1, y=0.2, z=0.3, w=0.4)
         ros2_pose = ROS2Pose(position=position, orientation=orientation)
 
-        # Convert to PoseModel
+        # Convert from ROS2Pose to Pose
         pose = self.bridge._from_ros2_pose(ros2_pose)
 
         # Check the conversion

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -81,6 +81,9 @@ class TestO3DExROS2Bridge(unittest.TestCase):
             binary_path=Path("/path/to/binary"),
             robotic_stack_command="ros2 launch robot.launch.py",
             entities=[self.test_entity],
+            required_actions=[],
+            required_services=[],
+            required_topics=[],
         )
 
     def test_init(self):

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -1,8 +1,17 @@
+import signal
+import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from rai_sim.o3de.o3de_bridge import O3DExROS2SimulationConfig
+from rai.communication.ros2.connectors import ROS2ARIConnector
+
+from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
 from rai_sim.simulation_bridge import (
     Entity,
+    PoseModel,
+    Rotation,
+    SpawnedEntity,
+    Translation,
 )
 
 
@@ -17,3 +26,96 @@ def test_load_config(sample_base_yaml_config: Path, sample_o3dexros2_config: Pat
     assert all(isinstance(e, Entity) for e in config.entities)
 
     assert len(config.entities) == 2
+
+
+class TestO3DExROS2Bridge(unittest.TestCase):
+    def setUp(self):
+        self.mock_connector = MagicMock(spec=ROS2ARIConnector)
+        self.mock_logger = MagicMock()
+        self.bridge = O3DExROS2Bridge(
+            connector=self.mock_connector, logger=self.mock_logger
+        )
+
+        # Create test data
+        self.test_entity = Entity(
+            name="test_entity1",
+            prefab_name="cube",
+            pose=PoseModel(
+                translation=Translation(x=1.0, y=2.0, z=3.0),
+                rotation=Rotation(x=0.0, y=0.0, z=0.0, w=1.0),
+            ),
+        )
+
+        self.test_spawned_entity = SpawnedEntity(
+            id="entity_id_123",
+            name="test_entity1",
+            prefab_name="cube",
+            pose=PoseModel(
+                translation=Translation(x=1.0, y=2.0, z=3.0),
+                rotation=Rotation(x=0.0, y=0.0, z=0.0, w=1.0),
+            ),
+        )
+
+        self.test_config = O3DExROS2SimulationConfig(
+            binary_path=Path("/path/to/binary"),
+            robotic_stack_command="ros2 launch robot.launch.py",
+            entities=[self.test_entity],
+        )
+
+    def test_init(self):
+        self.assertEqual(self.bridge.connector, self.mock_connector)
+        self.assertEqual(self.bridge.logger, self.mock_logger)
+        self.assertIsNone(self.bridge.current_sim_process)
+        self.assertIsNone(self.bridge.current_robotic_stack_process)
+        self.assertIsNone(self.bridge.current_binary_path)
+        self.assertEqual(self.bridge.spawned_entities, [])
+
+    @patch("subprocess.Popen")
+    def test_launch_robotic_stack(self, mock_popen):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 54321
+        mock_popen.return_value = mock_process
+
+        command = "ros2 launch robot.launch.py"
+        self.bridge._launch_robotic_stack(command)
+
+        mock_popen.assert_called_once_with(["ros2", "launch", "robot.launch.py"])
+        self.assertEqual(self.bridge.current_robotic_stack_process, mock_process)
+
+    @patch("subprocess.Popen")
+    def test_launch_binary(self, mock_popen):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 54322
+        mock_popen.return_value = mock_process
+
+        command = Path("/path/to/binary")
+        self.bridge._launch_binary(command)
+
+        mock_popen.assert_called_once_with(["/path/to/binary"])
+        self.assertEqual(self.bridge.current_sim_process, mock_process)
+
+    def test_shutdown_binary(self):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 0
+
+        self.bridge.current_sim_process = mock_process
+
+        self.bridge._shutdown_binary()
+
+        mock_process.send_signal.assert_called_once_with(signal.SIGINT)
+        mock_process.wait.assert_called_once()
+
+        self.assertIsNone(self.bridge.current_sim_process)
+
+    def test_shutdown_robotic_stack(self):
+        self.bridge.current_robotic_stack_process = MagicMock()
+        self.bridge.current_robotic_stack_process.poll.return_value = 0
+
+        self.bridge._shutdown_robotic_stack()
+
+        self.bridge.current_robotic_stack_process.send_signal.assert_called_once_with(
+            signal.SIGINT
+        )
+        self.bridge.current_robotic_stack_process.wait.assert_called_once()

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -45,12 +45,12 @@ def test_load_config(sample_base_yaml_config: Path, sample_o3dexros2_config: Pat
     assert isinstance(config, O3DExROS2SimulationConfig)
     assert config.binary_path == Path("/path/to/binary")
     assert config.robotic_stack_command == "ros2 launch robotic_stack.launch.py"
-    assert config.required_binary_ros2_stack == {
+    assert config.required_simulation_ros2_interfaces == {
         "services": ["/spawn_entity", "/delete_entity"],
         "topics": ["/color_image5", "/depth_image5", "/color_camera_info5"],
         "actions": [],
     }
-    assert config.required_robotic_ros2_stack == {
+    assert config.required_robotic_ros2_interfaces == {
         "services": [
             "/grounding_dino_classify",
             "/grounded_sam_segment",
@@ -97,8 +97,16 @@ class TestO3DExROS2Bridge(unittest.TestCase):
             binary_path=Path("/path/to/binary"),
             robotic_stack_command="ros2 launch robot.launch.py",
             entities=[self.test_entity],
-            required_binary_ros2_stack={"services": [], "topics": [], "actions": []},
-            required_robotic_ros2_stack={"services": [], "topics": [], "actions": []},
+            required_simulation_ros2_interfaces={
+                "services": [],
+                "topics": [],
+                "actions": [],
+            },
+            required_robotic_ros2_interfaces={
+                "services": [],
+                "topics": [],
+                "actions": [],
+            },
         )
 
     def test_init(self):

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from rai_sim.o3de.o3de_bridge import O3DExROS2SimulationConfig
+from rai_sim.simulation_bridge import (
+    Entity,
+)
+
+
+def test_load_config(sample_base_yaml_config: Path, sample_o3dexros2_config: Path):
+    config = O3DExROS2SimulationConfig.load_config(
+        sample_base_yaml_config, sample_o3dexros2_config
+    )
+    assert isinstance(config, O3DExROS2SimulationConfig)
+    assert config.binary_path == Path("/path/to/binary")
+    assert config.robotic_stack_command == "ros2 launch robotic_stack.launch.py"
+    assert isinstance(config.entities, list)
+    assert all(isinstance(e, Entity) for e in config.entities)
+
+    assert len(config.entities) == 2

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -242,6 +242,12 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
             "node property is missing",
         )
 
+    def resolve_annotation(self, annotation: type) -> type:
+        """Helper function to unwrap Optional types. Workaround for problem with asserting Optional types."""
+        if get_origin(annotation) is typing.Optional:
+            return get_args(annotation)[0]
+        return annotation
+
     def test_get_transform_signature(self):
         signature = inspect.signature(self.connector.get_transform)
         parameters = signature.parameters
@@ -258,8 +264,10 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
 
         for param_name, expected_type in expected_params.items():
             param = parameters[param_name]
-            assert param.annotation is expected_type, (
-                f"Parameter '{param_name}' has incorrect type annotation, expected: {expected_type}, got: {param.annotation}"
+            self.assertEqual(
+                self.resolve_annotation(param.annotation),
+                self.resolve_annotation(expected_type),
+                f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
             )
 
         # Check return type explicitly
@@ -268,12 +276,6 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
         )
 
     def test_send_message_signature(self):
-        def resolve_annotation(annotation: type):
-            """Helper function to unwrap Optional types. Workaround for problem with asserting Optional[QoSProfile] type."""
-            if get_origin(annotation) is typing.Optional:
-                return get_args(annotation)[0]
-            return annotation
-
         signature = inspect.signature(self.connector.send_message)
         parameters = signature.parameters
 
@@ -294,8 +296,8 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
         for param_name, expected_type in expected_params.items():
             param = parameters[param_name]
             self.assertEqual(
-                resolve_annotation(param.annotation),
-                resolve_annotation(expected_type),
+                self.resolve_annotation(param.annotation),
+                self.resolve_annotation(expected_type),
                 f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
             )
 
@@ -324,9 +326,9 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
 
         for param_name, expected_type in expected_params.items():
             param = parameters[param_name]
-            self.assertIs(
-                param.annotation,
-                expected_type,
+            self.assertEqual(
+                self.resolve_annotation(param.annotation),
+                self.resolve_annotation(expected_type),
                 f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
             )
 
@@ -348,8 +350,10 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
 
         for param_name, expected_type in expected_params.items():
             param = parameters[param_name]
-            assert param.annotation is expected_type, (
-                f"Parameter '{param_name}' has incorrect type annotation, expected: {expected_type}, got: {param.annotation}"
+            self.assertEqual(
+                self.resolve_annotation(param.annotation),
+                self.resolve_annotation(expected_type),
+                f"Parameter '{param_name}' has incorrect type, expected: {expected_type}, got: {param.annotation}",
             )
 
         self.assertEqual(

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -17,13 +17,14 @@ import signal
 import typing
 import unittest
 from pathlib import Path
-from typing import Optional, get_args, get_origin
+from typing import List, Optional, Tuple, get_args, get_origin
 from unittest.mock import MagicMock, patch
 
 import rclpy
 import rclpy.qos
 from geometry_msgs.msg import Point, Pose, Quaternion, TransformStamped
 from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
+from rclpy.node import Node
 from rclpy.qos import QoSProfile
 
 from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
@@ -330,3 +331,33 @@ class TestROS2ARIConnectorInterface(unittest.TestCase):
             ROS2ARIMessage,
             f"Return type is incorrect, expected: ROS2ARIMessage, got: {signature.return_annotation}",
         )
+
+    def test_get_topics_names_and_types_signature(self):
+        signature = inspect.signature(self.connector.get_topics_names_and_types)
+        parameters = signature.parameters
+
+        expected_params: dict[str, type] = {}
+
+        assert list(parameters.keys()) == list(expected_params.keys()), (
+            f"Parameter names do not match, expected: {list(expected_params.keys())}, got: {list(parameters.keys())}"
+        )
+
+        for param_name, expected_type in expected_params.items():
+            param = parameters[param_name]
+            assert param.annotation is expected_type, (
+                f"Parameter '{param_name}' has incorrect type annotation, expected: {expected_type}, got: {param.annotation}"
+            )
+
+        self.assertEqual(
+            signature.return_annotation,
+            List[Tuple[str, List[str]]],
+            f"Return type is incorrect, expected: List[Tuple[str, List[str]]], got: {signature.return_annotation}",
+        )
+
+    def test_node_property(self):
+        """Test that the node property returns the expected Node instance."""
+        mock_node = MagicMock(spec=Node)
+        self.connector._node = mock_node
+
+        self.assertEqual(self.connector.node, mock_node)
+        self.assertIsInstance(self.connector.node, Node)

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -22,7 +22,8 @@ from unittest.mock import MagicMock, patch
 
 import rclpy
 import rclpy.qos
-from geometry_msgs.msg import Point, Pose, Quaternion, TransformStamped
+from geometry_msgs.msg import Point, Quaternion, TransformStamped
+from geometry_msgs.msg import Pose as ROS2Pose
 from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
@@ -30,7 +31,7 @@ from rclpy.qos import QoSProfile
 from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
 from rai_sim.simulation_bridge import (
     Entity,
-    PoseModel,
+    Pose,
     Rotation,
     SpawnedEntity,
     Translation,
@@ -62,7 +63,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         self.test_entity = Entity(
             name="test_entity1",
             prefab_name="cube",
-            pose=PoseModel(
+            pose=Pose(
                 translation=Translation(x=1.0, y=2.0, z=3.0),
                 rotation=Rotation(x=0.0, y=0.0, z=0.0, w=1.0),
             ),
@@ -72,7 +73,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
             id="entity_id_123",
             name="test_entity1",
             prefab_name="cube",
-            pose=PoseModel(
+            pose=Pose(
                 translation=Translation(x=1.0, y=2.0, z=3.0),
                 rotation=Rotation(x=0.0, y=0.0, z=0.0, w=1.0),
             ),
@@ -158,7 +159,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
 
     def test_to_ros2_pose(self):
         # Create a pose
-        pose = PoseModel(
+        pose = Pose(
             translation=Translation(x=1.0, y=2.0, z=3.0),
             rotation=Rotation(x=0.1, y=0.2, z=0.3, w=0.4),
         )
@@ -179,7 +180,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         # Create a ROS2 pose
         position = Point(x=1.0, y=2.0, z=3.0)
         orientation = Quaternion(x=0.1, y=0.2, z=0.3, w=0.4)
-        ros2_pose = Pose(position=position, orientation=orientation)
+        ros2_pose = ROS2Pose(position=position, orientation=orientation)
 
         # Convert to PoseModel
         pose = self.bridge._from_ros2_pose(ros2_pose)

--- a/tests/rai_sim/test_simulation_bridge.py
+++ b/tests/rai_sim/test_simulation_bridge.py
@@ -1,3 +1,17 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import unittest
 from pathlib import Path

--- a/tests/rai_sim/test_simulation_bridge.py
+++ b/tests/rai_sim/test_simulation_bridge.py
@@ -149,38 +149,8 @@ def test_simulation_config_duplicate_names():
         SimulationConfig(entities=entities)
 
 
-@pytest.fixture
-def sample_yaml_config(tmp_path: Path) -> Path:
-    yaml_content = """
-    entities:
-      - name: entity1
-        prefab_name: cube
-        pose:
-          translation:
-            x: 1.0
-            y: 2.0
-            z: 3.0
-
-      - name: entity2
-        prefab_name: carrot
-        pose:
-          translation:
-            x: 1.0
-            y: 2.0
-            z: 3.0
-          rotation:
-            x: 0.1
-            y: 0.2
-            z: 0.3
-            w: 0.4
-    """
-    file_path = tmp_path / "test_config.yaml"
-    file_path.write_text(yaml_content)
-    return file_path
-
-
-def test_load_base_config(sample_yaml_config: Path):
-    config = SimulationConfig.load_base_config(sample_yaml_config)
+def test_load_base_config(sample_base_yaml_config: Path):
+    config = SimulationConfig.load_base_config(sample_base_yaml_config)
 
     assert isinstance(config.entities, list)
     assert all(isinstance(e, Entity) for e in config.entities)

--- a/tests/rai_sim/test_simulation_bridge.py
+++ b/tests/rai_sim/test_simulation_bridge.py
@@ -1,0 +1,185 @@
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from pydantic import ValidationError
+
+from rai_sim.simulation_bridge import (
+    Entity,
+    PoseModel,
+    Rotation,
+    SimulationConfig,
+    SpawnedEntity,
+    Translation,
+)
+
+
+# Helper Functions
+def create_translation(x: float, y: float, z: float) -> Translation:
+    return Translation(x=x, y=y, z=z)
+
+
+def create_rotation(x: float, y: float, z: float, w: float) -> Rotation:
+    return Rotation(x=x, y=y, z=z, w=w)
+
+
+def create_pose(
+    translation: Translation, rotation: Optional[Rotation] = None
+) -> PoseModel:
+    return PoseModel(translation=translation, rotation=rotation)
+
+
+# Test Cases
+def test_translation():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+
+    assert isinstance(translation.x, float)
+    assert isinstance(translation.y, float)
+    assert isinstance(translation.z, float)
+
+    assert translation.x == 1.1
+    assert translation.y == 2.2
+    assert translation.z == 3.3
+
+
+def test_rotation():
+    rotation = Rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+
+    assert isinstance(rotation.x, float)
+    assert isinstance(rotation.y, float)
+    assert isinstance(rotation.z, float)
+    assert isinstance(rotation.w, float)
+
+    assert rotation.x == 0.1
+    assert rotation.y == 0.2
+    assert rotation.z == 0.3
+    assert rotation.w == 0.4
+
+
+def test_pose():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    rotation = Rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+
+    pose = PoseModel(translation=translation, rotation=rotation)
+
+    assert isinstance(pose.translation, Translation)
+    assert isinstance(pose.rotation, Rotation)
+
+    assert pose.translation.x == 1.1
+    assert pose.rotation.w == 0.4
+
+
+def test_optional_rotation():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    pose = create_pose(translation=translation)
+
+    assert isinstance(pose.translation, Translation)
+    assert pose.rotation is None
+
+
+def test_entity():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    rotation = create_rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+    pose = create_pose(translation=translation, rotation=rotation)
+
+    entity = Entity(name="test_cube", prefab_name="cube", pose=pose)
+
+    assert isinstance(entity.name, str)
+    assert isinstance(entity.prefab_name, str)
+    assert isinstance(entity.pose, PoseModel)
+
+    assert entity.name == "test_cube"
+    assert entity.prefab_name == "cube"
+    assert entity.pose == pose
+
+
+def test_spawned_entity():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    rotation = create_rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+    pose = create_pose(translation=translation, rotation=rotation)
+
+    spawned_entity = SpawnedEntity(
+        name="test_cube",
+        prefab_name="cube",
+        pose=pose,
+        id="id_123",
+    )
+
+    assert isinstance(spawned_entity.name, str)
+    assert isinstance(spawned_entity.prefab_name, str)
+    assert isinstance(spawned_entity.pose, PoseModel)
+    assert isinstance(spawned_entity.id, str)
+
+    assert spawned_entity.id == "id_123"
+
+
+def test_simulation_config_unique_names():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    rotation = create_rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+    pose = create_pose(translation=translation, rotation=rotation)
+
+    entities = [
+        Entity(name="entity1", prefab_name="cube", pose=pose),
+        Entity(name="entity2", prefab_name="carrot", pose=pose),
+    ]
+
+    config = SimulationConfig(entities=entities)
+
+    assert isinstance(config.entities, list)
+    assert all(isinstance(e, Entity) for e in config.entities)
+
+    assert len(config.entities) == 2
+
+
+def test_simulation_config_duplicate_names():
+    translation = create_translation(x=1.1, y=2.2, z=3.3)
+    rotation = create_rotation(x=0.1, y=0.2, z=0.3, w=0.4)
+    pose = create_pose(translation=translation, rotation=rotation)
+
+    entities = [
+        Entity(name="duplicate", prefab_name="cube", pose=pose),
+        Entity(name="duplicate", prefab_name="carrot", pose=pose),
+    ]
+
+    with pytest.raises(ValidationError):
+        SimulationConfig(entities=entities)
+
+
+# Test Reading from YAML File
+@pytest.fixture
+def sample_yaml_config(tmp_path: Path) -> Path:
+    yaml_content = """
+    entities:
+      - name: entity1
+        prefab_name: cube
+        pose:
+          translation:
+            x: 1.0
+            y: 2.0
+            z: 3.0
+
+      - name: entity2
+        prefab_name: carrot
+        pose:
+          translation:
+            x: 1.0
+            y: 2.0
+            z: 3.0
+          rotation:
+            x: 0.1
+            y: 0.2
+            z: 0.3
+            w: 0.4
+    """
+    file_path = tmp_path / "test_config.yaml"
+    file_path.write_text(yaml_content)
+    return file_path
+
+
+def test_load_base_config(sample_yaml_config: Path):
+    config = SimulationConfig.load_base_config(sample_yaml_config)
+
+    assert isinstance(config.entities, list)
+    assert all(isinstance(e, Entity) for e in config.entities)
+
+    assert len(config.entities) == 2

--- a/tests/rai_sim/test_simulation_bridge.py
+++ b/tests/rai_sim/test_simulation_bridge.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 
 from rai_sim.simulation_bridge import (
     Entity,
-    PoseModel,
+    Pose,
     Rotation,
     SceneState,
     SimulationBridge,
@@ -41,10 +41,8 @@ def create_rotation(x: float, y: float, z: float, w: float) -> Rotation:
     return Rotation(x=x, y=y, z=z, w=w)
 
 
-def create_pose(
-    translation: Translation, rotation: Optional[Rotation] = None
-) -> PoseModel:
-    return PoseModel(translation=translation, rotation=rotation)
+def create_pose(translation: Translation, rotation: Optional[Rotation] = None) -> Pose:
+    return Pose(translation=translation, rotation=rotation)
 
 
 # Test Cases
@@ -78,7 +76,7 @@ def test_pose():
     translation = create_translation(x=1.1, y=2.2, z=3.3)
     rotation = Rotation(x=0.1, y=0.2, z=0.3, w=0.4)
 
-    pose = PoseModel(translation=translation, rotation=rotation)
+    pose = Pose(translation=translation, rotation=rotation)
 
     assert isinstance(pose.translation, Translation)
     assert isinstance(pose.rotation, Rotation)
@@ -104,7 +102,7 @@ def test_entity():
 
     assert isinstance(entity.name, str)
     assert isinstance(entity.prefab_name, str)
-    assert isinstance(entity.pose, PoseModel)
+    assert isinstance(entity.pose, Pose)
 
     assert entity.name == "test_cube"
     assert entity.prefab_name == "cube"
@@ -125,7 +123,7 @@ def test_spawned_entity():
 
     assert isinstance(spawned_entity.name, str)
     assert isinstance(spawned_entity.prefab_name, str)
-    assert isinstance(spawned_entity.pose, PoseModel)
+    assert isinstance(spawned_entity.pose, Pose)
     assert isinstance(spawned_entity.id, str)
 
     assert spawned_entity.id == "id_123"
@@ -194,7 +192,7 @@ class MockSimulationBridge(SimulationBridge[SimulationConfig]):
         """Mock implementation of _despawn_entity."""
         self.spawned_entities = [e for e in self.spawned_entities if e.id != entity.id]
 
-    def get_object_pose(self, entity: SpawnedEntity) -> PoseModel:
+    def get_object_pose(self, entity: SpawnedEntity) -> Pose:
         """Mock implementation of get_object_pose."""
         for spawned_entity in self.spawned_entities:
             if spawned_entity.id == entity.id:
@@ -216,7 +214,7 @@ class TestSimulationBridge(unittest.TestCase):
         self.test_entity1: Entity = Entity(
             name="test_entity1",
             prefab_name="test_prefab1",
-            pose=PoseModel(
+            pose=Pose(
                 translation=Translation(x=1.0, y=2.0, z=3.0),
                 rotation=Rotation(x=0.0, y=0.0, z=0.0, w=1.0),
             ),
@@ -225,7 +223,7 @@ class TestSimulationBridge(unittest.TestCase):
         self.test_entity2: Entity = Entity(
             name="test_entity2",
             prefab_name="test_prefab2",
-            pose=PoseModel(translation=Translation(x=4.0, y=5.0, z=6.0), rotation=None),
+            pose=Pose(translation=Translation(x=4.0, y=5.0, z=6.0), rotation=None),
         )
 
         # Create a test configuration
@@ -307,7 +305,7 @@ class TestSimulationBridge(unittest.TestCase):
             id="non_existent",
             name="non_existent",
             prefab_name="non_existent",
-            pose=PoseModel(translation=Translation(x=0.0, y=0.0, z=0.0)),
+            pose=Pose(translation=Translation(x=0.0, y=0.0, z=0.0)),
         )
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Purpose

To write unittests and docstrings for rai_sim package.

## Proposed Changes

* Unit tests for SimulationBridge interface and data models. 
* Unit tests for O3DExROS2Bridge with emphasis on testing compatibility with ROS2ARIConnector
* Updated README with new naming
* Docstrings
* applied some requested changed from review of #435 
* refactored, fixed and improved _is_ros2_stack_ready method

## Issues

## Testing
### Tests
`pytest tests/rai_sim`
### test _is_ros2_stack_ready method
Follow the instructions in https://github.com/RobotecAI/rai/pull/435#issue-2880749122
**BUT** use the following content of the `o3de_config.yaml`:
```
binary_path: /path/to/your/GameLauncher
robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
required_simulation_ros2_interfaces:
  services:
    - /spawn_entity
    - /delete_entity
  topics:
    - /color_image5
    - /depth_image5
    - /color_camera_info5
  actions: []
required_robotic_ros2_interfaces:
  services:
    - /grounding_dino_classify
    - /grounded_sam_segment
    - /manipulator_move_to
  topics: []
  actions: []
```
## Important info for person merging this PR
Remember about changing o3de_config.yaml in https://github.com/RobotecAI/rai/pull/435 description
