### PR TITLE
feat: enhance destroy_subscribers behavior

### DIFF
--- a/src/rai_core/rai/communication/ros2/connectors/ari_connector.py
+++ b/src/rai_core/rai/communication/ros2/connectors/ari_connector.py
@@ -39,12 +39,77 @@ from rai.communication.ros2.messages import ROS2ARIMessage
 
 
 class ROS2ARIConnector(ROS2ActionMixin, ROS2ServiceMixin, ARIConnector[ROS2ARIMessage]):
+    """ROS2-specific implementation of the ARIConnector.
+
+    This connector provides functionality for ROS2 communication through topics,
+    services, and actions, as well as TF (Transform) operations.
+
+    Parameters
+    ----------
+    node_name : str, optional
+        Name of the ROS2 node. If not provided, generates a unique name with UUID.
+    destroy_subscribers : bool, optional
+        Whether to destroy subscribers after receiving a message, by default False.
+        If True, the subscriber will be destroyed after the message is received.
+        If False, may lead to performance issues due to unneded subscribers.
+        It has been observed that destroying subscribers may lead to a crash of the node/executor.
+
+    Attributes
+    ----------
+    _node : Node
+        The ROS2 node instance.
+    _topic_api : ROS2TopicAPI
+        API for handling ROS2 topic operations.
+    _service_api : ROS2ServiceAPI
+        API for handling ROS2 service operations.
+    _actions_api : ROS2ActionAPI
+        API for handling ROS2 action operations.
+    _tf_buffer : Buffer
+        Buffer for storing TF transforms.
+    tf_listener : TransformListener
+        Listener for TF transforms.
+    _executor : MultiThreadedExecutor
+        ROS2 executor for running the node.
+    _thread : Thread
+        Thread running the executor.
+
+    Methods
+    -------
+    get_topics_names_and_types()
+        Get list of available topics and their message types.
+    get_services_names_and_types()
+        Get list of available services and their types.
+    get_actions_names_and_types()
+        Get list of available actions and their types.
+    send_message(message, target, msg_type, auto_qos_matching=True, qos_profile=None, **kwargs)
+        Send a message to a specified topic.
+    receive_message(source, timeout_sec=1.0, msg_type=None, auto_topic_type=True, **kwargs)
+        Receive a message from a specified topic.
+    wait_for_transform(tf_buffer, target_frame, source_frame, timeout_sec=1.0)
+        Wait for a transform to become available.
+    get_transform(target_frame, source_frame, timeout_sec=5.0)
+        Get the transform between two frames.
+    create_service(service_name, on_request, on_done=None, service_type, **kwargs)
+        Create a ROS2 service.
+    create_action(action_name, generate_feedback_callback, action_type, **kwargs)
+        Create a ROS2 action server.
+    shutdown()
+        Clean up resources and shut down the connector.
+
+    Notes
+    -----
+    This connector runs in a separate thread to handle ROS2 operations asynchronously.
+    It automatically manages the lifecycle of ROS2 nodes, topics, services, and actions.
+    """
+
     def __init__(
-        self, node_name: str = f"rai_ros2_ari_connector_{str(uuid.uuid4())[-12:]}"
+        self,
+        node_name: str = f"rai_ros2_ari_connector_{str(uuid.uuid4())[-12:]}",
+        destroy_subscribers: bool = False,
     ):
         super().__init__()
         self._node = Node(node_name)
-        self._topic_api = ROS2TopicAPI(self._node)
+        self._topic_api = ROS2TopicAPI(self._node, destroy_subscribers)
         self._service_api = ROS2ServiceAPI(self._node)
         self._actions_api = ROS2ActionAPI(self._node)
         self._tf_buffer = Buffer(node=self._node)

--- a/src/rai_core/rai/communication/ros2/connectors/hri_connector.py
+++ b/src/rai_core/rai/communication/ros2/connectors/hri_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import threading
 import uuid
 from typing import Any, Callable, List, Literal, Optional, Tuple, Union
@@ -19,7 +20,6 @@ from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
-import rai_interfaces.msg
 from rai.communication import HRIConnector
 from rai.communication.ros2.api import (
     ConfigurableROS2TopicAPI,
@@ -30,6 +30,11 @@ from rai.communication.ros2.api import (
 from rai.communication.ros2.connectors.action_mixin import ROS2ActionMixin
 from rai.communication.ros2.connectors.service_mixin import ROS2ServiceMixin
 from rai.communication.ros2.messages import ROS2HRIMessage
+
+try:
+    import rai_interfaces.msg
+except ImportError:
+    logging.warning("rai_interfaces is not installed, ROS 2 HRIMessage will not work.")
 
 
 class ROS2HRIConnector(ROS2ActionMixin, ROS2ServiceMixin, HRIConnector[ROS2HRIMessage]):


### PR DESCRIPTION
## Purpose

Sometimes, destroying the subscribers lead to crash of the node/executor. An effort has ben made to allow persistent subscribers. 

## Proposed Changes

Enhances the logic behind handling destroy_subscribers in ROS2TopicAPI
ROS2ARIConnector docstring

## Issues

- Links to relevant issues

## Testing

```python
from rai.communication.ros2 import ROS2ARIConnector
from rai.tools.ros2 import ReceiveROS2MessageTool
import rclpy
import time
import subprocess

rclpy.init()

proc = subprocess.Popen(["ros2", "topic", "pub", "topic", "std_msgs/String", f"data: 'Hello {time.time()}'"])

connector = ROS2ARIConnector(destroy_subscribers=True)
tool = ReceiveROS2MessageTool(connector=connector)
try:
    for i in range(10):
        msg = tool.run(tool_input={"topic": "topic", "timeout_sec": 2.0})
        print(msg)
finally:
    connector.shutdown()
    rclpy.shutdown()
    proc.terminate()
```
