### PR TITLE
refactor: wait for message

### DIFF
--- a/src/rai_core/rai/communication/ros2/api.py
+++ b/src/rai_core/rai/communication/ros2/api.py
@@ -293,11 +293,11 @@ class ROS2TopicAPI:
 
     def _is_topic_available(self, topic: str, timeout_sec: float) -> bool:
         ts = time.time()
-        topic = topic.replace("/", "")
+        topic = topic if topic.startswith("/") else f"/{topic}"
         while time.time() - ts < timeout_sec:
-            topic_endpoints = self.get_topic_names_and_types()
-            if topic in [te[0].replace("/", "") for te in topic_endpoints]:
-                return True
+            for topic_name, _ in self.get_topic_names_and_types():
+                if topic == topic_name:
+                    return True
             time.sleep(0.1)
         return False
 

--- a/src/rai_core/rai/communication/ros2/api.py
+++ b/src/rai_core/rai/communication/ros2/api.py
@@ -293,9 +293,10 @@ class ROS2TopicAPI:
 
     def _is_topic_available(self, topic: str, timeout_sec: float) -> bool:
         ts = time.time()
+        topic = topic.replace("/", "")
         while time.time() - ts < timeout_sec:
             topic_endpoints = self.get_topic_names_and_types()
-            if topic in [te[0] for te in topic_endpoints]:
+            if topic in [te[0].replace("/", "") for te in topic_endpoints]:
                 return True
             time.sleep(0.1)
         return False

--- a/src/rai_core/rai/communication/ros2/api.py
+++ b/src/rai_core/rai/communication/ros2/api.py
@@ -55,7 +55,7 @@ from rclpy.qos import (
 from rclpy.task import Future
 from rclpy.topic_endpoint_info import TopicEndpointInfo
 
-from rai.tools.ros.utils import import_message_from_str, wait_for_message
+from rai.tools.ros.utils import import_message_from_str
 
 
 def adapt_requests_to_offers(publisher_info: List[TopicEndpointInfo]) -> QoSProfile:
@@ -206,6 +206,7 @@ class ROS2TopicAPI:
         timeout_sec: float = 1.0,
         auto_qos_matching: bool = True,
         qos_profile: Optional[QoSProfile] = None,
+        retry_count: int = 3,
     ) -> Any:
         """Receive a single message from a ROS2 topic.
 
@@ -241,19 +242,63 @@ class ROS2TopicAPI:
         )
 
         msg_cls = self._get_message_class(msg_type)
-        success, msg = wait_for_message(
-            msg_cls,
-            self._node,
-            topic,
-            qos_profile=qos_profile,
-            time_to_wait=int(timeout_sec),
-        )
+        if not self._is_topic_available(topic, timeout_sec):
+            raise ValueError(
+                f"Topic {topic} is not available within {timeout_sec} seconds. Check if the topic exists."
+            )
 
-        if not success:
+        for _ in range(retry_count):
+            success, msg = self._wait_for_message(
+                msg_cls,
+                self._node,
+                topic,
+                qos_profile=qos_profile,
+                timeout_sec=timeout_sec / retry_count,
+            )
+            if success:
+                return msg
+        else:
             raise ValueError(
                 f"No message received from topic: {topic} within {timeout_sec} seconds"
             )
-        return msg
+
+    def _wait_for_message(
+        self,
+        msg_cls: Type[Any],
+        node: rclpy.node.Node,
+        topic: str,
+        qos_profile: QoSProfile,
+        timeout_sec: float,
+    ) -> Tuple[bool, Any]:
+        success = False
+        msg = None
+
+        def callback(received_msg: Any):
+            nonlocal success
+            nonlocal msg
+            success = True
+            msg = received_msg
+
+        sub = node.create_subscription(
+            msg_cls, topic, callback, qos_profile=qos_profile
+        )
+        ts = time.time()
+        while time.time() - ts < timeout_sec:
+            if success:
+                node.destroy_subscription(sub)
+                return True, msg
+            time.sleep(0.01)
+        node.destroy_subscription(sub)
+        return False, None
+
+    def _is_topic_available(self, topic: str, timeout_sec: float) -> bool:
+        ts = time.time()
+        while time.time() - ts < timeout_sec:
+            topic_endpoints = self.get_topic_names_and_types()
+            if topic in [te[0] for te in topic_endpoints]:
+                return True
+            time.sleep(0.1)
+        return False
 
     def _get_or_create_publisher(
         self, topic: str, msg_cls: Type[Any], qos_profile: QoSProfile

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -207,12 +207,6 @@ def test_ros2_single_message_publish_wrong_qos_setup(
         shutdown_executors_and_threads(executors, threads)
 
 
-@pytest.mark.xfail(
-    reason="Test expected to fail: ROS2 node discovery is asynchronous and the current implementation "
-    "doesn't wait for topic discovery. "
-    "TODO: Implement a proper discovery mechanism with timeout "
-    "to ensure reliable topic communication."
-)
 def test_ros2_single_message_receive_no_discovery_time(
     ros_setup: None, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/communication/ros2/test_connectors.py
+++ b/tests/communication/ros2/test_connectors.py
@@ -64,12 +64,6 @@ def test_ros2ari_connector_send_message(
         shutdown_executors_and_threads(executors, threads)
 
 
-@pytest.mark.xfail(
-    reason="Test expected to fail: ROS2 node discovery is asynchronous and the current implementation "
-    "doesn't wait for topic discovery. "
-    "TODO: Implement a proper discovery mechanism with timeout "
-    "to ensure reliable topic communication."
-)
 def test_ros2ari_connector_receive_message(
     ros_setup: None, request: pytest.FixtureRequest
 ):

--- a/tests/tools/ros2/test_topic_tools.py
+++ b/tests/tools/ros2/test_topic_tools.py
@@ -68,12 +68,6 @@ def test_publish_message_tool(ros_setup: None, request: pytest.FixtureRequest) -
         shutdown_executors_and_threads(executors, threads)
 
 
-@pytest.mark.xfail(
-    reason="Test expected to fail: ROS2 node discovery is asynchronous and the current implementation "
-    "doesn't wait for topic discovery. "
-    "TODO: Implement a proper discovery mechanism with timeout "
-    "to ensure reliable topic communication."
-)
 def test_receive_message_tool(ros_setup: None, request: pytest.FixtureRequest) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     connector = ROS2ARIConnector()
@@ -89,12 +83,6 @@ def test_receive_message_tool(ros_setup: None, request: pytest.FixtureRequest) -
         shutdown_executors_and_threads(executors, threads)
 
 
-@pytest.mark.xfail(
-    reason="Test expected to fail: ROS2 node discovery is asynchronous and the current implementation "
-    "doesn't wait for topic discovery. "
-    "TODO: Implement a proper discovery mechanism with timeout "
-    "to ensure reliable topic communication."
-)
 def test_receive_image_tool(ros_setup: None, request: pytest.FixtureRequest) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     connector = ROS2ARIConnector()


### PR DESCRIPTION
## Purpose

The 2.0 architecture lacked topic discovery mechanism making synthetic tests harder. 

## Proposed Changes

New, internal implementation of wait_for_message which seems more stable than the rclpy version. 

## Testing

CI/pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable retry mechanism for message reception, enhancing reliability for communications.
  
- **Refactor**
	- Streamlined the message handling process by transitioning to a connector-based approach, simplifying message retrieval and cleanup procedures.
  
- **Tests**
	- Updated several tests by removing failure expectations, reflecting improvements in asynchronous topic discovery and overall test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->