### PR TITLE
feat: ROS2 tools allowlist

### DIFF
--- a/src/rai_core/rai/tools/ros2/base.py
+++ b/src/rai_core/rai/tools/ros2/base.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from langchain_core.tools import BaseTool
+
+from rai.communication.ros2.connectors import ROS2ARIConnector
+
+
+class BaseROS2Tool(BaseTool):
+    """
+    Base class for all ROS2 tools.
+
+    Parameters
+    ----------
+    connector : ROS2ARIConnector
+        The connector to the ROS2 system.
+    readable : Optional[List[str]]
+        The topics that can be read. If the list is not provided, all topics can be read.
+    writable : Optional[List[str]]
+        The names (topics/actions/services) that can be written. If the list is not provided, all topics can be written.
+    forbidden : Optional[List[str]]
+        The names (topics/actions/services) that are forbidden to read and write.
+    """
+
+    connector: ROS2ARIConnector
+    readable: Optional[List[str]] = None
+    writable: Optional[List[str]] = None
+    forbidden: Optional[List[str]] = None
+
+    name: str = ""
+    description: str = ""
+
+    def is_readable(self, topic: str) -> bool:
+        if self.forbidden is not None and topic in self.forbidden:
+            return False
+        if self.readable is None:
+            return True
+        return topic in self.readable
+
+    def is_writable(self, topic: str) -> bool:
+        if self.forbidden is not None and topic in self.forbidden:
+            return False
+        if self.writable is None:
+            return True
+        return topic in self.writable

--- a/src/rai_core/rai/tools/ros2/services.py
+++ b/src/rai_core/rai/tools/ros2/services.py
@@ -21,10 +21,10 @@ except ImportError:
 
 from typing import Any, Dict, Type
 
-from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
+from rai.communication.ros2.connectors import ROS2ARIMessage
+from rai.tools.ros2.base import BaseROS2Tool
 
 
 class CallROS2ServiceToolInput(BaseModel):
@@ -35,8 +35,7 @@ class CallROS2ServiceToolInput(BaseModel):
     )
 
 
-class CallROS2ServiceTool(BaseTool):
-    connector: ROS2ARIConnector
+class CallROS2ServiceTool(BaseROS2Tool):
     name: str = "call_ros2_service"
     description: str = "Call a ROS2 service"
     args_schema: Type[CallROS2ServiceToolInput] = CallROS2ServiceToolInput
@@ -44,6 +43,8 @@ class CallROS2ServiceTool(BaseTool):
     def _run(
         self, service_name: str, service_type: str, service_args: Dict[str, Any]
     ) -> str:
+        if not self.is_writable(service_name):
+            raise ValueError(f"Service {service_name} is not writable")
         message = ROS2ARIMessage(payload=service_args)
         response = self.connector.service_call(
             message, service_name, msg_type=service_type

--- a/src/rai_core/rai/tools/ros2/topics.py
+++ b/src/rai_core/rai/tools/ros2/topics.py
@@ -209,11 +209,26 @@ class GetROS2TopicsNamesAndTypesTool(BaseROS2Tool):
                 if self.is_writable(topic):
                     writable_topics.append({"topic": topic, "type": type})
 
-            text_response = f"{'\n'.join([stringify_dict(topic_description) for topic_description in readable_and_writable_topics])}"
+            text_response = "\n".join(
+                [
+                    stringify_dict(topic_description)
+                    for topic_description in readable_and_writable_topics
+                ]
+            )
             if readable_topics:
-                text_response += f"\nReadable topics: {'\n'.join([stringify_dict(topic_description) for topic_description in readable_topics])}"
+                text_response += "\nReadable topics:" + "\n".join(
+                    [
+                        stringify_dict(topic_description)
+                        for topic_description in readable_topics
+                    ]
+                )
             if writable_topics:
-                text_response += f"\nWritable topics: {'\n'.join([stringify_dict(topic_description) for topic_description in writable_topics])}"
+                text_response += "\nWritable topics:" + "\n".join(
+                    [
+                        stringify_dict(topic_description)
+                        for topic_description in writable_topics
+                    ]
+                )
             return text_response
 
 

--- a/src/rai_core/rai/tools/ros2/topics.py
+++ b/src/rai_core/rai/tools/ros2/topics.py
@@ -20,7 +20,7 @@ except ImportError:
     )
 
 import json
-from typing import Any, Dict, List, Literal, Tuple, Type
+from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Type
 
 import rosidl_runtime_py.set_message
 import rosidl_runtime_py.utilities
@@ -34,6 +34,7 @@ from sensor_msgs.msg import CompressedImage, Image
 from rai.communication.ros2.connectors import ROS2ARIConnector, ROS2ARIMessage
 from rai.messages.multimodal import MultimodalArtifact
 from rai.messages.utils import preprocess_image
+from rai.tools.ros2.base import BaseROS2Tool
 from rai.tools.ros2.utils import ros2_message_to_dict
 
 
@@ -41,6 +42,26 @@ class ROS2TopicsToolkit(BaseToolkit):
     name: str = "ROS2TopicsToolkit"
     description: str = "A toolkit for ROS2 topics"
     connector: ROS2ARIConnector
+    readable: Optional[
+        Annotated[
+            List[str],
+            """The topics that can be read.
+            If the list is not provided, all topics can be read.""",
+        ]
+    ] = None
+    writable: Optional[
+        Annotated[
+            List[str],
+            """The names (topics/actions/services) that can be written.
+            If the list is not provided, all topics can be written.""",
+        ]
+    ] = None
+    forbidden: Optional[
+        Annotated[
+            List[str],
+            """The names (topics/actions/services) that are forbidden to read and write.""",
+        ]
+    ] = None
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -48,12 +69,42 @@ class ROS2TopicsToolkit(BaseToolkit):
 
     def get_tools(self) -> List[BaseTool]:
         return [
-            PublishROS2MessageTool(connector=self.connector),
-            ReceiveROS2MessageTool(connector=self.connector),
-            GetROS2ImageTool(connector=self.connector),
-            GetROS2TransformTool(connector=self.connector),
-            GetROS2TopicsNamesAndTypesTool(connector=self.connector),
-            GetROS2MessageInterfaceTool(connector=self.connector),
+            PublishROS2MessageTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
+            ReceiveROS2MessageTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
+            GetROS2ImageTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
+            GetROS2TransformTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
+            GetROS2TopicsNamesAndTypesTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
+            GetROS2MessageInterfaceTool(
+                connector=self.connector,
+                readable=self.readable,
+                writable=self.writable,
+                forbidden=self.forbidden,
+            ),
         ]
 
 
@@ -63,13 +114,14 @@ class PublishROS2MessageToolInput(BaseModel):
     message_type: str = Field(..., description="The type of the message")
 
 
-class PublishROS2MessageTool(BaseTool):
-    connector: ROS2ARIConnector
+class PublishROS2MessageTool(BaseROS2Tool):
     name: str = "publish_ros2_message"
     description: str = "Publish a message to a ROS2 topic"
     args_schema: Type[PublishROS2MessageToolInput] = PublishROS2MessageToolInput
 
     def _run(self, topic: str, message: Dict[str, Any], message_type: str) -> str:
+        if not self.is_writable(topic):
+            raise ValueError(f"Topic {topic} is not writable")
         ros_message = ROS2ARIMessage(
             payload=message,
             metadata={"topic": topic},
@@ -82,13 +134,15 @@ class ReceiveROS2MessageToolInput(BaseModel):
     topic: str = Field(..., description="The topic to receive the message from")
 
 
-class ReceiveROS2MessageTool(BaseTool):
+class ReceiveROS2MessageTool(BaseROS2Tool):
     connector: ROS2ARIConnector
     name: str = "receive_ros2_message"
     description: str = "Receive a message from a ROS2 topic"
     args_schema: Type[ReceiveROS2MessageToolInput] = ReceiveROS2MessageToolInput
 
     def _run(self, topic: str) -> str:
+        if not self.is_readable(topic):
+            raise ValueError(f"Topic {topic} is not readable")
         message = self.connector.receive_message(topic)
         return str({"payload": message.payload, "metadata": message.metadata})
 
@@ -98,7 +152,7 @@ class GetROS2ImageToolInput(BaseModel):
     timeout_sec: float = Field(1.0, description="The timeout in seconds")
 
 
-class GetROS2ImageTool(BaseTool):
+class GetROS2ImageTool(BaseROS2Tool):
     connector: ROS2ARIConnector
     name: str = "get_ros2_image"
     description: str = "Get an image from a ROS2 topic"
@@ -108,6 +162,8 @@ class GetROS2ImageTool(BaseTool):
     def _run(
         self, topic: str, timeout_sec: float = 1.0
     ) -> Tuple[str, MultimodalArtifact]:
+        if not self.is_readable(topic):
+            raise ValueError(f"Topic {topic} is not readable")
         message = self.connector.receive_message(topic, timeout_sec=timeout_sec)
         msg_type = type(message.payload)
         if msg_type == Image:
@@ -127,18 +183,38 @@ class GetROS2ImageTool(BaseTool):
         )  # type: ignore
 
 
-class GetROS2TopicsNamesAndTypesTool(BaseTool):
+class GetROS2TopicsNamesAndTypesTool(BaseROS2Tool):
     connector: ROS2ARIConnector
     name: str = "get_ros2_topics_names_and_types"
     description: str = "Get the names and types of all ROS2 topics"
 
     def _run(self) -> str:
         topics_and_types = self.connector.get_topics_names_and_types()
-        response = [
-            stringify_dict({"topic": topic, "type": type})
-            for topic, type in topics_and_types
-        ]
-        return "\n".join(response)
+        if all([self.readable is None, self.writable is None, self.forbidden is None]):
+            response = [
+                {"topic": topic, "type": type} for topic, type in topics_and_types
+            ]
+            return f"{'\n'.join([stringify_dict(topic) for topic in response])}"
+        else:
+            readable_and_writable_topics: List[Dict[str, Any]] = []
+            readable_topics: List[Dict[str, Any]] = []
+            writable_topics: List[Dict[str, Any]] = []
+
+            for topic, type in topics_and_types:
+                if self.is_readable(topic) and self.is_writable(topic):
+                    readable_and_writable_topics.append({"topic": topic, "type": type})
+                    continue
+                if self.is_readable(topic):
+                    readable_topics.append({"topic": topic, "type": type})
+                if self.is_writable(topic):
+                    writable_topics.append({"topic": topic, "type": type})
+
+            text_response = f"{'\n'.join([stringify_dict(topic_description) for topic_description in readable_and_writable_topics])}"
+            if readable_topics:
+                text_response += f"\nReadable topics: {'\n'.join([stringify_dict(topic_description) for topic_description in readable_topics])}"
+            if writable_topics:
+                text_response += f"\nWritable topics: {'\n'.join([stringify_dict(topic_description) for topic_description in writable_topics])}"
+            return text_response
 
 
 class GetROS2MessageInterfaceToolInput(BaseModel):
@@ -147,7 +223,7 @@ class GetROS2MessageInterfaceToolInput(BaseModel):
     )
 
 
-class GetROS2MessageInterfaceTool(BaseTool):
+class GetROS2MessageInterfaceTool(BaseROS2Tool):
     connector: ROS2ARIConnector
     name: str = "get_ros2_message_interface"
     description: str = "Get the interface of a ROS2 message"
@@ -179,7 +255,7 @@ class GetROS2TransformToolInput(BaseModel):
     timeout_sec: float = Field(default=5.0, description="The timeout in seconds")
 
 
-class GetROS2TransformTool(BaseTool):
+class GetROS2TransformTool(BaseROS2Tool):
     connector: ROS2ARIConnector
     name: str = "get_ros2_transform"
     description: str = "Get the transform between two frames"

--- a/src/rai_core/rai/tools/ros2/topics.py
+++ b/src/rai_core/rai/tools/ros2/topics.py
@@ -194,7 +194,7 @@ class GetROS2TopicsNamesAndTypesTool(BaseROS2Tool):
             response = [
                 {"topic": topic, "type": type} for topic, type in topics_and_types
             ]
-            return f"{'\n'.join([stringify_dict(topic) for topic in response])}"
+            return "\n".join([stringify_dict(topic) for topic in response])
         else:
             readable_and_writable_topics: List[Dict[str, Any]] = []
             readable_topics: List[Dict[str, Any]] = []

--- a/tests/communication/ros2/__init__.py
+++ b/tests/communication/ros2/__init__.py
@@ -15,7 +15,7 @@
 from .helpers import (
     ActionServer,
     MessagePublisher,
-    MessageReceiver,
+    MessageSubscriber,
     multi_threaded_spinner,
     shutdown_executors_and_threads,
 )
@@ -23,7 +23,7 @@ from .helpers import (
 __all__ = [
     "ActionServer",
     "MessagePublisher",
-    "MessageReceiver",
+    "MessageSubscriber",
     "multi_threaded_spinner",
     "shutdown_executors_and_threads",
 ]

--- a/tests/communication/ros2/helpers.py
+++ b/tests/communication/ros2/helpers.py
@@ -14,7 +14,7 @@
 
 import threading
 import time
-from typing import Generator, List, Tuple
+from typing import Any, Generator, List, Tuple
 
 import numpy as np
 import pytest
@@ -95,15 +95,16 @@ class ImagePublisher(Node):
         self.publisher.publish(msg)
 
 
-class MessageReceiver(Node):
-    def __init__(self, topic: str):
-        super().__init__("test_message_receiver")
+class MessageSubscriber(Node):
+    def __init__(self, topic: str, msg_type: Any = String):
+        super().__init__("test_message_subscriber")
+        self.msg_type = msg_type
         self.subscription = self.create_subscription(
-            String, topic, self.handle_test_message, 10
+            msg_type, topic, self.handle_test_message, 10
         )
-        self.received_messages: List[String] = []
+        self.received_messages: List[msg_type] = []
 
-    def handle_test_message(self, msg: String) -> None:
+    def handle_test_message(self, msg: Any) -> None:
         self.received_messages.append(msg)
 
 

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -32,7 +32,7 @@ from .helpers import ActionServer_ as ActionServer
 from .helpers import (
     HRIMessageSubscriber,
     MessagePublisher,
-    MessageReceiver,
+    MessageSubscriber,
     ServiceServer,
     multi_threaded_spinner,
     ros_setup,
@@ -47,7 +47,7 @@ def test_ros2_single_message_publish(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     node = Node(node_name)
     executors, threads = multi_threaded_spinner([message_receiver, node])
 
@@ -127,7 +127,7 @@ def test_ros2_single_message_publish_configured_no_config(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     node = Node(node_name)
     executors, threads = multi_threaded_spinner([message_receiver, node])
 
@@ -147,7 +147,7 @@ def test_ros2_single_message_publish_wrong_msg_type(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     node = Node(node_name)
     executors, threads = multi_threaded_spinner([message_receiver, node])
 
@@ -168,7 +168,7 @@ def test_ros2_single_message_publish_wrong_msg_content(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     node = Node(node_name)
     executors, threads = multi_threaded_spinner([message_receiver, node])
 
@@ -189,7 +189,7 @@ def test_ros2_single_message_publish_wrong_qos_setup(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     node = Node(node_name)
     executors, threads = multi_threaded_spinner([message_receiver, node])
 

--- a/tests/communication/ros2/test_connectors.py
+++ b/tests/communication/ros2/test_connectors.py
@@ -32,7 +32,7 @@ from .helpers import ActionServer_ as ActionServer
 from .helpers import (
     HRIMessageSubscriber,
     MessagePublisher,
-    MessageReceiver,
+    MessageSubscriber,
     ServiceServer,
     multi_threaded_spinner,
     ros_setup,
@@ -46,7 +46,7 @@ def test_ros2ari_connector_send_message(
     ros_setup: None, request: pytest.FixtureRequest
 ):
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
-    message_receiver = MessageReceiver(topic_name)
+    message_receiver = MessageSubscriber(topic_name)
     executors, threads = multi_threaded_spinner([message_receiver])
     connector = ROS2ARIConnector()
     try:


### PR DESCRIPTION
## Purpose

RAI 1.x had a allowlist feature in StateBasedAgent, allowing the LLM to interact with certain topics only. This PR reintroduces the feature with extension to readable, writable and forbidden names (topics/services/actions)

## Proposed Changes

- ROS2BaseTool with connector and configurable list of readable, writable and forbidden names
- Extended tests

## Issues

Closes #479 

## Testing

Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configurable access controls for ROS2 interactions, allowing for granular read, write, and forbidden permissions.
	- Enhanced error handling now prevents unauthorized operations and displays clear error feedback.

- **Refactor**
	- Unified the underlying framework for ROS2 tools, streamlining behavior across actions, topics, and services.
	- Renamed messaging components for improved clarity and consistency.

- **Tests**
	- Expanded test coverage to ensure proper handling of access permissions and robust operation under varied conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->