### PR TITLE
fix(README.md): remove poetry shell before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ rosdep install --from-paths src --ignore-src -r -y
 Run the configuration tool to set up your vendor and other settings:
 
 ```bash
-poetry shell
-streamlit run src/rai/rai/utils/configurator.py
+poetry run streamlit run src/rai/rai/utils/configurator.py
 ```
 
 > [!TIP]  


### PR DESCRIPTION
## Purpose

Fixes 
```bash
      import em

  ModuleNotFoundError: No module named 'em'
```
During first colcon build

## Proposed Changes

poetry run instead of poetry shell 

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
