### PR TITLE
perf: improve performance of O3DE Benchmark

### DIFF
--- a/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
+++ b/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
             final_gripper_state=False,
             frame_id="panda_link0",
         )  # return to case position
-        time.sleep(2)  # admire the end position for a second ;)
+        time.sleep(0.5)  # admire the end position for a second ;)
 
     bench_logger.info("===============================================================")
     bench_logger.info("ALL SCENARIOS DONE. BENCHMARK COMPLETED!")

--- a/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
+++ b/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
 
     # custom request to arm
     base_arm_pose = Pose(
-        translation=Translation(x=0.5, y=0.1, z=0.3),
+        translation=Translation(x=0.1, y=0.5, z=0.4),
         rotation=Rotation(x=1.0, y=0.0, z=0.0, w=0.0),
     )
 
@@ -183,7 +183,7 @@ if __name__ == "__main__":
             final_gripper_state=False,
             frame_id="panda_link0",
         )  # return to case position
-        time.sleep(0.5)  # admire the end position for a second ;)
+        time.sleep(0.2)  # admire the end position for a second ;)
 
     bench_logger.info("===============================================================")
     bench_logger.info("ALL SCENARIOS DONE. BENCHMARK COMPLETED!")

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -408,7 +408,7 @@ class O3DEngineArmManipulationBridge(O3DExROS2Bridge):
         request.target_pose.header.frame_id = frame_id
 
         request.target_pose.pose.position.x = pose.translation.x
-        request.target_pose.pose.position.x = pose.translation.y
+        request.target_pose.pose.position.y = pose.translation.y
         request.target_pose.pose.position.z = pose.translation.z
 
         if pose.rotation:

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -201,7 +201,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         return SceneState(entities=entities)
 
     def _is_ros2_stack_ready(
-        self, required_ros2_stack: dict[str, List[str]], retries: int = 30
+        self, required_ros2_stack: dict[str, List[str]], retries: int = 120
     ) -> bool:
         for i in range(retries):
             available_topics = self.connector.get_topics_names_and_types()
@@ -259,7 +259,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
                 self.logger.info("All required ROS2 stack components are available.")
                 return True
 
-            time.sleep(3)
+            time.sleep(0.5)
 
         self.logger.error(
             "Maximum number of retries reached. Required ROS2 stack components are not fully available."


### PR DESCRIPTION
## Purpose

- Improve performance of O3DE benchmark

## Proposed Changes
reduce sleep times 
move arm to more accessible position after every scenario

## Issues
These changes reduce time of execution only slightly.
The most time consuming are LLM processing and tool calls

## Testing
1. Setup the repository
2. Install dependencies listed in: 
https://github.com/RobotecAI/rai/blob/main/docs/demos/manipulation.md

and:
```bash
poetry install --with openset
colcon build --symlink-install
source setup_shell.sh
```

3. Download GameLauncher binary: [humble](https://robotecai.sharepoint.com/:u:/g/EfBxGXkAOCVApgxD1QPW-nABov0bquxBgkIOJ_HGsdQhHA) or [jazzy](https://robotecai.sharepoint.com/:u:/g/ETTc3wvDM2xOjjySUjb-85YBHUW4g1MFi_69bbcR3iU3vw)

4. Populate `src/rai_bench/rai_bench/o3de_test_bench/configs/o3de_config.yaml` with:
```yaml
binary_path: /path/to/your/GameLauncher
robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
required_services:
  - /grounding_dino_classify
  - /grounded_sam_segment
  - /manipulator_move_to
  - /spawn_entity
  - /delete_entity
required_topics:
  - /color_image5
  - /depth_image5
  - /color_camera_info5
required_actions: []
```

5. Run the benchmark
```bash
python src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
```

6. What to look for:
- If simulation starts 
- If arm is moved to the correct position after each scenario(top right corner of the table)
