### PR TITLE
fix: manipulaiton o3de 

### DIFF
--- a/examples/manipulation-demo-no-binary.launch.py
+++ b/examples/manipulation-demo-no-binary.launch.py
@@ -34,7 +34,6 @@ def generate_launch_description():
     launch_robotic_manipulation = Node(
         package="robotic_manipulation",
         executable="robotic_manipulation",
-        # name="robotic_manipulation_node",
         output="screen",
         parameters=[
             {"use_sim_time": True},

--- a/src/rai_bench/rai_bench/examples/manipulation_o3de/main.py
+++ b/src/rai_bench/rai_bench/examples/manipulation_o3de/main.py
@@ -86,21 +86,26 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str):
         GetROS2TopicsNamesAndTypesTool(connector=connector),
     ]
     # define loggers
-    Path(out_dir).mkdir(parents=True, exist_ok=True)
-    log_file = f"{out_dir}/benchmark.log"
+    experiment_dir = Path(out_dir)
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    log_file = experiment_dir / "benchmark.log"
+
     file_handler = logging.FileHandler(log_file)
     file_handler.setLevel(logging.DEBUG)
-
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     file_handler.setFormatter(formatter)
 
     bench_logger = logging.getLogger("Benchmark logger")
+    for handler in bench_logger.handlers:
+        bench_logger.removeHandler(handler)
     bench_logger.setLevel(logging.INFO)
     bench_logger.addHandler(file_handler)
 
     agent_logger = logging.getLogger("Agent logger")
+    for handler in agent_logger.handlers:
+        agent_logger.removeHandler(handler)
     agent_logger.setLevel(logging.INFO)
     agent_logger.addHandler(file_handler)
 
@@ -174,7 +179,7 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str):
             simulation_bridge=o3de,
             scenarios=all_scenarios,
             logger=bench_logger,
-            results_dir=Path(out_dir),
+            results_dir=experiment_dir,
         )
         for scenario in all_scenarios:
             agent = create_conversational_agent(

--- a/src/rai_bench/rai_bench/examples/manipulation_o3de/main.py
+++ b/src/rai_bench/rai_bench/examples/manipulation_o3de/main.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-import logging
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -23,7 +20,6 @@ import rclpy
 from langchain.tools import BaseTool
 from rai.agents.langchain.core import create_conversational_agent
 from rai.communication.ros2.connectors import ROS2Connector
-from rai.initialization import get_llm_model_direct
 from rai.tools.ros2 import (
     GetObjectPositionsTool,
     GetROS2ImageTool,
@@ -36,39 +32,28 @@ from rai_bench.examples.manipulation_o3de.scenarios import (
     trivial_scenarios,
 )
 from rai_bench.manipulation_o3de.benchmark import ManipulationO3DEBenchmark
+from rai_bench.utils import (
+    define_benchmark_loggers,
+    get_llm_for_benchmark,
+    parse_benchmark_args,
+)
 from rai_sim.o3de.o3de_bridge import (
     O3DEngineArmManipulationBridge,
 )
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Run the Tool Calling Agent Benchmark")
-    parser.add_argument(
-        "--model-name",
-        type=str,
-        help="Model name to use for benchmarking",
-    )
-    parser.add_argument(
-        "--vendor", type=str, default=None, help="Vendor of the model (optional)"
-    )
-    now = datetime.now()
-    parser.add_argument(
-        "--out_dir",
-        type=str,
-        default=f"src/rai_bench/rai_bench/experiments/o3de_manipulation/{now.strftime('%Y-%m-%d_%H-%M-%S')}",
-        help="Output directory for results and logs",
-    )
-    return parser.parse_args()
-
-
 def run_benchmark(model_name: str, vendor: str, out_dir: str):
+    experiment_dir = Path(out_dir)
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    bench_logger, agent_logger = define_benchmark_loggers(out_dir=experiment_dir)
+
     rclpy.init()
     connector = ROS2Connector()
     node = connector.node
     node.declare_parameter("conversion_ratio", 1.0)
 
     # define model
-    llm = get_llm_model_direct(model_name=model_name, vendor=vendor)
+    llm = get_llm_for_benchmark(model_name=model_name, vendor=vendor)
 
     # define tools
     tools: List[BaseTool] = [
@@ -85,29 +70,6 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str):
         GetROS2ImageTool(connector=connector),
         GetROS2TopicsNamesAndTypesTool(connector=connector),
     ]
-    # define loggers
-    experiment_dir = Path(out_dir)
-    experiment_dir.mkdir(parents=True, exist_ok=True)
-    log_file = experiment_dir / "benchmark.log"
-
-    file_handler = logging.FileHandler(log_file)
-    file_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    file_handler.setFormatter(formatter)
-
-    bench_logger = logging.getLogger("Benchmark logger")
-    for handler in bench_logger.handlers:
-        bench_logger.removeHandler(handler)
-    bench_logger.setLevel(logging.INFO)
-    bench_logger.addHandler(file_handler)
-
-    agent_logger = logging.getLogger("Agent logger")
-    for handler in agent_logger.handlers:
-        agent_logger.removeHandler(handler)
-    agent_logger.setLevel(logging.INFO)
-    agent_logger.addHandler(file_handler)
 
     configs_dir = "src/rai_bench/rai_bench/examples/manipulation_o3de/configs/"
     connector_path = configs_dir + "o3de_config.yaml"
@@ -189,6 +151,7 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str):
             o3de.reset_arm()
             time.sleep(0.2)  # admire the end position for a second ;)
 
+        time.sleep(3)
         bench_logger.info(
             "==============================================================="
         )
@@ -203,5 +166,5 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str):
 
 
 if __name__ == "__main__":
-    args = parse_args()
+    args = parse_benchmark_args()
     run_benchmark(model_name=args.model_name, vendor=args.vendor, out_dir=args.out_dir)

--- a/src/rai_bench/rai_bench/examples/tool_calling_agent/main.py
+++ b/src/rai_bench/rai_bench/examples/tool_calling_agent/main.py
@@ -53,9 +53,9 @@ def parse_args():
 def run_benchmark(model_name: str, vendor: str, out_dir: str, extra_tool_calls: int):
     experiment_dir = Path(out_dir)
     experiment_dir.mkdir(parents=True, exist_ok=True)
-    log_filename = experiment_dir / "benchmark.log"
+    log_file = experiment_dir / "benchmark.log"
 
-    file_handler = logging.FileHandler(log_filename)
+    file_handler = logging.FileHandler(log_file)
     file_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -63,10 +63,14 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str, extra_tool_calls: 
     file_handler.setFormatter(formatter)
 
     bench_logger = logging.getLogger("Benchmark logger")
+    for handler in bench_logger.handlers:
+        bench_logger.removeHandler(handler)
     bench_logger.setLevel(logging.INFO)
     bench_logger.addHandler(file_handler)
 
     agent_logger = logging.getLogger("Agent logger")
+    for handler in agent_logger.handlers:
+        agent_logger.removeHandler(handler)
     agent_logger.setLevel(logging.INFO)
     agent_logger.addHandler(file_handler)
 

--- a/src/rai_bench/rai_bench/examples/tool_calling_agent/main.py
+++ b/src/rai_bench/rai_bench/examples/tool_calling_agent/main.py
@@ -12,67 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-import logging
-from datetime import datetime
 from pathlib import Path
 
-from rai import get_llm_model_direct
 from rai.agents.langchain.core import create_conversational_agent
 
 from rai_bench.examples.tool_calling_agent.tasks import get_all_tasks
 from rai_bench.tool_calling_agent.benchmark import ToolCallingAgentBenchmark
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Run the Tool Calling Agent Benchmark")
-    parser.add_argument(
-        "--model-name",
-        type=str,
-        help="Model name to use for benchmarking",
-        required=True,
-    )
-    parser.add_argument("--vendor", type=str, help="Vendor of the model", required=True)
-    parser.add_argument(
-        "--extra-tool-calls",
-        type=int,
-        help="Number of extra tools calls agent can make and still pass the task",
-        default=0,
-    )
-    now = datetime.now()
-    parser.add_argument(
-        "--out_dir",
-        type=str,
-        default=f"src/rai_bench/rai_bench/experiments/o3de_manipulation/{now.strftime('%Y-%m-%d_%H-%M-%S')}",
-        help="Output directory for results and logs",
-    )
-
-    return parser.parse_args()
+from rai_bench.utils import (
+    define_benchmark_loggers,
+    get_llm_for_benchmark,
+    parse_benchmark_args,
+)
 
 
 def run_benchmark(model_name: str, vendor: str, out_dir: str, extra_tool_calls: int):
     experiment_dir = Path(out_dir)
     experiment_dir.mkdir(parents=True, exist_ok=True)
-    log_file = experiment_dir / "benchmark.log"
-
-    file_handler = logging.FileHandler(log_file)
-    file_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    file_handler.setFormatter(formatter)
-
-    bench_logger = logging.getLogger("Benchmark logger")
-    for handler in bench_logger.handlers:
-        bench_logger.removeHandler(handler)
-    bench_logger.setLevel(logging.INFO)
-    bench_logger.addHandler(file_handler)
-
-    agent_logger = logging.getLogger("Agent logger")
-    for handler in agent_logger.handlers:
-        agent_logger.removeHandler(handler)
-    agent_logger.setLevel(logging.INFO)
-    agent_logger.addHandler(file_handler)
+    bench_logger, agent_logger = define_benchmark_loggers(out_dir=experiment_dir)
 
     all_tasks = get_all_tasks(extra_tool_calls=extra_tool_calls)
     for task in all_tasks:
@@ -85,7 +41,7 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str, extra_tool_calls: 
         results_dir=experiment_dir,
     )
 
-    llm = get_llm_model_direct(model_name=model_name, vendor=vendor)
+    llm = get_llm_for_benchmark(model_name=model_name, vendor=vendor)
     for task in all_tasks:
         agent = create_conversational_agent(
             llm=llm,
@@ -95,9 +51,13 @@ def run_benchmark(model_name: str, vendor: str, out_dir: str, extra_tool_calls: 
         )
         benchmark.run_next(agent=agent)
 
+    bench_logger.info("===============================================================")
+    bench_logger.info("ALL SCENARIOS DONE. BENCHMARK COMPLETED!")
+    bench_logger.info("===============================================================")
+
 
 if __name__ == "__main__":
-    args = parse_args()
+    args = parse_benchmark_args()
     run_benchmark(
         model_name=args.model_name,
         vendor=args.vendor,

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -263,8 +263,3 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
         )
         self.csv_initialize(self.summary_filename, BenchmarkSummary)
         self.csv_writerow(self.summary_filename, summary)
-
-        self.logger.info(
-            f"Summary for model {self.model_name}: Success rate {success_rate:.2f}%, "
-            f"Average time {avg_time:.3f}s, Total tasks: {len(self.scenario_results)}"
-        )

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Generic, List, TypeVar
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from rai.messages import HumanMultimodalMessage
 
@@ -172,35 +173,38 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
 
             ts = time.perf_counter()
             prev_count: int = 0
-            for state in agent.stream(
-                {"messages": [HumanMessage(content=scenario.task.task_prompt)]},
-                {
-                    "recursion_limit": 100
-                },  # NOTE (jmatejcz) what should be recursion limit?
-            ):
-                node = next(iter(state))
-                new_messages = state[node]["messages"][prev_count:]
-                prev_count = len(state[node]["messages"])
+            try:
+                for state in agent.stream(
+                    {"messages": [HumanMessage(content=scenario.task.task_prompt)]},
+                    {
+                        "recursion_limit": 100
+                    },  # NOTE (jmatejcz) what should be recursion limit?
+                ):
+                    node = next(iter(state))
+                    new_messages = state[node]["messages"][prev_count:]
+                    prev_count = len(state[node]["messages"])
 
-                for msg in new_messages:
-                    if isinstance(msg, HumanMultimodalMessage):
-                        last_msg = msg.text
-                    elif isinstance(msg, BaseMessage):
-                        if isinstance(msg.content, list):
-                            if len(msg.content) == 1:
-                                if type(msg.content[0]) is dict:
-                                    last_msg = msg.content[0].get("text", "")
+                    for msg in new_messages:
+                        if isinstance(msg, HumanMultimodalMessage):
+                            last_msg = msg.text
+                        elif isinstance(msg, BaseMessage):
+                            if isinstance(msg.content, list):
+                                if len(msg.content) == 1:
+                                    if type(msg.content[0]) is dict:
+                                        last_msg = msg.content[0].get("text", "")
+                            else:
+                                last_msg = msg.content
+                                self.logger.debug(f"{node}: {last_msg}")
+
                         else:
-                            last_msg = msg.content
-                            self.logger.debug(f"{node}: {last_msg}")
+                            raise ValueError(f"Unexpected type of message: {type(msg)}")
 
-                    else:
-                        raise ValueError(f"Unexpected type of message: {type(msg)}")
+                        if isinstance(msg, AIMessage):
+                            tool_calls_num += len(msg.tool_calls)
 
-                    if isinstance(msg, AIMessage):
-                        tool_calls_num += len(msg.tool_calls)
-
-                    self.logger.info(f"AI Message: {msg}")
+                        self.logger.info(f"AI Message: {msg}")
+            except GraphRecursionError as e:
+                self.logger.error(msg=f"Reached recursion limit {e}")
 
             te = time.perf_counter()
             try:
@@ -221,6 +225,7 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
                 )
                 self.scenario_results.append(scenario_result)
                 self.csv_writerow(self.results_filename, scenario_result)
+                # computing after every iteration in case of early stopping
                 self.compute_and_save_summary()
             except EntitiesMismatchException as e:
                 self.logger.error(e)

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -78,7 +78,10 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
         """
         # try:
         i, task = next(self._tasks)
-        self.logger.info(  # type: ignore
+        self.logger.info(
+            "======================================================================================"
+        )
+        self.logger.info(
             f"RUNNING TASK NUMBER {i + 1} / {self.num_tasks}, TASK {task.get_prompt()}"
         )
         callbacks = self.score_tracing_handler.get_callbacks()
@@ -124,7 +127,6 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
         except GraphRecursionError as e:
             self.logger.error(msg=f"Reached recursion limit {e}")
 
-        self.logger.debug(messages)
         tool_calls = task.get_tool_calls_from_messages(messages=messages)
         score = task.validate(tool_calls=tool_calls)
         te = time.perf_counter()

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -188,8 +188,3 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
         )
         self.csv_initialize(self.summary_filename, BenchmarkSummary)
         self.csv_writerow(self.summary_filename, summary)
-
-        self.logger.info(
-            f"Summary for model {self.model_name}: Success rate {success_rate:.2f}%, "
-            f"Average time {avg_time:.3f}s, Total tasks: {len(self.task_results)}"
-        )

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
@@ -75,7 +75,8 @@ class BaseVisionAgent(BaseAgent):
             raise Exception("Could not download weights")
 
     def _remove_weights(self, path: str):
-        # NOTE (jm) sometimes downloding weights bugs and creates a dir
+        # Sometimes redownloding weights bugged and created a dir
+        # so check also for dir and remove it in both cases
         if os.path.isdir(path):
             shutil.rmtree(path)
         elif os.path.isfile(path):

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
@@ -14,6 +14,7 @@
 
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -46,9 +47,10 @@ class BaseVisionAgent(BaseAgent):
                 self._weights_path / "vision" / "weights" / self.WEIGHTS_FILENAME
             )
             # make sure the file exists
-            if install_path.exists():
+            if install_path.exists() and install_path.is_file():
                 self._weights_path = install_path
             else:
+                self._remove_weights(path=install_path)
                 self._download_weights(install_path)
                 self._weights_path = install_path
 
@@ -72,8 +74,11 @@ class BaseVisionAgent(BaseAgent):
             self.logger.error("Could not download weights")
             raise Exception("Could not download weights")
 
-    def _remove_weights(self, path: Path):
-        if path.exists():
+    def _remove_weights(self, path: str):
+        # NOTE (jm) sometimes downloding weights bugs and creates a dir
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        elif os.path.isfile(path):
             os.remove(path)
 
     def stop(self):

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounded_sam.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounded_sam.py
@@ -40,9 +40,9 @@ class GroundedSamAgent(BaseVisionAgent):
         super().__init__(weights_path, ros2_name)
         try:
             self._segmenter = GDSegmenter(self._weights_path)
-        except Exception:
+        except Exception as e:
             self.logger.error(
-                "Could not load model. The weights might be corrupted. Redownloading..."
+                f"Could not load model : {e}. The weights might be corrupted. Redownloading..."
             )
             self._remove_weights(self.weight_path)
             self._init_weight_path()

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounding_dino.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounding_dino.py
@@ -69,7 +69,8 @@ class GroundingDinoAgent(BaseVisionAgent):
 
         ts = self.ros2_connector._node.get_clock().now().to_msg()
         response.detections.detections = [  # type: ignore
-            box.to_detection_msg(class_dict, ts) for box in boxes  # type: ignore
+            box.to_detection_msg(class_dict, ts)
+            for box in boxes  # type: ignore
         ]
         response.detections.header.stamp = ts  # type: ignore
         response.detections.detection_classes = class_array  # type: ignore

--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounding_dino.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/grounding_dino.py
@@ -35,9 +35,9 @@ class GroundingDinoAgent(BaseVisionAgent):
         super().__init__(weights_path, ros2_name)
         try:
             self._boxer = GDBoxer(self._weights_path)
-        except Exception:
+        except Exception as e:
             self.logger.error(
-                "Could not load model. The weights might be corrupted. Redownloading..."
+                f"Could not load model: {e}, The weights might be corrupted. Redownloading..."
             )
             self._remove_weights(self.weight_path)
             self._init_weight_path()
@@ -69,8 +69,7 @@ class GroundingDinoAgent(BaseVisionAgent):
 
         ts = self.ros2_connector._node.get_clock().now().to_msg()
         response.detections.detections = [  # type: ignore
-            box.to_detection_msg(class_dict, ts)  # type: ignore
-            for box in boxes
+            box.to_detection_msg(class_dict, ts) for box in boxes  # type: ignore
         ]
         response.detections.header.stamp = ts  # type: ignore
         response.detections.detection_classes = class_array  # type: ignore

--- a/src/rai_sim/rai_sim/simulation_bridge.py
+++ b/src/rai_sim/rai_sim/simulation_bridge.py
@@ -126,7 +126,7 @@ class SimulationConfig(BaseModel):
         """
         with open(base_config_path) as f:
             content = yaml.safe_load(f)
-        frame_id = content["frame_id"]
+        frame_id = content.get("frame_id", "odom")
         entities = [
             Entity(
                 name=entity["name"],

--- a/tests/rai_sim/test_o3de_bridge.py
+++ b/tests/rai_sim/test_o3de_bridge.py
@@ -159,15 +159,16 @@ class TestO3DExROS2Bridge(unittest.TestCase):
         self.assertIsNone(self.bridge.current_sim_process)
 
     def test_shutdown_robotic_stack(self):
-        self.bridge.current_robotic_stack_process = MagicMock()
-        self.bridge.current_robotic_stack_process.poll.return_value = 0
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 0
+
+        self.bridge.current_robotic_stack_process = mock_process
 
         self.bridge._shutdown_robotic_stack()
 
-        self.bridge.current_robotic_stack_process.send_signal.assert_called_once_with(
-            signal.SIGINT
-        )
-        self.bridge.current_robotic_stack_process.wait.assert_called_once()
+        mock_process.send_signal.assert_called_once_with(signal.SIGINT)
+        mock_process.wait.assert_called_once()
+        self.assertIsNone(self.bridge.current_robotic_stack_process)
 
     def test_get_available_spawnable_names(self):
         # Mock the response


### PR DESCRIPTION
## Purpose
Manipulation o3de benchmark is not working properly after some recent PRs.

## Proposed Changes
- Changed shutdown of o3de binary and robotic stack, now after SIGINT signal does not close processes, send SIGTERM, if this does not work, KILL. This ensures closing all dandling processes after finishing benchmark.

- Redownloading weights was bugged and resulted in always redownloding weights if anything went wrong (for example cuda out of memory). On top of that this redownload created nested dir in place of previous weights which resulted in further crashes.
refactored logic to always remove file or dir before redownloding.

- Keep alive param now set to 10 seconds when running model with ollama. This prevents ollama from consuming resources after benchmark.

- Assigning "odom" as default value of frame_id for entities loaded from configs. Sending proper prefab name to spawn entity service

- Adjusted logging

- Added utils for common benchmark logic

- Catching recurssion limit error in manipulation bench

## Issues
https://github.com/RobotecAI/rai/issues/555
https://github.com/RobotecAI/rai/issues/556


## Testing
1. Run `python src/rai_bench/rai_bench/examples/test_models.py`
with settings:
```python
 models_name = ["qwen2.5:7b", "llama3.2"]
    vendors = ["ollama", "ollama"]
    benchmarks = ["manipulation_o3de"]
    extra_tool_calls = [5]
    repeats = 1
```
2. Check if all processes consuming VRAM (nvidia-smi check) are closed after qwen iteration ends.
3. Check if entites spawn correctly ( on the table )
4. Check if logs are properly stored
5. Remove weights and check if they are downloaded properly
