### PR TITLE
fix!: make asr and tts agents compliant to new api

### DIFF
--- a/src/rai_core/rai/communication/ros2/__init__.py
+++ b/src/rai_core/rai/communication/ros2/__init__.py
@@ -21,7 +21,6 @@ if importlib.util.find_spec("rclpy") is None:
 
 from .api import (
     IROS2Message,  # TODO: IROS2Message should not be a part of the public API
-    TopicConfig,  # TODO: TopicConfig should not be a part of the public API
 )
 from .connectors import ROS2Connector, ROS2HRIConnector
 from .context import ROS2Context
@@ -35,7 +34,6 @@ __all__ = [
     "ROS2HRIConnector",
     "ROS2HRIMessage",
     "ROS2Message",
-    "TopicConfig",
     "wait_for_ros2_actions",
     "wait_for_ros2_services",
     "wait_for_ros2_topics",

--- a/src/rai_core/rai/communication/ros2/api/__init__.py
+++ b/src/rai_core/rai/communication/ros2/api/__init__.py
@@ -22,15 +22,13 @@ from .conversion import (
     ros2_message_to_dict,
 )
 from .service import ROS2ServiceAPI
-from .topic import ConfigurableROS2TopicAPI, ROS2TopicAPI, TopicConfig
+from .topic import ROS2TopicAPI
 
 __all__ = [
-    "ConfigurableROS2TopicAPI",
     "IROS2Message",
     "ROS2ActionAPI",
     "ROS2ServiceAPI",
     "ROS2TopicAPI",
-    "TopicConfig",
     "convert_ros_img_to_base64",
     "convert_ros_img_to_cv2mat",
     "convert_ros_img_to_ndarray",

--- a/src/rai_core/rai/communication/ros2/api/action.py
+++ b/src/rai_core/rai/communication/ros2/api/action.py
@@ -32,14 +32,9 @@ from typing import (
 
 import rclpy
 import rclpy.action
-import rclpy.callback_groups
-import rclpy.executors
 import rclpy.node
-import rclpy.qos
-import rclpy.subscription
 import rclpy.task
 import rosidl_runtime_py.set_message
-import rosidl_runtime_py.utilities
 from action_msgs.srv import CancelGoal
 from rclpy.action import ActionClient, CancelResponse, GoalResponse
 from rclpy.action.client import ClientGoalHandle

--- a/src/rai_core/rai/communication/ros2/api/base.py
+++ b/src/rai_core/rai/communication/ros2/api/base.py
@@ -24,16 +24,8 @@ from typing import (
 )
 
 import rclpy
-import rclpy.action
-import rclpy.callback_groups
-import rclpy.executors
 import rclpy.node
-import rclpy.qos
-import rclpy.subscription
-import rclpy.task
-import rosidl_runtime_py.convert
 import rosidl_runtime_py.set_message
-import rosidl_runtime_py.utilities
 from rclpy.qos import (
     DurabilityPolicy,
     HistoryPolicy,


### PR DESCRIPTION
## Purpose

Make asr and tts agents compliant to new api

## Proposed Changes

fixes agents to use new api, removes unused and deprecated topic confiugrable api

## Issues

https://github.com/RobotecAI/rai/issues/559

## Testing

Following script has been run, with `TextToSpeechAgent` and `SpeechRecognitionAgent`.

```python
from rai.communication.ros2 import ROS2Context
from rai_s2s.s2s.agents.s2s_agent import SpeechToSpeechAgent
from rai_s2s.asr.agents.asr_agent import SpeechRecognitionAgent
from rai_s2s.tts.agents.tts_agent import TextToSpeechAgent
from rai_s2s.s2s.agents.ros2s2s_agent import ROS2S2SAgent
from rai_s2s.asr.models import OpenAIWhisper, SileroVAD
from rai_s2s.sound_device import SoundDeviceConfig
from rai_s2s import OpenTTS

from rai.agents import AgentRunner


@ROS2Context()
def main():
    speaker_config = SoundDeviceConfig(
        stream=True,
        is_output=True,
        device_name="Sennheiser USB headset: Audio (hw:1,0)",
        # device_name="Jabra Speak2 40 MS: USB Audio (hw:2,0)",
        # device_name="default",
    )

    microphone_config = SoundDeviceConfig(
        stream=True,
        channels=1,
        device_name="default",
        consumer_sampling_rate=16000,
        dtype="int16",
        is_input=True,
    )

    # whisper = LocalWhisper("tiny", 16000)
    whisper = OpenAIWhisper("gpt-4o-mini-transcribe", 16000)
    vad = SileroVAD(16000, 0.5)
    tts = OpenTTS()

    agent = TextToSpeechAgent(
        ros2_name="name",
        # from_human_topic="/from_human",
        # to_human_topic="/to_human",
        # microphone_config=microphone_config,
        speaker_config=speaker_config,
        # transcription_model=whisper,
        # vad=vad,
        tts=tts,
    )

    runner = AgentRunner([agent])
    runner.run_and_wait_for_shutdown()


if __name__ == "__main__":
    main()
```
