### PR TITLE
fix(`ConfigurableTopicsApi`): reading a single messaged from non configured topics

### DIFF
--- a/src/rai_core/rai/communication/ros2/api/topic.py
+++ b/src/rai_core/rai/communication/ros2/api/topic.py
@@ -513,7 +513,8 @@ class ConfigurableROS2TopicAPI(ROS2TopicAPI):
             ValueError: For unconfigured topics, inherits parent class exceptions
         """
         if topic not in self.topic_msg_queue:
-            super().receive(
+            print(f"Running receive for {topic}")
+            return super().receive(
                 topic,
                 auto_topic_type=auto_topic_type,
                 msg_type=msg_type,
@@ -523,6 +524,7 @@ class ConfigurableROS2TopicAPI(ROS2TopicAPI):
                 retry_count=retry_count,
             )
         else:
+            print(f"Running receive for {topic} queue")
             ts = time.time()
             while time.time() - ts < timeout_sec:
                 with self.topic_queue_locks[topic]:

--- a/src/rai_core/rai/communication/ros2/api/topic.py
+++ b/src/rai_core/rai/communication/ros2/api/topic.py
@@ -513,7 +513,6 @@ class ConfigurableROS2TopicAPI(ROS2TopicAPI):
             ValueError: For unconfigured topics, inherits parent class exceptions
         """
         if topic not in self.topic_msg_queue:
-            print(f"Running receive for {topic}")
             return super().receive(
                 topic,
                 auto_topic_type=auto_topic_type,
@@ -524,7 +523,6 @@ class ConfigurableROS2TopicAPI(ROS2TopicAPI):
                 retry_count=retry_count,
             )
         else:
-            print(f"Running receive for {topic} queue")
             ts = time.time()
             while time.time() - ts < timeout_sec:
                 with self.topic_queue_locks[topic]:

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -152,9 +152,9 @@ def test_ros2_single_message_receive_no_discovery_time_configurable(
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
-    message_receiver = MessageSubscriber(topic_name)
+    message_publisher = MessagePublisher(topic_name)
     node = Node(node_name)
-    executors, threads = multi_threaded_spinner([message_receiver, node])
+    executors, threads = multi_threaded_spinner([message_publisher, node])
 
     try:
         topic_api = ConfigurableROS2TopicAPI(node)

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -146,9 +146,10 @@ def test_ros2_single_message_publish_configured_no_config(
     finally:
         shutdown_executors_and_threads(executors, threads)
 
+
 def test_ros2_single_message_receive_no_discovery_time_configurable(
     ros_setup: None, request: pytest.FixtureRequest
-)-> None:
+) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore
     message_receiver = MessageSubscriber(topic_name)
@@ -166,6 +167,7 @@ def test_ros2_single_message_receive_no_discovery_time_configurable(
         assert msg.data == "Hello, ROS2!"
     finally:
         shutdown_executors_and_threads(executors, threads)
+
 
 def test_ros2_single_message_publish_wrong_msg_type(
     ros_setup: None, request: pytest.FixtureRequest
@@ -234,7 +236,10 @@ def test_ros2_single_message_publish_wrong_qos_setup(
 
 @pytest.mark.parametrize("destroy_subscribers", [False, True])
 def test_ros2_single_message_receive_no_discovery_time(
-    ros_setup: None, request: pytest.FixtureRequest, destroy_subscribers: bool, configurable_api: bool
+    ros_setup: None,
+    request: pytest.FixtureRequest,
+    destroy_subscribers: bool,
+    configurable_api: bool,
 ) -> None:
     topic_name = f"{request.node.originalname}_topic"  # type: ignore
     node_name = f"{request.node.originalname}_node"  # type: ignore


### PR DESCRIPTION
## Purpose

`ConfigurableTopicsAPI` when `receive` is called can't read 1 message from a ros2 topic. It's because code from `ROS2TopicAPI` and `ConfigurableTopicsAPI` is not fully compatible and subscribers seem not to be created properly.
By default in `ROS2TopicsAPI` the parameter `destroy_subscribers = False`. Therefore `_wait_for_message_persistent` method is selected and raises KeyError.

## Proposed Changes

- [x] add a test for the bug
- [x] parametrize ROS2TopicsAPI test with `destroy_subscribers`
- [x] fix lack of return in `ConfigurableTopicsAPI`
- [ ] fix `ConfigurableTopicsAPI`

## Issues

## Testing
CI
