### PR TITLE
refactor: ros2 tools in manimulation demo

### DIFF
--- a/src/rai_core/rai/tools/ros2/__init__.py
+++ b/src/rai_core/rai/tools/ros2/__init__.py
@@ -18,7 +18,6 @@ if importlib.util.find_spec("rclpy") is None:
     raise ImportError(
         "This is a ROS2 feature. Make sure ROS2 is installed and sourced."
     )
-
 from .cli import (
     ROS2CLIToolkit,
     ros2_action,
@@ -48,11 +47,6 @@ from .generic import (
     ROS2TopicsToolkit,
     StartROS2ActionTool,
 )
-from .manipulation.custom import (
-    GetObjectPositionsTool,
-    MoveToPointTool,
-    MoveToPointToolInput,
-)
 from .navigation.nav2 import (
     CancelNavigateToPoseTool,
     GetNavigateToPoseFeedbackTool,
@@ -71,7 +65,6 @@ __all__ = [
     "CancelROS2ActionTool",
     "GetNavigateToPoseFeedbackTool",
     "GetNavigateToPoseResultTool",
-    "GetObjectPositionsTool",
     "GetROS2ActionFeedbackTool",
     "GetROS2ActionIDsTool",
     "GetROS2ActionResultTool",
@@ -83,8 +76,6 @@ __all__ = [
     "GetROS2TopicsNamesAndTypesTool",
     "GetROS2TransformConfiguredTool",
     "GetROS2TransformTool",
-    "MoveToPointTool",
-    "MoveToPointToolInput",
     "Nav2Toolkit",
     "NavigateToPoseTool",
     "PublishROS2MessageTool",

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/gdino_tools.py
@@ -16,11 +16,10 @@ from typing import List, NamedTuple, Type
 
 import numpy as np
 import sensor_msgs.msg
-from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
-from rai.communication.ros2 import ROS2Connector
 from rai.communication.ros2.api import convert_ros_img_to_ndarray
 from rai.communication.ros2.ros_async import get_future_result
+from rai.tools.ros2.base import BaseROS2Tool
 from rclpy.exceptions import (
     ParameterNotDeclaredException,
     ParameterUninitializedException,
@@ -78,9 +77,7 @@ class DistanceMeasurement(NamedTuple):
 
 
 # --------------------- Tools ---------------------
-class GroundingDinoBaseTool(BaseTool):
-    connector: ROS2Connector = Field(..., exclude=True)
-
+class GroundingDinoBaseTool(BaseROS2Tool):
     box_threshold: float = Field(default=0.35, description="Box threshold for GDINO")
     text_threshold: float = Field(default=0.45, description="Text threshold for GDINO")
 
@@ -89,7 +86,7 @@ class GroundingDinoBaseTool(BaseTool):
     ) -> Future:
         cli = self.connector.node.create_client(RAIGroundingDino, GDINO_SERVICE_NAME)
         while not cli.wait_for_service(timeout_sec=1.0):
-            self.node.get_logger().info(
+            self.connector.node.get_logger().info(
                 f"service {GDINO_SERVICE_NAME} not available, waiting again..."
             )
         req = RAIGroundingDino.Request()

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/tools/segmentation_tools.py
@@ -18,14 +18,13 @@ import cv2
 import numpy as np
 import rclpy
 import sensor_msgs.msg
-from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 from rai.communication.ros2.api import (
     convert_ros_img_to_base64,
     convert_ros_img_to_ndarray,
 )
-from rai.communication.ros2.connectors import ROS2Connector
 from rai.communication.ros2.ros_async import get_future_result
+from rai.tools.ros2.base import BaseROS2Tool
 from rclpy import Future
 from rclpy.exceptions import (
     ParameterNotDeclaredException,
@@ -67,12 +66,7 @@ class GetGrabbingPointInput(BaseModel):
 
 
 # --------------------- Tools ---------------------
-class GetSegmentationTool:
-    connector: ROS2Connector = Field(..., exclude=True)
-
-    name: str = ""
-    description: str = ""
-
+class GetSegmentationTool(BaseROS2Tool):
     box_threshold: float = Field(default=0.35, description="Box threshold for GDINO")
     text_threshold: float = Field(default=0.45, description="Text threshold for GDINO")
 
@@ -194,9 +188,7 @@ def depth_to_point_cloud(
     return points
 
 
-class GetGrabbingPointTool(BaseTool):
-    connector: ROS2Connector = Field(..., exclude=True)
-
+class GetGrabbingPointTool(BaseROS2Tool):
     name: str = "GetGrabbingPointTool"
     description: str = "Get the grabbing point of an object"
     pcd: List[Any] = []


### PR DESCRIPTION
## Purpose

- Not all ros2 tools has bee refactored to use rai_core API

## Proposed Changes

- [ ] refactor tools
- [ ] don't import manipulation tools in `rai.tools.ros2` package to avoid circular import

## Issues

resolves: https://github.com/RobotecAI/rai/issues/408

## Testing

```
cd src/rai_extensions/rai_open_set_vision/
python scripts/run_vision_agents.py
# TODO
```
