### PR TITLE
docs: update rai sim readme

### DIFF
--- a/src/rai_bench/README.md
+++ b/src/rai_bench/README.md
@@ -57,7 +57,7 @@ Scenarios can be loaded manually like:
 ```python
 one_carrot_simulation_config = O3DExROS2SimulationConfig.load_config(
         base_config_path=Path("path_to_scene.yaml"),
-        connector_config_path=Path("path_to_o3de_config.yaml"),
+        bridge_config_path=Path("path_to_o3de_config.yaml"),
     )
 
 Scenario(task=GrabCarrotTask(logger=some_logger), simulation_config=one_carrot_simulation_config)

--- a/src/rai_bench/README.md
+++ b/src/rai_bench/README.md
@@ -77,19 +77,19 @@ or can be imported from exisitng packets [scenarios_packets](./rai_bench/o3de_te
 
 ```python
 t_scenarios = trivial_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=bridge_config_path, logger=bench_logger
     )
 e_scenarios = easy_scenarios(
-    configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+    configs_dir=configs_dir, bridge_config_path=bridge_config_path, logger=bench_logger
 )
 m_scenarios = medium_scenarios(
-    configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+    configs_dir=configs_dir, bridge_config_path=bridge_config_path, logger=bench_logger
 )
 h_scenarios = hard_scenarios(
-    configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+    configs_dir=configs_dir, bridge_config_path=bridge_config_path, logger=bench_logger
 )
 vh_scenarios = very_hard_scenarios(
-    configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+    configs_dir=configs_dir, bridge_config_path=bridge_config_path, logger=bench_logger
 )
 ```
 

--- a/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
+++ b/src/rai_bench/rai_bench/examples/o3de_test_benchmark.py
@@ -147,19 +147,19 @@ if __name__ == "__main__":
 
     ### import ready scenarios
     t_scenarios = trivial_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=connector_path, logger=bench_logger
     )
     e_scenarios = easy_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=connector_path, logger=bench_logger
     )
     m_scenarios = medium_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=connector_path, logger=bench_logger
     )
     h_scenarios = hard_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=connector_path, logger=bench_logger
     )
     vh_scenarios = very_hard_scenarios(
-        configs_dir=configs_dir, connector_path=connector_path, logger=bench_logger
+        configs_dir=configs_dir, bridge_config_path=connector_path, logger=bench_logger
     )
 
     all_scenarios = t_scenarios + e_scenarios + m_scenarios + h_scenarios + vh_scenarios

--- a/src/rai_bench/rai_bench/o3de_test_bench/scenarios.py
+++ b/src/rai_bench/rai_bench/o3de_test_bench/scenarios.py
@@ -38,7 +38,7 @@ loggers_type = Union[RcutilsLogger, logging.Logger]
 
 
 def trivial_scenarios(
-    configs_dir: str, connector_path: str, logger: loggers_type | None
+    configs_dir: str, bridge_config_path: str, logger: loggers_type | None
 ) -> List[Scenario[O3DExROS2SimulationConfig]]:
     """Packet of trivial scenarios. The grading is subjective.
     This packet contains easy variants of 'easy' tasks with minimalistic scenes setups(1 object).
@@ -53,8 +53,8 @@ def trivial_scenarios(
     ----------
     configs_dir : str
         path to directory with simulation configs
-    connector_path : str
-        path to connector config
+    bridge_config_path : str
+        path to simulation bridge config
 
 
     Returns
@@ -70,7 +70,7 @@ def trivial_scenarios(
         configs_dir + "1carrot.yaml",
     ]
     simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in simulation_configs_paths
     ]
     # place object at coords
@@ -112,7 +112,7 @@ def trivial_scenarios(
 
 
 def easy_scenarios(
-    configs_dir: str, connector_path: str, logger: loggers_type | None
+    configs_dir: str, bridge_config_path: str, logger: loggers_type | None
 ) -> List[Scenario[O3DExROS2SimulationConfig]]:
     """Packet of easy scenarios. The grading is subjective.
     This packet contains easy variants of 'easy' tasks with scenes containg no more than 3 objects
@@ -129,8 +129,8 @@ def easy_scenarios(
     ----------
     configs_dir : str
         path to directory with simulation configs
-    connector_path : str
-        path to connector config
+    bridge_config_path : str
+        path to simulation bridge config
 
 
     Returns
@@ -151,7 +151,7 @@ def easy_scenarios(
         configs_dir + "1carrot_1t_1rc.yaml",
     ]
     simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in simulation_configs_paths
     ]
     # place object at coords
@@ -213,7 +213,7 @@ def easy_scenarios(
 
 
 def medium_scenarios(
-    configs_dir: str, connector_path: str, logger: loggers_type | None
+    configs_dir: str, bridge_config_path: str, logger: loggers_type | None
 ) -> List[Scenario[O3DExROS2SimulationConfig]]:
     """Packet of medium scenarios. The grading is subjective.
     This packet contains harder variants of 'easy' tasks with scenes containg 4-7 objects
@@ -233,8 +233,8 @@ def medium_scenarios(
     ----------
     configs_dir : str
         path to directory with simulation configs
-    connector_path : str
-        path to connector config
+    bridge_config_path : str
+        path to simulation bridge config
 
 
     Returns
@@ -265,11 +265,11 @@ def medium_scenarios(
         configs_dir + "1carrot_1t_1rc.yaml",
     ]
     medium_simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in medium_simulation_configs_paths
     ]
     easy_simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in easy_simulation_configs_paths
     ]
     # move objects to the left
@@ -347,7 +347,7 @@ def medium_scenarios(
 
 
 def hard_scenarios(
-    configs_dir: str, connector_path: str, logger: loggers_type | None
+    configs_dir: str, bridge_config_path: str, logger: loggers_type | None
 ) -> List[Scenario[O3DExROS2SimulationConfig]]:
     """Packet of hard scenarios. The grading is subjective.
     This packet contains harder variants of 'easy' tasks with majority of scenes containg 8+ objects,
@@ -368,8 +368,8 @@ def hard_scenarios(
     ----------
     configs_dir : str
         path to directory with simulation configs
-    connector_path : str
-        path to connector config
+    bridge_config_path : str
+        path to simulation bridge config
 
 
     Returns
@@ -399,11 +399,11 @@ def hard_scenarios(
         configs_dir + "3rc_3bc_stacked.yaml",
     ]
     medium_simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in medium_simulation_configs_paths
     ]
     hard_simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in hard_simulation_configs_paths
     ]
     # move objects to the left
@@ -481,7 +481,7 @@ def hard_scenarios(
 
 
 def very_hard_scenarios(
-    configs_dir: str, connector_path: str, logger: loggers_type | None
+    configs_dir: str, bridge_config_path: str, logger: loggers_type | None
 ) -> List[Scenario[O3DExROS2SimulationConfig]]:
     """Packet of very_hard scenarios. The grading is subjective.
     This packet contains harder variants of 'hard' tasks with majority of scenes containg 8+ objects,
@@ -498,8 +498,8 @@ def very_hard_scenarios(
     ----------
     configs_dir : str
         path to directory with simulation configs
-    connector_path : str
-        path to connector config
+    bridge_config_path : str
+        path to simulation bridge config
 
 
     Returns
@@ -519,7 +519,7 @@ def very_hard_scenarios(
         configs_dir + "3rc_3bc_stacked.yaml",
     ]
     hard_simulations_configs = [
-        O3DExROS2SimulationConfig.load_config(Path(path), Path(connector_path))
+        O3DExROS2SimulationConfig.load_config(Path(path), Path(bridge_config_path))
         for path in hard_simulation_configs_paths
     ]
     # build tower task

--- a/src/rai_sim/README.md
+++ b/src/rai_sim/README.md
@@ -12,7 +12,7 @@ The RAI Sim is a package providing interface to implement connection with a spec
 
 - `SceneState` - stores the current info about spawned entities
 
-### Example O3DE with ROS2 implementation
+### Example implementation for simulations based on O3DE with ROS2
 
 - `O3DExROS2Bridge` - An implementation of SimulationBridge for working with simulation based on O3DE and ROS2.
 - `O3DExROS2SimulationConfig` - config class for `O3DExROS2Bridge`
@@ -22,29 +22,7 @@ The RAI Sim is a package providing interface to implement connection with a spec
 1. Setup RAI - follow [README.md](https://github.com/RobotecAI/rai)
 2. Setup rai-manipulation-demo - follow [manipulation.md](https://github.com/RobotecAI/rai/blob/main/docs/demos/manipulation.md)
 3. Click to download GameLauncher binary from s3 bucket: [humble](https://robotec-ml-rai-public.s3.eu-north-1.amazonaws.com/RAIManipulationDemo_jammyhumble.zip) or [jazzy](https://robotec-ml-rai-public.s3.eu-north-1.amazonaws.com/RAIManipulationDemo_noblejazzy.zip).
-4. Populate the .yaml config with the following content:
-
-```
-binary_path: /path/to/your/GameLauncher
-level: RoboticManipulationBenchmark
-robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
-required_simulation_ros2_interfaces:
-  services:
-    - /spawn_entity
-    - /delete_entity
-  topics:
-    - /color_image5
-    - /depth_image5
-    - /color_camera_info5
-  actions: []
-required_robotic_ros2_interfaces:
-  services:
-    - /grounding_dino_classify
-    - /grounded_sam_segment
-    - /manipulator_move_to
-  topics: []
-  actions: []
-```
+4. Adjust binary_path in `src/rai_bench/rai_bench/o3de_test_bench/configs/o3de_config.yaml` with the path to the downloaded binary.
 
 5. Run example script:
 
@@ -127,3 +105,7 @@ if __name__ == "__main__":
 
 > [!WARNING]
 > It is not recommended to resize the binary window because it may crash the simulation.
+
+#### Usage with custom O3DE simulation
+
+Follow [o3de_setup.md](../../docs/rai_sim/o3de_setup.md) to create your custom binary compatible with `O3DExROS2SimulationBridge`.

--- a/src/rai_sim/README.md
+++ b/src/rai_sim/README.md
@@ -48,9 +48,9 @@ required_robotic_ros2_interfaces:
 
 5. Run example script:
 
-# TODO (test it)
+<!-- # TODO (test it)
 
-# TODO (change connector to bridge everywhere, check it)
+# TODO (change connector to bridge everywhere, check it) -->
 
 ```
 import rclpy
@@ -124,3 +124,6 @@ if __name__ == "__main__":
         logger.info("Cleanup complete")
 
 ```
+
+> [!WARNING]
+> It is not recommended to resize the binary window because it may crash the simulation.

--- a/src/rai_sim/README.md
+++ b/src/rai_sim/README.md
@@ -12,7 +12,88 @@ The RAI Sim is a package providing interface to implement connection with a spec
 
 - `SceneState` - stores the current info about spawned entities
 
-### Example implementation
+### Example O3DE with ROS2 implementation
 
 - `O3DExROS2Bridge` - An implementation of SimulationBridge for working with simulation based on O3DE and ROS2.
 - `O3DExROS2SimulationConfig` - config class for `O3DExROS2Bridge`
+
+#### Example usage with rai-manipulation-demo
+
+1. Setup RAI - follow [README.md](https://github.com/RobotecAI/rai)
+2. Setup rai-manipulation-demo - follow [manipulation.md](https://github.com/RobotecAI/rai/blob/main/docs/demos/manipulation.md)
+3. # TODO (instructions to download binary from s3 bucket when it's ready)
+4. Populate the .yaml config with the following content:
+
+```
+binary_path: /path/to/your/GameLauncher
+level: RoboticManipulationBenchmark
+robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
+required_simulation_ros2_interfaces:
+  services:
+    - /spawn_entity
+    - /delete_entity
+  topics:
+    - /color_image5
+    - /depth_image5
+    - /color_camera_info5
+  actions: []
+required_robotic_ros2_interfaces:
+  services:
+    - /grounding_dino_classify
+    - /grounded_sam_segment
+    - /manipulator_move_to
+  topics: []
+  actions: []
+robotic_stack_command: ros2 launch examples/manipulation-demo-no-binary.launch.py
+required_simulation_ros2_interfaces:
+  services:
+    - /spawn_entity
+    - /delete_entity
+  topics:
+    - /color_image5
+    - /depth_image5
+    - /color_camera_info5
+  actions: []
+required_robotic_ros2_interfaces:
+  services:
+    - /grounding_dino_classify
+    - /grounded_sam_segment
+    - /manipulator_move_to
+  topics: []
+  actions: []
+```
+
+5. Run example script:
+
+# TODO (test it)
+
+# TODO (change connector to bridge everywhere, check it)
+
+```
+import rclpy
+from rai_sim.o3de.o3de_bridge import O3DExROS2Bridge, O3DExROS2SimulationConfig
+from rai.communication.ros2.connectors import ROS2ARIConnector
+import time
+
+from pathlib import Path
+
+if __name__ == "__main__":
+
+    try:
+        rclpy.init()
+        connector = ROS2ARIConnector()
+        o3de = O3DExROS2Bridge(connector)
+        scene_config  = O3DExROS2SimulationConfig.load_config(base_config_path=Path("base_config1.yaml"), bridge_config_path=Path("old_o3de_config.yaml"))
+        o3de.setup_scene(scene_config)
+        time.sleep(100)
+
+    except Exception as e:
+        raise e
+    finally:
+        o3de.shutdown()
+
+
+        connector.shutdown()
+        rclpy.shutdown()
+
+```

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -50,11 +50,11 @@ class O3DExROS2SimulationConfig(SimulationConfig):
 
     @classmethod
     def load_config(
-        cls, base_config_path: Path, connector_config_path: Path
+        cls, base_config_path: Path, bridge_config_path: Path
     ) -> "O3DExROS2SimulationConfig":
         base_config = SimulationConfig.load_base_config(base_config_path)
 
-        with open(connector_config_path) as f:
+        with open(bridge_config_path) as f:
             connector_content: dict[str, Any] = yaml.safe_load(f)
         return cls(**base_config.model_dump(), **connector_content)
 

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -55,8 +55,8 @@ class O3DExROS2SimulationConfig(SimulationConfig):
         base_config = SimulationConfig.load_base_config(base_config_path)
 
         with open(bridge_config_path) as f:
-            connector_content: dict[str, Any] = yaml.safe_load(f)
-        return cls(**base_config.model_dump(), **connector_content)
+            bridge_config_content: dict[str, Any] = yaml.safe_load(f)
+        return cls(**base_config.model_dump(), **bridge_config_content)
 
 
 class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):

--- a/src/rai_sim/rai_sim/tools.py
+++ b/src/rai_sim/rai_sim/tools.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type
+from typing import List, Type
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from rai_sim.simulation_bridge import Pose, SimulationBridge
+from rai_sim.simulation_bridge import Pose, SimulationBridge, SimulationConfig
 
 
 class GetObjectPositionsGroundTruthToolInput(BaseModel):
@@ -34,7 +34,7 @@ class GetObjectPositionsGroundTruthTool(BaseTool):
         "While position detection is reliable, please note that object classification may occasionally be inaccurate."
     )
 
-    simulation: SimulationBridge
+    simulation: SimulationBridge[SimulationConfig]
 
     args_schema: Type[GetObjectPositionsGroundTruthToolInput] = (
         GetObjectPositionsGroundTruthToolInput
@@ -49,7 +49,7 @@ class GetObjectPositionsGroundTruthTool(BaseTool):
         return all([word in prefab_name for word in object_name.split()])
 
     def _run(self, object_name: str):
-        poses = []
+        poses: List[Pose] = []
         for entity in self.simulation.get_scene_state().entities:
             if self.match_name(object_name, entity.prefab_name):
                 poses.append(entity.pose)


### PR DESCRIPTION
## Purpose

To update rai_sim README with the new coming changes and with example usage.

## Proposed Changes

* Updated README - to be up to date with development + added example usage with O3DExROS2Bridge.
* Renamed connector_config to bridge_config to adjust to changed naming convention
* Fixed typing in GetObjectpositionsGroundTruthTool https://github.com/RobotecAI/rai/pull/468/commits/1e8643092aa16acad3a1af954535a8210218ae58 


## Testing
Read and try to run the example.

> [!NOTE] 
> To be ready for review after #445 and #452 are merged.
