### PR TITLE
fix: react agent

### DIFF
--- a/examples/agents/react.py
+++ b/examples/agents/react.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rai.agents import ReActAgent
-from rai.communication import ROS2ARIConnector, ROS2HRIConnector
+from rai.communication.ros2 import ROS2ARIConnector, ROS2HRIConnector
 from rai.tools.ros2 import ROS2Toolkit
 from rai.utils import ROS2Context, wait_for_shutdown
 

--- a/src/rai_core/rai/agents/react_agent.py
+++ b/src/rai_core/rai/agents/react_agent.py
@@ -48,6 +48,7 @@ class ReActAgent(BaseAgent):
         self.state = state or ReActAgentState(messages=[])
         self.thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self.connectors = connectors
 
     def run(self):
         if self.thread is not None:

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -101,6 +101,8 @@ class HRIMessage(BaseMessage):
         cls,
         message: LangchainBaseMessage | RAIMultimodalMessage,
         communication_id: Optional[str] = None,
+        seq_no: int = 0,
+        seq_end: bool = False
     ) -> "HRIMessage":
         if isinstance(message, RAIMultimodalMessage):
             text = message.text
@@ -122,6 +124,8 @@ class HRIMessage(BaseMessage):
             ),
             message_author=message.type,  # type: ignore
             communication_id=communication_id,
+            seq_no=seq_no,
+            seq_end=seq_end
         )
 
     @classmethod

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -102,7 +102,7 @@ class HRIMessage(BaseMessage):
         message: LangchainBaseMessage | RAIMultimodalMessage,
         communication_id: Optional[str] = None,
         seq_no: int = 0,
-        seq_end: bool = False
+        seq_end: bool = False,
     ) -> "HRIMessage":
         if isinstance(message, RAIMultimodalMessage):
             text = message.text
@@ -125,7 +125,7 @@ class HRIMessage(BaseMessage):
             message_author=message.type,  # type: ignore
             communication_id=communication_id,
             seq_no=seq_no,
-            seq_end=seq_end
+            seq_end=seq_end,
         )
 
     @classmethod


### PR DESCRIPTION
## Purpose

Currently example `ReActAgent` doesn't work due to wrong imports and communication errors. This PR fixes the agent.

## Proposed Changes

- fix imports
- add connectors as a ReActAgent class attribute
- fix arguments in HRIMessage `from_langchain` method

## Issues

## Testing

Terminal 1:
```bash
python examples/agents/react.py
```

Terminal 2:
```bash
ros2 topic pub /from_human rai_interfaces/msg/HRIMessage "{'text': 'Find ros2 topic with images and describe 1 image.'}" --once
```

Terminal 3:
```bash
ros2 topic echo /to_human rai_interfaces/msg/HRIMessage
```