### PR TITLE
fix: add base_url parameter to ChatOpenAI initialization

### DIFF
--- a/src/rai_core/rai/utils/configurator.py
+++ b/src/rai_core/rai/utils/configurator.py
@@ -746,7 +746,8 @@ elif st.session_state.current_step == 7:
             model_name = st.session_state.config[vendor_name][f"{model_type}_model"]
 
             if vendor_name == "openai":
-                return ChatOpenAI(model=model_name)
+                base_url = st.session_state.config["openai"]["base_url"]
+                return ChatOpenAI(model=model_name, base_url=base_url)
             elif vendor_name == "aws":
                 return ChatBedrock(model_id=model_name)
             elif vendor_name == "ollama":


### PR DESCRIPTION
## Purpose

When running `poetry run streamlit run src/rai_core/rai/utils/configurator.py` with a `config.toml` file containing OpenAI settings,
like this
```
 [openai]
simple_model = "qwen-plus"
complex_model = "qwen-plus"
embeddings_model = "text-embedding-v3"
base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
```
the original code lacked the base_url parameter for the ChatOpenAI model. This caused errors when trying to connect to a custom OpenAI endpoint. 

## Proposed Changes
```
  if vendor_name == "openai":
      base_url = st.session_state.config["openai"]["base_url"]
      return ChatOpenAI(model=model_name, base_url=base_url)
```

## Test
![93535810f40d22443b2da1bfab77e1d](https://github.com/user-attachments/assets/15091b93-f75b-48c1-b9a2-ce82c5783590)

## Addition
```
    def test_embeddings_model():
        try:
            embeddings_model_vendor_name = st.session_state.config["vendor"][
                "embeddings_model"
            ]
            if embeddings_model_vendor_name == "openai":
                embeddings_model = OpenAIEmbeddings(
                    model=st.session_state.config["openai"]["embeddings_model"]
                )
```
Since `OpenAIEmbeddings` does not support the `base_url` parameter, alternative methods are required to call embeddings when using custom models.

