### PR TITLE
fix: fix error with openset launch failed to shutdown error

### DIFF
--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/services/grounded_sam.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/services/grounded_sam.py
@@ -135,7 +135,7 @@ def main(args=None):
         gsam_service.get_logger().error(f"Error: {e}")
     finally:
         gsam_service.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/services/grounding_dino.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/services/grounding_dino.py
@@ -146,7 +146,7 @@ def main(args=None):
         gdino_service.get_logger().error(f"Error: {e}")
     finally:
         gdino_service.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

To avoid error presented in **Issues** section. Error occurs because openset.launch launches two services that call rclpy.shutdown().

## Proposed Changes

Replaced `rclpy.shutdown()` with `rclpy.try_shutdown()`.

## Issues
```
[grounding_dino-1] [INFO] [1742811569.341587684] [grounding_dino]: Shutting down
[grounding_dino-1] Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
[grounded_sam-2] [INFO] [1742811569.453077639] [grounded_sam]: Shutting down
[grounded_sam-2] Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
[grounding_dino-1] final text_encoder_type: bert-base-uncased
[grounding_dino-1] Traceback (most recent call last):
[grounding_dino-1]   File "/home/mkotynia/repos/RAI/rai/install/rai_open_set_vision/lib/rai_open_set_vision/grounding_dino", line 33, in <module>
[grounding_dino-1]     sys.exit(load_entry_point('rai-open-set-vision', 'console_scripts', 'grounding_dino')())
[grounding_dino-1]   File "/home/mkotynia/repos/RAI/rai/build/rai_open_set_vision/rai_open_set_vision/services/grounding_dino.py", line 150, in main
[grounding_dino-1]     rclpy.shutdown()
[grounding_dino-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 126, in shutdown
[grounding_dino-1]     _shutdown(context=context)
[grounding_dino-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/utilities.py", line 58, in shutdown
[grounding_dino-1]     return context.shutdown()
[grounding_dino-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/context.py", line 102, in shutdown
[grounding_dino-1]     self.__context.shutdown()
[grounding_dino-1] rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context, at ./src/rcl/init.c:241
[grounded_sam-2] Traceback (most recent call last):
[grounded_sam-2]   File "/home/mkotynia/repos/RAI/rai/install/rai_open_set_vision/lib/rai_open_set_vision/grounded_sam", line 33, in <module>
[grounded_sam-2]     sys.exit(load_entry_point('rai-open-set-vision', 'console_scripts', 'grounded_sam')())
[grounded_sam-2]   File "/home/mkotynia/repos/RAI/rai/build/rai_open_set_vision/rai_open_set_vision/services/grounded_sam.py", line 139, in main
[grounded_sam-2]     rclpy.shutdown()
[grounded_sam-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 126, in shutdown
[grounded_sam-2]     _shutdown(context=context)
[grounded_sam-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/utilities.py", line 58, in shutdown
[grounded_sam-2]     return context.shutdown()
[grounded_sam-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/context.py", line 102, in shutdown
[grounded_sam-2]     self.__context.shutdown()
[grounded_sam-2] rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context, at ./src/rcl/init.c:241
[ERROR] [grounding_dino-1]: process has died [pid 246384, exit code 1, cmd '/home/mkotynia/repos/RAI/rai/install/rai_open_set_vision/lib/rai_open_set_vision/grounding_dino --ros-args -r __node:=grounding_dino --params-file /tmp/launch_params__269g3o_'].
[ERROR] [grounded_sam-2]: process has died [pid 246386, exit code 1, cmd '/home/mkotynia/repos/RAI/rai/install/rai_open_set_vision/lib/rai_open_set_vision/grounded_sam --ros-args -r __node:=grounded_sam --params-file /tmp/launch_params_5e90783g'].
```

## Testing
1. Setup the repository
```bash
poetry install --with openset
colcon build --symlink-install
source setup_shell.sh
```
2. Run openset.launch file:
```
ros2 launch src/rai_bringup/launch/openset.launch.py
```
Before the change, after ctrl+C, the output looks like in the **Issues** section. 
After the change, the output looks like the following:
```
[grounding_dino-1] [INFO] [1742817608.842270180] [grounding_dino]: Shutting down
[grounding_dino-1] Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
[grounded_sam-2] [INFO] [1742817608.940513492] [grounded_sam]: Shutting down
[grounded_sam-2] Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
[grounding_dino-1] final text_encoder_type: bert-base-uncased
[INFO] [grounding_dino-1]: process has finished cleanly [pid 266146]
[INFO] [grounded_sam-2]: process has finished cleanly [pid 266148]

After the change the error no longer occurs, and grounding_dino-1 and grounded_sam-2 processes are finished cleanly.
```
