### PR TITLE
feat: monitor if sim and robotic stack processes are running

### DIFF
--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -70,6 +70,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         self.current_sim_process = None
         self.current_robotic_stack_process = None
         self.current_binary_path = None
+        self.current_binary_level = None
 
     def shutdown(self):
         self._shutdown_binary()
@@ -273,12 +274,16 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         self,
         simulation_config: O3DExROS2SimulationConfig,
     ):
-        if self.current_binary_path != simulation_config.binary_path:
+        if (
+            self.current_binary_path != simulation_config.binary_path
+            or self.current_binary_level != simulation_config.level
+        ):
             if self.current_sim_process:
                 self.shutdown()
             self._launch_binary(simulation_config)
             self._launch_robotic_stack(simulation_config)
             self.current_binary_path = simulation_config.binary_path
+            self.current_binary_level = simulation_config.level
 
         else:
             while self.spawned_entities:

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -43,10 +43,6 @@ from rai_sim.simulation_bridge import (
 )
 
 
-class ProcessMonitorError(Exception):
-    """Exception raised when a monitored process terminates unexpectedly."""
-
-
 class O3DExROS2SimulationConfig(SimulationConfig):
     binary_path: Path
     level: Optional[str] = None

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -339,7 +339,7 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         for child in children:
             self._processes.append(
                 Process(
-                    name=psutil.Process(child.pid).name(),
+                    name=child.name(),
                     process=child,
                 )
             )

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -287,7 +287,6 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
         else:
             while self.spawned_entities:
                 self._despawn_entity(self.spawned_entities[0])
-            self.logger.info(f"Entities after despawn: {self.spawned_entities}")
 
         for entity in simulation_config.entities:
             self._spawn_entity(entity)

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, List, Optional, TypeVar, Union
 
+import psutil
 import yaml
-from psutil import Process as PsutilProcess
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -173,7 +173,7 @@ class SceneState(BaseModel):
 @dataclass(frozen=True)
 class Process:
     name: str
-    process: Union[subprocess.Popen[Any], PsutilProcess]
+    process: Union[subprocess.Popen[Any], psutil.Process]
 
 
 SimulationConfigT = TypeVar("SimulationConfigT", bound=SimulationConfig)

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -118,18 +118,24 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         self.assertEqual(self.bridge.spawned_entities, [])
 
     @patch("subprocess.Popen")
-    def test_launch_robotic_stack(self, mock_popen):
+    @patch("psutil.Process")
+    def test_launch_robotic_stack(
+        self, mock_psutil_process: MagicMock, mock_popen: MagicMock
+    ):
         mock_process = MagicMock()
         mock_process.poll.return_value = None
         mock_process.pid = 54321
         mock_popen.return_value = mock_process
+
         self.bridge._launch_robotic_stack(self.test_config)
 
         mock_popen.assert_called_once_with(["ros2", "launch", "robot.launch.py"])
+        mock_psutil_process.assert_any_call(mock_process.pid)
         self.assertEqual(self.bridge.current_robotic_stack_process, mock_process)
 
     @patch("subprocess.Popen")
-    def test_launch_binary(self, mock_popen):
+    @patch("psutil.Process")
+    def test_launch_binary(self, mock_psutil_process: MagicMock, mock_popen: MagicMock):
         mock_process = MagicMock()
         mock_process.poll.return_value = None
         mock_process.pid = 54322
@@ -138,6 +144,7 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         self.bridge._launch_binary(self.test_config)
 
         mock_popen.assert_called_once_with(["/path/to/binary"])
+        mock_psutil_process.assert_called_once_with(mock_process.pid)
         self.assertEqual(self.bridge.current_sim_process, mock_process)
 
     def test_shutdown_binary(self):


### PR DESCRIPTION
## Purpose

To monitor whether the sim and robotic stack processes are working in case the binary or robotic stack processes are unexpectedly terminated.

## Proposed Changes

Implemented the` _monitor_processes` method that is run as a thread monitoring the required processes in the background. On the O3DExROS2Bridge example, when a problem with a process is detected, SIGINT is sent to the main script process and then the simulation bridge, connector, and ros2 are shut down.

Added minor fix of setup_scene method in https://github.com/RobotecAI/rai/pull/445/commits/39e7541db800b7d03c79b8a51ef146be85860eba, related to https://github.com/RobotecAI/rai/commit/bbc6bc2b5e0e43f2aff1e845fda86cef9ec1e632. 

## Issues

To handle the unexpected termination of the binary and robotic stack processes (like this https://github.com/RobotecAI/rai/pull/435#issuecomment-2690171554).

## Testing
1. Setup the repository
```bash
poetry install --with openset
colcon build --symlink-install
source setup_shell.sh
```

2. Click to download GameLauncher binary from s3 bucket: [humble](https://robotec-ml-rai-public.s3.eu-north-1.amazonaws.com/RAIManipulationDemo_jammyhumble.zip) or [jazzy](https://robotec-ml-rai-public.s3.eu-north-1.amazonaws.com/RAIManipulationDemo_noblejazzy.zip).

3. Populate `src/rai_bench/rai_bench/o3de_test_bench/configs/o3de_config.yaml` with the following content and adjust the path to binary:
```yaml
binary_path: /path/to/your/GameLauncher
level: RoboticManipulationBenchmark
robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
required_simulation_ros2_interfaces:
  services:
    - /spawn_entity
    - /delete_entity
  topics:
    - /color_image5
    - /depth_image5
    - /color_camera_info5
  actions: []
required_robotic_ros2_interfaces:
  services:
    - /grounding_dino_classify
    - /grounded_sam_segment
    - /manipulator_move_to
  topics: []
  actions: []
```
Populate the following script in the rai root dir, and run it.
```
import rclpy
import logging
import time
from pathlib import Path

from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
from rai.communication.ros2.connectors import ROS2ARIConnector


if __name__ == "__main__":
    logging.basicConfig(
        level=logging.INFO,
        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
    )
    logger = logging.getLogger("O3DExROS2-Sim")
    
    o3de = None
    connector = None
    monitor = None
    
    try:
        rclpy.init()
        
        connector = ROS2ARIConnector()
        o3de = O3DExROS2Bridge(connector, logger=logger)
            
        scene_config = O3DExROS2SimulationConfig.load_config(
            base_config_path=Path("src/rai_bench/rai_bench/o3de_test_bench/configs/1a_1t.yaml"), 
            connector_config_path=Path("src/rai_bench/rai_bench/o3de_test_bench/configs/o3de_config.yaml")
        )
        
        o3de.setup_scene(scene_config)

        time.sleep(100)
        
        scene_config = O3DExROS2SimulationConfig.load_config(
            base_config_path=Path("src/rai_bench/rai_bench/o3de_test_bench/configs/1carrot_1a_1t_1bc_1corn.yaml"), 
            connector_config_path=Path("src/rai_bench/rai_bench/o3de_test_bench/configs/o3de_config.yaml")
        )
        o3de.setup_scene(scene_config)
        time.sleep(100)

    except KeyboardInterrupt:
        logger.info("Received KeyboardInterrupt.")
    except Exception as e:
        logger.exception(f"Error occurred: {e}")
        raise e
        
    finally:
        logger.info("Shutting down script...")

        if o3de:
            o3de.stop_monitoring()
            logger.info("Shutting down O3DE bridge")
            o3de.shutdown()
        
        if connector:
            logger.info("Shutting down connector")
            connector.shutdown()
        
        logger.info("Shutting down ROS2")
        rclpy.try_shutdown()
        
        logger.info("Cleanup complete")
```
### Tested cases
I tested it by:
* shutting down the binary window with close button
* resizing the binary window and clicking Force Quit when binary window shows message: "RAIManipulationDemo" is not responding.
* killing processes with binary and with robotic stack through terminal.
* killing single nodes (grounded_sam, grounding_dino, robot_state_publisher, static_transform_publisher)

> [!NOTE]
> I am going to add example script in README in separate PR #468 when this PR and #452 are merged. There are changes related to binary structure (possibility to use levels) in #452 and taking into account changes from both PRs to update README will be needed.
In #468 `connector_config_path` is also going to be changed to `bridge_config_path` to fit the changed naming convention.

> [!NOTE]
> If the changes from this PR are accepted and #452 is merged, I suggest using monitoring in the o3de_test_benchmark_script.py as well.