### PR TITLE
feat: support images understaning in debugging assistant for local model

### DIFF
--- a/docs/debugging_assistant.md
+++ b/docs/debugging_assistant.md
@@ -22,7 +22,7 @@ The ROS 2 Debugging Assistant is an interactive tool that helps developers inspe
 
 ```sh
 source setup_shell.sh
-streamlit run src/rai/rai/tools/debugging_assistant.py
+streamlit run src/rai_core/rai/tools/debugging_assistant.py
 ```
 
 ## Usage Examples

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -17,7 +17,7 @@ llm = ChatOllama(model='llava')
 Ollama supports OpenAI compatible APIs (see [details](https://ollama.com/blog/openai-compatibility)).
 
 > [!TIP]
-> Such setup might be more convenient if you frequently switch between OpenAI API and
+> Such a setup might be more convenient if you frequently switch between OpenAI API and
 > local models.
 
 To configure ollama through OpenAI API in `rai`:
@@ -49,7 +49,7 @@ echo 'TEMPLATE """'"$(ollama show --template llama3.2)"'"""' >> Modelfile
 ollama create llama3.2-vision-tools
 ```
 
-3. Configure the model through OpenAI compatible API in [config.toml](../config.toml)
+3. Configure the model through an OpenAI compatible API in [config.toml](../config.toml)
 
 ```toml
 [openai]

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -2,12 +2,61 @@
 
 ## Ollama
 
-For installation see: https://ollama.com/
+For installation see: https://ollama.com/. Then start
+[ollama server](https://github.com/ollama/ollama?tab=readme-ov-file#start-ollama) with
+`ollama serve` command.
 
 ```python
 from langchain_community.chat_models import ChatOllama
 
 llm = ChatOllama(model='llava')
+```
+
+### Configure ollama wth OpenAI compatible API
+
+Ollama supports OpenAI compatible APIs (see [details](https://ollama.com/blog/openai-compatibility)).
+
+> [!TIP]
+> Such setup might be more convenient if you frequently switch between OpenAI API and
+> local models.
+
+To configure ollama through OpenAI API in `rai`:
+
+1. Add `base_url` to [config.toml](../config.toml)
+
+```toml
+[openai]
+simple_model = "llama3.2"
+complex_model = "llama3.2"
+...
+base_url = "http://localhost:11434/v1"
+```
+
+### Example of setting up vision models with tool calling
+
+In this example `llama3.2-vision` will be used.
+
+1. Create a custom ollama `Modelfile` and load the model
+
+> [!NOTE]
+> Such setup is not officially supported by Ollama and it's not guaranteed to be
+> working in all cases.
+
+```shell
+ollama pull llama3.2
+echo FROM llama3.2-vision > Modelfile
+echo 'TEMPLATE """'"$(ollama show --template llama3.2)"'"""' >> Modelfile
+ollama create llama3.2-vision-tools
+```
+
+3. Configure the model through OpenAI compatible API in [config.toml](../config.toml)
+
+```toml
+[openai]
+simple_model = "llama3.2-vision-tools"
+complex_model = "llama3.2-vision-tools"
+...
+base_url = "http://localhost:11434/v1"
 ```
 
 ## OpenAI

--- a/src/rai_core/rai/tools/debugging_assistant.py
+++ b/src/rai_core/rai/tools/debugging_assistant.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import rclpy
 import streamlit as st
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from rai.agents.conversational_agent import create_conversational_agent
 from rai.agents.integrations.streamlit import get_streamlit_cb, streamlit_invoke
+from rai.communication.ros2.connectors import ROS2ARIConnector
 from rai.tools.ros.cli import (
     ros2_action,
     ros2_interface,
@@ -25,15 +27,28 @@ from rai.tools.ros.cli import (
     ros2_service,
     ros2_topic,
 )
+from rai.tools.ros2.topics import GetROS2ImageTool
 from rai.utils.model_initialization import get_llm_model
 
 
 @st.cache_resource
 def initialize_graph():
+    rclpy.init()
     llm = get_llm_model(model_type="complex_model", streaming=True)
+
+    connector = ROS2ARIConnector()
+
     agent = create_conversational_agent(
         llm,
-        [ros2_topic, ros2_interface, ros2_node, ros2_service, ros2_action, ros2_param],
+        [
+            ros2_topic,
+            ros2_interface,
+            ros2_node,
+            ros2_service,
+            ros2_action,
+            ros2_param,
+            GetROS2ImageTool(connector=connector),
+        ],
         system_prompt="""You are a ROS 2 expert helping a user with their ROS 2 questions. You have access to various tools that allow you to query the ROS 2 system.
                 Be proactive and use the tools to answer questions. Retrieve as much information from the ROS 2 system as possible.
                 """,


### PR DESCRIPTION
## Purpose

- Support image understanding features for local models 

> [!NOTE]
> Please don't squash commits on merge, they are loosely related

## Proposed Changes

- add `GetRos2Image` tool to `debugging_assistant`
- describe details of ollama setup with OpenAI API
- describe ollama setup with local VLMs for tool calling
- fix path to `debugging_assistant` in docs

## Issues

## Testing

- ollama model shoud be created as described in updated docs
- config shoud be changed as described in updated docs
- streamlit should be run as described in updated docs
- I started [manipulation demo](https://github.com/RobotecAI/rai/pull/440) binary in the background.

This is the conversation print that I got:
[ROS 2 Debugging Assistant - llama3.2-vision-tools.pdf](https://github.com/user-attachments/files/18989096/ROS.2.Debugging.Assistant.-.llama3.2-vision-tools.pdf)

Please note that in my tests:
- Model hallucinates and calls too many tools, but the setup works (it called tool to get an image, then looked and interpreted the image)
- For better models and prompt engineering performance should be better, this PR is an example of rai setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the debugging assistant with image retrieval capabilities for improved troubleshooting workflows.
  
- **Documentation**
	- Updated launch instructions for the debugging assistant.
	- Expanded vendor guides with detailed setup instructions for configuring the Ollama server, OpenAI-compatible APIs, and vision model examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->