### PR TITLE
feat(`ros2_tools`): add `timeout_sec` param to `get_ros2_image`

### DIFF
--- a/src/rai_core/rai/tools/ros2/topics.py
+++ b/src/rai_core/rai/tools/ros2/topics.py
@@ -74,6 +74,7 @@ class ReceiveROS2MessageTool(BaseTool):
 
 class GetROS2ImageToolInput(BaseModel):
     topic: str = Field(..., description="The topic to receive the image from")
+    timeout_sec: float = Field(..., description="The timeout in seconds")
 
 
 class GetROS2ImageTool(BaseTool):
@@ -83,8 +84,8 @@ class GetROS2ImageTool(BaseTool):
     args_schema: Type[GetROS2ImageToolInput] = GetROS2ImageToolInput
     response_format: Literal["content", "content_and_artifact"] = "content_and_artifact"
 
-    def _run(self, topic: str) -> Tuple[str, MultimodalArtifact]:
-        message = self.connector.receive_message(topic)
+    def _run(self, topic: str, timeout_sec: float) -> Tuple[str, MultimodalArtifact]:
+        message = self.connector.receive_message(topic, timeout_sec=timeout_sec)
         msg_type = type(message.payload)
         if msg_type == Image:
             image = CvBridge().imgmsg_to_cv2(  # type: ignore

--- a/src/rai_core/rai/tools/ros2/topics.py
+++ b/src/rai_core/rai/tools/ros2/topics.py
@@ -74,7 +74,7 @@ class ReceiveROS2MessageTool(BaseTool):
 
 class GetROS2ImageToolInput(BaseModel):
     topic: str = Field(..., description="The topic to receive the image from")
-    timeout_sec: float = Field(..., description="The timeout in seconds")
+    timeout_sec: float = Field(1.0, description="The timeout in seconds")
 
 
 class GetROS2ImageTool(BaseTool):
@@ -84,7 +84,9 @@ class GetROS2ImageTool(BaseTool):
     args_schema: Type[GetROS2ImageToolInput] = GetROS2ImageToolInput
     response_format: Literal["content", "content_and_artifact"] = "content_and_artifact"
 
-    def _run(self, topic: str, timeout_sec: float) -> Tuple[str, MultimodalArtifact]:
+    def _run(
+        self, topic: str, timeout_sec: float = 1.0
+    ) -> Tuple[str, MultimodalArtifact]:
         message = self.connector.receive_message(topic, timeout_sec=timeout_sec)
         msg_type = type(message.payload)
         if msg_type == Image:


### PR DESCRIPTION
## Purpose

Current implementation makes it possible only to get images from ros2 topics with frequency >= 1Hz. Which might not always be the case.

## Proposed Changes

Make `timeout_sec` parameter available to the LLM in tool call.

## Issues

## Testing
