### PR TITLE
fix: ros2 import guards

### DIFF
--- a/src/rai_core/rai/tools/ros2/generic/actions.py
+++ b/src/rai_core/rai/tools/ros2/generic/actions.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    pass
-except ImportError:
+import importlib.util
+
+if importlib.util.find_spec("rclpy") is None:
     raise ImportError(
         "This is a ROS2 feature. Make sure ROS2 is installed and sourced."
     )

--- a/src/rai_core/rai/tools/ros2/generic/services.py
+++ b/src/rai_core/rai/tools/ros2/generic/services.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    pass
-except ImportError:
+import importlib.util
+
+if importlib.util.find_spec("rclpy") is None:
     raise ImportError(
         "This is a ROS2 feature. Make sure ROS2 is installed and sourced."
     )

--- a/src/rai_core/rai/tools/ros2/generic/topics.py
+++ b/src/rai_core/rai/tools/ros2/generic/topics.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    pass
-except ImportError:
+import importlib.util
+
+if importlib.util.find_spec("rclpy") is None:
     raise ImportError(
         "This is a ROS2 feature. Make sure ROS2 is installed and sourced."
     )


### PR DESCRIPTION
## Purpose

- To fix rclpy import guards for ros2 functionalities. Current guards have no effect.

## Proposed Changes

 Use `importlib.util.find_spec` to check if `rclpy` can be imported correcty.

## Issues

## Testing

