### PR TITLE
fix: collecting messages from agent

### DIFF
--- a/src/rai_extensions/rai_open_set_vision/scripts/run_vision_agents.py
+++ b/src/rai_extensions/rai_open_set_vision/scripts/run_vision_agents.py
@@ -14,7 +14,7 @@
 
 
 import rclpy
-from rai.utils import wait_for_shutdown
+from rai.agents import wait_for_shutdown
 from rai_open_set_vision.agents import GroundedSamAgent, GroundingDinoAgent
 
 


### PR DESCRIPTION
## Purpose
fix collecting messages from agent, described in issue linked below.
## Proposed Changes
in agent.stream() loop there is now counter for how many messages were already received and on each iteration only the [received_count: ] messages are appended.

Also fixed import issue in openset https://github.com/RobotecAI/rai/pull/544/commits/161b696d5f476e39035e861b89f71cbdb8f4f06b
which was introduced in some other refactors

## Issues 
https://github.com/RobotecAI/rai/issues/543


## Testing
1. Run  `src/rai_bench/rai_bench/examples/test_models.py` in debug mode.
2.  Track messages appended in loop 
![image](https://github.com/user-attachments/assets/07762082-66f5-4e51-bb92-677dab4599ac)
Check if all unique(ids of messages) messages from state variable are appended to messages properly.

Do this for both tool calling agent and manipulaiton_o3de (change in `src/rai_bench/rai_bench/examples/test_models.py` selected benchamrk if needed).



