### PR TITLE
ci: standardize runtime

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     runs-on:
-      - ubuntu-latest
+      - ubuntu-24.04
     container:
       image: python:3.12-slim
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Purpose

Standardize runtime between ci jobs.

## Proposed Changes

[ci: use ubuntu-24.04 for running ci jobs](https://github.com/RobotecAI/rai/commit/dfa11143dfd33bf81ab5ee32f030a3a9d9ca0c60)

## Issues

-   Links to relevant issues

## Testing

-   How was it tested, what were the results?
