### PR TITLE
feat: add conversation id to HRI message

### DIFF
--- a/src/rai_asr/rai_asr/agents/asr_agent.py
+++ b/src/rai_asr/rai_asr/agents/asr_agent.py
@@ -274,5 +274,9 @@ class SpeechRecognitionAgent(BaseAgent):
             except Exception as e:
                 self.logger.error(f"Error sending message to {topic}: {e}")
         else:
-            msg = ROS2HRIMessage(HRIPayload(text=data), "human")
+            msg = ROS2HRIMessage(
+                HRIPayload(text=data),
+                "human",
+                ROS2HRIMessage.generate_conversation_id(),
+            )
             self.connectors["ros2_hri"].send_message(msg, topic)

--- a/src/rai_core/rai/agents/langchain/callback.py
+++ b/src/rai_core/rai/agents/langchain/callback.py
@@ -39,6 +39,10 @@ class HRICallbackHandler(BaseCallbackHandler):
         self.max_buffer_size = max_buffer_size
         self._buffer_lock = threading.Lock()
         self.logger = logger or logging.getLogger(__name__)
+        self.current_conversation_id = None
+
+    def set_conversation_id(self, conversation_id: str):
+        self.current_conversation_id = conversation_id
 
     def _should_split(self, token: str) -> bool:
         return token in self.splitting_chars
@@ -49,7 +53,9 @@ class HRICallbackHandler(BaseCallbackHandler):
         )
         for connector_name, connector in self.connectors.items():
             try:
-                connector.send_all_targets(AIMessage(content=tokens))
+                connector.send_all_targets(
+                    AIMessage(content=tokens), self.current_conversation_id
+                )
                 self.logger.debug(f"Sent {len(tokens)} tokens to {connector_name}")
             except Exception as e:
                 self.logger.error(

--- a/src/rai_core/rai/agents/react_agent.py
+++ b/src/rai_core/rai/agents/react_agent.py
@@ -61,7 +61,6 @@ class ReActAgent(BaseAgent):
                 self.logger.info("Waiting for messages...")
             if received_messages:
                 self.logger.info("Received messages")
-                self.callback.set_conversation_id(HRIMessage.generate_conversation_id())
                 reduced_message = self._reduce_messages(received_messages)
                 langchain_message = reduced_message.to_langchain()
                 self.state["messages"].append(langchain_message)

--- a/src/rai_core/rai/agents/react_agent.py
+++ b/src/rai_core/rai/agents/react_agent.py
@@ -61,6 +61,7 @@ class ReActAgent(BaseAgent):
                 self.logger.info("Waiting for messages...")
             if received_messages:
                 self.logger.info("Received messages")
+                self.callback.set_conversation_id(HRIMessage.generate_conversation_id())
                 reduced_message = self._reduce_messages(received_messages)
                 langchain_message = reduced_message.to_langchain()
                 self.state["messages"].append(langchain_message)

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -56,7 +56,9 @@ class HRIMessage(BaseMessage):
         payload: HRIPayload,
         metadata: Optional[Dict[str, Any]] = None,
         message_author: Literal["ai", "human"] = "ai",
-        conversation_id: Optional[str] = None,
+        communication_id: Optional[str] = None,
+        seq_no: int = 0,
+        seq_end: bool = False,
         **kwargs,
     ):
         super().__init__(payload, metadata)
@@ -64,7 +66,9 @@ class HRIMessage(BaseMessage):
         self.text = payload.text
         self.images = payload.images
         self.audios = payload.audios
-        self.conversation_id = conversation_id
+        self.communication_id = communication_id
+        self.seq_no = seq_no
+        self.seq_end = seq_end
 
     def __bool__(self) -> bool:
         return bool(self.text or self.images or self.audios)

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -177,12 +177,17 @@ class HRIConnector(Generic[T], BaseConnector[T]):
     def _build_message(
         self,
         message: LangchainBaseMessage | RAIMultimodalMessage,
+        conversation_id: Optional[str] = None,
     ) -> T:
-        return self.T_class.from_langchain(message)
+        return self.T_class.from_langchain(message, conversation_id)
 
-    def send_all_targets(self, message: LangchainBaseMessage | RAIMultimodalMessage):
+    def send_all_targets(
+        self,
+        message: LangchainBaseMessage | RAIMultimodalMessage,
+        conversation_id: Optional[str] = None,
+    ):
         for target in self.configured_targets:
-            to_send = self._build_message(message)
+            to_send = self._build_message(message, conversation_id)
             self.send_message(to_send, target)
 
     def receive_all_sources(self, timeout_sec: float = 1.0) -> dict[str, T]:

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -182,16 +182,20 @@ class HRIConnector(Generic[T], BaseConnector[T]):
         self,
         message: LangchainBaseMessage | RAIMultimodalMessage,
         communication_id: Optional[str] = None,
+        seq_no: int = 0,
+        seq_end: bool = False,
     ) -> T:
-        return self.T_class.from_langchain(message, communication_id)
+        return self.T_class.from_langchain(message, communication_id, seq_no, seq_end)
 
     def send_all_targets(
         self,
         message: LangchainBaseMessage | RAIMultimodalMessage,
         communication_id: Optional[str] = None,
+        seq_no: int = 0,
+        seq_end: bool = False,
     ):
         for target in self.configured_targets:
-            to_send = self._build_message(message, communication_id)
+            to_send = self._build_message(message, communication_id, seq_no, seq_end)
             self.send_message(to_send, target)
 
     def receive_all_sources(self, timeout_sec: float = 1.0) -> dict[str, T]:

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -55,6 +55,7 @@ class HRIMessage(BaseMessage):
         payload: HRIPayload,
         metadata: Optional[Dict[str, Any]] = None,
         message_author: Literal["ai", "human"] = "ai",
+        conversation_id: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(payload, metadata)
@@ -62,6 +63,7 @@ class HRIMessage(BaseMessage):
         self.text = payload.text
         self.images = payload.images
         self.audios = payload.audios
+        self.conversation_id = conversation_id
 
     def __bool__(self) -> bool:
         return bool(self.text or self.images or self.audios)
@@ -115,6 +117,7 @@ class HRIMessage(BaseMessage):
     def from_langchain(
         cls,
         message: LangchainBaseMessage | RAIMultimodalMessage,
+        conversation_id: Optional[str] = None,
     ) -> "HRIMessage":
         if isinstance(message, RAIMultimodalMessage):
             text = message.text
@@ -137,6 +140,7 @@ class HRIMessage(BaseMessage):
                 ),
             ),
             message_author=message.type,  # type: ignore
+            conversation_id=conversation_id,
         )
 
 

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -122,7 +122,7 @@ class HRIMessage(BaseMessage):
     def from_langchain(
         cls,
         message: LangchainBaseMessage | RAIMultimodalMessage,
-        conversation_id: Optional[str] = None,
+        communication_id: Optional[str] = None,
     ) -> "HRIMessage":
         if isinstance(message, RAIMultimodalMessage):
             text = message.text
@@ -145,12 +145,12 @@ class HRIMessage(BaseMessage):
                 ),
             ),
             message_author=message.type,  # type: ignore
-            conversation_id=conversation_id,
+            communication_id=communication_id,
         )
 
     @classmethod
-    def generate_conversation_id(cls) -> str:
-        """Generate a unique conversation ID."""
+    def generate_communication_id(cls) -> str:
+        """Generate a unique communication ID."""
         return str(uuid.uuid1())
 
 
@@ -181,17 +181,17 @@ class HRIConnector(Generic[T], BaseConnector[T]):
     def _build_message(
         self,
         message: LangchainBaseMessage | RAIMultimodalMessage,
-        conversation_id: Optional[str] = None,
+        communication_id: Optional[str] = None,
     ) -> T:
-        return self.T_class.from_langchain(message, conversation_id)
+        return self.T_class.from_langchain(message, communication_id)
 
     def send_all_targets(
         self,
         message: LangchainBaseMessage | RAIMultimodalMessage,
-        conversation_id: Optional[str] = None,
+        communication_id: Optional[str] = None,
     ):
         for target in self.configured_targets:
-            to_send = self._build_message(message, conversation_id)
+            to_send = self._build_message(message, communication_id)
             self.send_message(to_send, target)
 
     def receive_all_sources(self, timeout_sec: float = 1.0) -> dict[str, T]:

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -74,7 +74,7 @@ class HRIMessage(BaseMessage):
         return bool(self.text or self.images or self.audios)
 
     def __repr__(self):
-        return f"HRIMessage(type={self.message_author}, text={self.text}, images={self.images}, audios={self.audios})"
+        return f"HRIMessage(type={self.message_author}, text={self.text}, images={self.images}, audios={self.audios}, communication_id={self.communication_id}, seq_no={self.seq_no}, seq_end={self.seq_end})"
 
     def _image_to_base64(self, image: ImageType) -> str:
         buffered = BytesIO()

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import uuid
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, Dict, Generic, Literal, Optional, Sequence, TypeVar, get_args
@@ -142,6 +143,11 @@ class HRIMessage(BaseMessage):
             message_author=message.type,  # type: ignore
             conversation_id=conversation_id,
         )
+
+    @classmethod
+    def generate_conversation_id(cls) -> str:
+        """Generate a unique conversation ID."""
+        return str(uuid.uuid1())
 
 
 T = TypeVar("T", bound=HRIMessage)

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -42,8 +42,13 @@ class ROS2ARIMessage(ARIMessage):
 
 
 class ROS2HRIMessage(HRIMessage):
-    def __init__(self, payload: HRIPayload, message_author: Literal["ai", "human"]):
-        super().__init__(payload, {}, message_author)
+    def __init__(
+        self,
+        payload: HRIPayload,
+        message_author: Literal["ai", "human"],
+        conversation_id: Optional[str] = None,
+    ):
+        super().__init__(payload, {}, message_author, conversation_id)
 
     @classmethod
     def from_ros2(
@@ -66,9 +71,11 @@ class ROS2HRIMessage(HRIMessage):
             )
             for audio_msg in cast(List[ROS2HRIMessage__Audio], msg.audios)
         ]
+        conversation_id = msg.conversation_id if msg.conversation_id != "" else None
         return ROS2HRIMessage(
             payload=HRIPayload(text=msg.text, images=pil_images, audios=audio_segments),
             message_author=message_author,
+            conversation_id=conversation_id,
         )
 
     def to_ros2_dict(self) -> OrderedDict[str, Any]:
@@ -94,6 +101,7 @@ class ROS2HRIMessage(HRIMessage):
                     text=self.payload.text,
                     images=img_msgs,
                     audios=audio_msgs,
+                    conversation_id=self.conversation_id or "",
                 )
             ),
         )

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import uuid
 from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Optional, cast
 
@@ -105,3 +106,8 @@ class ROS2HRIMessage(HRIMessage):
                 )
             ),
         )
+
+    @classmethod
+    def generate_conversation_id(cls) -> str:
+        """Generate a unique conversation ID."""
+        return str(uuid.uuid1())

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -46,9 +46,11 @@ class ROS2HRIMessage(HRIMessage):
         self,
         payload: HRIPayload,
         message_author: Literal["ai", "human"],
-        conversation_id: Optional[str] = None,
+        communication_id: Optional[str] = None,
+        seq_no: int = 0,
+        seq_end: bool = False,
     ):
-        super().__init__(payload, {}, message_author, conversation_id)
+        super().__init__(payload, {}, message_author, communication_id, seq_no, seq_end)
 
     @classmethod
     def from_ros2(
@@ -71,11 +73,13 @@ class ROS2HRIMessage(HRIMessage):
             )
             for audio_msg in cast(List[ROS2HRIMessage__Audio], msg.audios)
         ]
-        conversation_id = msg.conversation_id if msg.conversation_id != "" else None
+        communication_id = msg.communication_id if msg.communication_id != "" else None
         return ROS2HRIMessage(
             payload=HRIPayload(text=msg.text, images=pil_images, audios=audio_segments),
             message_author=message_author,
-            conversation_id=conversation_id,
+            communication_id=communication_id,
+            seq_no=msg.seq_no,
+            seq_end=msg.seq_end,
         )
 
     def to_ros2_dict(self) -> OrderedDict[str, Any]:
@@ -101,7 +105,9 @@ class ROS2HRIMessage(HRIMessage):
                     text=self.payload.text,
                     images=img_msgs,
                     audios=audio_msgs,
-                    conversation_id=self.conversation_id or "",
+                    conversation_id=self.communication_id or "",
+                    seq_no=self.seq_no,
+                    seq_end=self.seq_end,
                 )
             ),
         )

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -105,7 +105,7 @@ class ROS2HRIMessage(HRIMessage):
                     text=self.payload.text,
                     images=img_msgs,
                     audios=audio_msgs,
-                    conversation_id=self.communication_id or "",
+                    communication_id=self.communication_id or "",
                     seq_no=self.seq_no,
                     seq_end=self.seq_end,
                 )

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import uuid
 from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Optional, cast
 
@@ -106,8 +105,3 @@ class ROS2HRIMessage(HRIMessage):
                 )
             ),
         )
-
-    @classmethod
-    def generate_conversation_id(cls) -> str:
-        """Generate a unique conversation ID."""
-        return str(uuid.uuid1())

--- a/src/rai_interfaces/msg/HRIMessage.msg
+++ b/src/rai_interfaces/msg/HRIMessage.msg
@@ -18,3 +18,4 @@ std_msgs/Header header
 string text
 sensor_msgs/Image[] images
 rai_interfaces/AudioMessage[] audios
+string conversation_id

--- a/src/rai_interfaces/msg/HRIMessage.msg
+++ b/src/rai_interfaces/msg/HRIMessage.msg
@@ -18,4 +18,6 @@ std_msgs/Header header
 string text
 sensor_msgs/Image[] images
 rai_interfaces/AudioMessage[] audios
-string conversation_id
+string communication_id
+int64 seq_no
+bool seq_end

--- a/tests/communication/ros2/helpers.py
+++ b/tests/communication/ros2/helpers.py
@@ -180,12 +180,11 @@ class TestActionClient(Node):
 
     def get_result_callback(self, future):
         result = future.result().result
-        self.get_logger().info(f"Result: {result.sequence}")
-        rclpy.shutdown()
+        self.get_logger().info(f"Result: {result}")
 
     def feedback_callback(self, feedback_msg):
         feedback = feedback_msg.feedback
-        self.get_logger().info(f"Received feedback: {feedback.partial_sequence}")
+        self.get_logger().info(f"Received feedback: {feedback}")
 
 
 class TestServiceClient(Node):

--- a/tests/communication/ros2/test_connectors.py
+++ b/tests/communication/ros2/test_connectors.py
@@ -233,13 +233,11 @@ def test_ros2ari_connector_create_service(
         service_client = TestServiceClient()
         executors, threads = multi_threaded_spinner([service_client])
         service_client.send_request()
-        time.sleep(0.01)
+        time.sleep(0.02)
         assert mock_callback.called
-    except Exception as e:
-        raise e
-
-    connector.shutdown()
-    shutdown_executors_and_threads(executors, threads)
+    finally:
+        connector.shutdown()
+        shutdown_executors_and_threads(executors, threads)
 
 
 def test_ros2ari_connector_action_call(ros_setup: None, request: pytest.FixtureRequest):
@@ -258,7 +256,7 @@ def test_ros2ari_connector_action_call(ros_setup: None, request: pytest.FixtureR
         action_client = TestActionClient()
         executors, threads = multi_threaded_spinner([action_client])
         action_client.send_goal()
-        time.sleep(0.01)
+        time.sleep(0.02)
+        assert mock_callback.called
     finally:
         shutdown_executors_and_threads(executors, threads)
-        assert mock_callback.called

--- a/tests/communication/ros2/test_connectors.py
+++ b/tests/communication/ros2/test_connectors.py
@@ -184,7 +184,9 @@ def test_ros2hri_default_message_publish(
         audios = [AudioSegment.silent(duration=1000)]
         text = "Hello, HRI!"
         payload = HRIPayload(images=images, audios=audios, text=text)
-        message = ROS2HRIMessage(payload=payload, message_author="ai")
+        message = ROS2HRIMessage(
+            payload=payload, message_author="ai", communication_id=""
+        )
         connector.send_message(message, target=topic_name)
         time.sleep(1)  # wait for the message to be received
 

--- a/tests/communication/test_hri_message.py
+++ b/tests/communication/test_hri_message.py
@@ -40,6 +40,8 @@ def test_initialization(image, audio):
         payload=payload,
         message_author="human",
         communication_id=HRIMessage.generate_communication_id(),
+        seq_no=0,
+        seq_end=True,
     )
 
     assert message.text == "Hello"
@@ -50,13 +52,19 @@ def test_initialization(image, audio):
 
 def test_repr():
     payload = HRIPayload(text="Hello")
+    comm_id = HRIMessage.generate_communication_id()
     message = HRIMessage(
         payload=payload,
         message_author="ai",
-        communication_id=HRIMessage.generate_communication_id(),
+        communication_id=comm_id,
+        seq_no=0,
+        seq_end=True,
     )
 
-    assert repr(message) == "HRIMessage(type=ai, text=Hello, images=[], audios=[])"
+    assert (
+        repr(message)
+        == f"HRIMessage(type=ai, text=Hello, images=[], audios=[], communication_id={comm_id}, seq_no=0, seq_end=True)"
+    )
 
 
 def test_to_langchain_human():
@@ -65,6 +73,8 @@ def test_to_langchain_human():
         payload=payload,
         message_author="human",
         communication_id=HRIMessage.generate_communication_id(),
+        seq_no=0,
+        seq_end=True,
     )
     langchain_message = message.to_langchain()
 
@@ -78,6 +88,8 @@ def test_to_langchain_ai_multimodal(image, audio):
         payload=payload,
         message_author="ai",
         communication_id=HRIMessage.generate_communication_id(),
+        seq_no=0,
+        seq_end=True,
     )
 
     with pytest.raises(

--- a/tests/communication/test_hri_message.py
+++ b/tests/communication/test_hri_message.py
@@ -39,7 +39,7 @@ def test_initialization(image, audio):
     message = HRIMessage(
         payload=payload,
         message_author="human",
-        conversation_id=HRIMessage.generate_conversation_id(),
+        communication_id=HRIMessage.generate_communication_id(),
     )
 
     assert message.text == "Hello"
@@ -53,7 +53,7 @@ def test_repr():
     message = HRIMessage(
         payload=payload,
         message_author="ai",
-        conversation_id=HRIMessage.generate_conversation_id(),
+        communication_id=HRIMessage.generate_communication_id(),
     )
 
     assert repr(message) == "HRIMessage(type=ai, text=Hello, images=[], audios=[])"
@@ -64,7 +64,7 @@ def test_to_langchain_human():
     message = HRIMessage(
         payload=payload,
         message_author="human",
-        conversation_id=HRIMessage.generate_conversation_id(),
+        communication_id=HRIMessage.generate_communication_id(),
     )
     langchain_message = message.to_langchain()
 
@@ -77,7 +77,7 @@ def test_to_langchain_ai_multimodal(image, audio):
     message = HRIMessage(
         payload=payload,
         message_author="ai",
-        conversation_id=HRIMessage.generate_conversation_id(),
+        communication_id=HRIMessage.generate_communication_id(),
     )
 
     with pytest.raises(
@@ -95,7 +95,7 @@ def test_from_langchain_human():
     langchain_message = HumanMessage(content="Hello")
     hri_message = HRIMessage.from_langchain(
         langchain_message,
-        conversation_id=HRIMessage.generate_conversation_id(),
+        communication_id=HRIMessage.generate_communication_id(),
     )
 
     assert hri_message.text == "Hello"

--- a/tests/communication/test_hri_message.py
+++ b/tests/communication/test_hri_message.py
@@ -36,7 +36,11 @@ def audio():
 
 def test_initialization(image, audio):
     payload = HRIPayload(text="Hello", images=[image], audios=[audio])
-    message = HRIMessage(payload=payload, message_author="human")
+    message = HRIMessage(
+        payload=payload,
+        message_author="human",
+        conversation_id=HRIMessage.generate_conversation_id(),
+    )
 
     assert message.text == "Hello"
     assert message.images == [image]
@@ -46,14 +50,22 @@ def test_initialization(image, audio):
 
 def test_repr():
     payload = HRIPayload(text="Hello")
-    message = HRIMessage(payload=payload, message_author="ai")
+    message = HRIMessage(
+        payload=payload,
+        message_author="ai",
+        conversation_id=HRIMessage.generate_conversation_id(),
+    )
 
     assert repr(message) == "HRIMessage(type=ai, text=Hello, images=[], audios=[])"
 
 
 def test_to_langchain_human():
     payload = HRIPayload(text="Hi there", images=[], audios=[])
-    message = HRIMessage(payload=payload, message_author="human")
+    message = HRIMessage(
+        payload=payload,
+        message_author="human",
+        conversation_id=HRIMessage.generate_conversation_id(),
+    )
     langchain_message = message.to_langchain()
 
     assert isinstance(langchain_message, HumanMessage)
@@ -62,7 +74,11 @@ def test_to_langchain_human():
 
 def test_to_langchain_ai_multimodal(image, audio):
     payload = HRIPayload(text="Response", images=[image], audios=[audio])
-    message = HRIMessage(payload=payload, message_author="ai")
+    message = HRIMessage(
+        payload=payload,
+        message_author="ai",
+        conversation_id=HRIMessage.generate_conversation_id(),
+    )
 
     with pytest.raises(
         ValueError
@@ -77,7 +93,10 @@ def test_to_langchain_ai_multimodal(image, audio):
 
 def test_from_langchain_human():
     langchain_message = HumanMessage(content="Hello")
-    hri_message = HRIMessage.from_langchain(langchain_message)
+    hri_message = HRIMessage.from_langchain(
+        langchain_message,
+        conversation_id=HRIMessage.generate_conversation_id(),
+    )
 
     assert hri_message.text == "Hello"
     assert hri_message.images == []


### PR DESCRIPTION
## Purpose

It is useful to have conversation id assigned when the message is passed between different agents

## Proposed Changes

Adds conversation id to `HRIMessage`
Makes it so that ASR agent "follows" a single conversation, so delayed messages from different conversations don't affect runtime
Makes TTS and conversational agents handle the conversation id

## Issues

N/A

## Testing

tests pass
