### PR TITLE
fix: arm reset and cleanup in o3de manipulation benchmark  

### DIFF
--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -23,12 +23,11 @@ from typing import Any, Dict, List, Optional, Set
 import yaml
 from geometry_msgs.msg import Point, PoseStamped, Quaternion
 from geometry_msgs.msg import Pose as ROS2Pose
-from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
-from rai.utils.ros_async import get_future_result
 from std_msgs.msg import Header
-from std_srvs.srv import Trigger
 from tf2_geometry_msgs import do_transform_pose
 
+from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
+from rai.utils.ros_async import get_future_result
 from rai_interfaces.srv import ManipulatorMoveTo
 from rai_sim.simulation_bridge import (
     Entity,
@@ -396,19 +395,13 @@ class O3DExROS2Bridge(SimulationBridge[O3DExROS2SimulationConfig]):
 
 class O3DEngineArmManipulationBridge(O3DExROS2Bridge):
     def reset_arm(self):
-        client = self.connector.node.create_client(
-            Trigger,
-            "/reset_manipulator",
+        self.connector.service_call(
+            ROS2ARIMessage(payload={}),
+            target="/reset_manipulator",
+            msg_type="std_srvs/srv/Trigger",
         )
-        while not client.wait_for_service(timeout_sec=5.0):
-            self.connector.node.get_logger().info("Service not available, waiting...")
 
-        self.connector.node.get_logger().info("Making request to reset manipulator...")
-        request = Trigger.Request()
-        future = client.call_async(request)
-        result = get_future_result(future, timeout_sec=5.0)
-
-        self.connector.node.get_logger().debug(f"Reset manipulator result: {result}")
+        self.connector.node.get_logger().debug("Reset manipulator arm: DONE")
 
     def move_arm(
         self,


### PR DESCRIPTION
## Purpose

Fix 2 things in o3de manipulation benchmark
- fix are reset
- cleanup

## Proposed Changes

- use rai ros2 connector to call service
- shutdown in `finally:` block

## Issues

## Testing
