### PR TITLE
refactor: relative imports -> absolute imports

### DIFF
--- a/src/rai_core/rai/agents/langchain/agent.py
+++ b/src/rai_core/rai/agents/langchain/agent.py
@@ -22,12 +22,11 @@ from typing import Deque, Dict, List, Literal, Optional, TypedDict
 from langchain_core.messages import BaseMessage
 from langchain_core.runnables import Runnable
 
+from rai.agents.base import BaseAgent
+from rai.agents.langchain.callback import HRICallbackHandler
+from rai.agents.langchain.runnables import ReActAgentState
 from rai.communication.hri_connector import HRIConnector, HRIMessage
 from rai.initialization import get_tracing_callbacks
-
-from ..base import BaseAgent
-from .callback import HRICallbackHandler
-from .runnables import ReActAgentState
 
 
 class BaseState(TypedDict):

--- a/src/rai_core/rai/agents/langchain/react_agent.py
+++ b/src/rai_core/rai/agents/langchain/react_agent.py
@@ -17,10 +17,9 @@ from typing import Dict, List, Optional
 from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
 
+from rai.agents.langchain.agent import LangChainAgent
+from rai.agents.langchain.runnables import ReActAgentState, create_react_runnable
 from rai.communication.hri_connector import HRIConnector, HRIMessage
-
-from .agent import LangChainAgent
-from .runnables import ReActAgentState, create_react_runnable
 
 
 class ReActAgent(LangChainAgent):

--- a/src/rai_core/rai/agents/langchain/runnables.py
+++ b/src/rai_core/rai/agents/langchain/runnables.py
@@ -31,10 +31,9 @@ from langchain_core.tools import BaseTool
 from langgraph.graph import START, StateGraph
 from langgraph.prebuilt.tool_node import tools_condition
 
+from rai.agents.tool_runner import ToolRunner
 from rai.initialization import get_llm_model
 from rai.messages import HumanMultimodalMessage
-
-from ..tool_runner import ToolRunner
 
 
 class ReActAgentState(TypedDict):

--- a/src/rai_core/rai/agents/langchain/state_based_agent.py
+++ b/src/rai_core/rai/agents/langchain/state_based_agent.py
@@ -23,13 +23,12 @@ from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field
 
+from rai.agents.langchain.agent import LangChainAgent, newMessageBehaviorType
+from rai.agents.langchain.runnables import ReActAgentState, create_state_based_runnable
 from rai.aggregators import BaseAggregator
 from rai.communication.base_connector import BaseConnector
 from rai.communication.hri_connector import HRIConnector, HRIMessage
 from rai.messages.multimodal import HumanMultimodalMessage
-
-from .agent import LangChainAgent, newMessageBehaviorType
-from .runnables import ReActAgentState, create_state_based_runnable
 
 
 class StateBasedConfig(BaseModel):

--- a/src/rai_core/rai/agents/ros2/state_based_agent.py
+++ b/src/rai_core/rai/agents/ros2/state_based_agent.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rai.agents.langchain import BaseStateBasedAgent
 from rai.communication.ros2 import ROS2Connector
-
-from ..langchain import BaseStateBasedAgent
 
 
 class ROS2StateBasedAgent(BaseStateBasedAgent):

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -24,10 +24,9 @@ from PIL.Image import Image as ImageType
 from pydantic import Field
 from pydub import AudioSegment
 
+from rai.communication.base_connector import BaseConnector, BaseMessage
 from rai.messages import AIMultimodalMessage, HumanMultimodalMessage
 from rai.messages import MultimodalMessage as RAIMultimodalMessage
-
-from .base_connector import BaseConnector, BaseMessage
 
 
 class HRIException(Exception):

--- a/src/rai_core/rai/types/geometry.py
+++ b/src/rai_core/rai/types/geometry.py
@@ -14,8 +14,8 @@
 
 from typing import List
 
-from .base import ROS2BaseModel
-from .std import Header
+from rai.types.base import ROS2BaseModel
+from rai.types.std import Header
 
 
 class BaseGeometryModel(ROS2BaseModel):

--- a/src/rai_core/rai/types/rai_interfaces.py
+++ b/src/rai_core/rai/types/rai_interfaces.py
@@ -14,11 +14,11 @@
 
 from typing import List
 
-from .base import ROS2BaseModel
-from .geometry import PoseStamped
-from .sensor import Image
-from .std import Header
-from .vision import Detection2D
+from rai.types.base import ROS2BaseModel
+from rai.types.geometry import PoseStamped
+from rai.types.sensor import Image
+from rai.types.std import Header
+from rai.types.vision import Detection2D
 
 
 class RAIDetectionArray(ROS2BaseModel):

--- a/src/rai_core/rai/types/sensor.py
+++ b/src/rai_core/rai/types/sensor.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 from typing import List
 
-from .base import ROS2BaseModel
-from .std import Header
-from .vision import RegionOfInterest
+from rai.types.base import ROS2BaseModel
+from rai.types.std import Header
+from rai.types.vision import RegionOfInterest
 
 
 class BaseSensorModel(ROS2BaseModel):

--- a/src/rai_core/rai/types/std.py
+++ b/src/rai_core/rai/types/std.py
@@ -14,7 +14,7 @@
 
 from pydantic import Field
 
-from . import ROS2BaseModel
+from rai.types.base import ROS2BaseModel
 
 
 class BaseStdModel(ROS2BaseModel):

--- a/src/rai_core/rai/types/vision.py
+++ b/src/rai_core/rai/types/vision.py
@@ -14,9 +14,9 @@
 
 from typing import List
 
-from .base import ROS2BaseModel
-from .geometry import Pose2D, PoseWithCovariance
-from .std import Header
+from rai.types.base import ROS2BaseModel
+from rai.types.geometry import Pose2D, PoseWithCovariance
+from rai.types.std import Header
 
 
 class BaseVisionModel(ROS2BaseModel):


### PR DESCRIPTION
## Purpose

As of now, relative imports are not tracked by the import tests, which can lead to problems. 

## Proposed Changes

Refactored non __init__.py files to only use absolute paths.

## Issues

- Links to relevant issues

## Testing

- How was it tested, what were the results?
