### PR TITLE
feat(LangChainAgent): stream_response

### DIFF
--- a/src/rai_core/rai/agents/langchain/agent.py
+++ b/src/rai_core/rai/agents/langchain/agent.py
@@ -53,6 +53,8 @@ class LangChainAgent(BaseAgent):
         Dict of target_name: connector. Agent will send it's output to these targets using connectors.
     runnable : Runnable
         LangChain runnable that will be used to generate output.
+    stream_response : bool, optional
+        If True, the agent will stream the response to the target connectors. Make sure that the runnable is configured to stream.
     state : BaseState | None, optional
         State to seed the LangChain runnable. If None - empty state is used.
     new_message_behavior : newMessageBehaviorType, optional

--- a/src/rai_core/rai/agents/langchain/agent.py
+++ b/src/rai_core/rai/agents/langchain/agent.py
@@ -107,6 +107,7 @@ class LangChainAgent(BaseAgent):
         self,
         target_connectors: Dict[str, HRIConnector[HRIMessage]],
         runnable: Runnable[Any, Any],
+        stream_response: bool,
         state: BaseState | None = None,
         new_message_behavior: newMessageBehaviorType = "interrupt_keep_last",
         max_size: int = 100,
@@ -114,6 +115,7 @@ class LangChainAgent(BaseAgent):
         super().__init__()
         self.logger = logging.getLogger(__name__)
         self.agent = runnable
+        self.stream_response = stream_response
         self.new_message_behavior: newMessageBehaviorType = new_message_behavior
         self.tracing_callbacks = get_tracing_callbacks()
         self.state = state or ReActAgentState(messages=[])
@@ -121,6 +123,7 @@ class LangChainAgent(BaseAgent):
             connectors=target_connectors,
             aggregate_chunks=True,
             logger=self.logger,
+            stream_response=stream_response,
         )
 
         self._received_messages: Deque[HRIMessage] = deque()
@@ -182,8 +185,8 @@ class LangChainAgent(BaseAgent):
     def _run_agent(self):
         if len(self._received_messages) == 0:
             self._agent_ready_event.set()
-            self.logger.info("Waiting for messages...")
-            time.sleep(0.5)
+            self.logger.debug("Waiting for messages...")
+            time.sleep(0.1)
             return
         self._agent_ready_event.clear()
         try:

--- a/src/rai_core/rai/agents/langchain/agent.py
+++ b/src/rai_core/rai/agents/langchain/agent.py
@@ -109,7 +109,7 @@ class LangChainAgent(BaseAgent):
         self,
         target_connectors: Dict[str, HRIConnector[HRIMessage]],
         runnable: Runnable[Any, Any],
-        stream_response: bool,
+        stream_response: bool = True,
         state: BaseState | None = None,
         new_message_behavior: newMessageBehaviorType = "interrupt_keep_last",
         max_size: int = 100,

--- a/src/rai_core/rai/agents/langchain/react_agent.py
+++ b/src/rai_core/rai/agents/langchain/react_agent.py
@@ -34,6 +34,7 @@ class ReActAgent(LangChainAgent):
         tools: Optional[List[BaseTool]] = None,
         state: Optional[ReActAgentState] = None,
         system_prompt: Optional[str | SystemMultimodalMessage] = None,
+        stream_response: bool = True,
     ):
         runnable = create_react_runnable(
             llm=llm, tools=tools, system_prompt=system_prompt
@@ -42,4 +43,5 @@ class ReActAgent(LangChainAgent):
             target_connectors=target_connectors,
             runnable=runnable,
             state=state,
+            stream_response=stream_response,
         )


### PR DESCRIPTION
## Purpose

When using LangChainAgent with llm configured without streaming=True, the output would be (silently) discarded. 
This PR aims to improve the behavior with flawed configuration.

## Proposed Changes

- stream_response parameter
- logging error on flawed configurations

## Issues

-   Links to relevant issues

## Testing

terminal 1
```python
from rai import get_llm_model, AgentRunner
from rai.agents import ReActAgent
from rai.communication.ros2 import ROS2HRIConnector, ROS2HRIMessage
from rai.communication.ros2 import ROS2Context

@ROS2Context()
def main():
    connector = ROS2HRIConnector() # Initialize communication over ROS 2

    agent = ReActAgent(
        # configure output
        target_connectors={
            "/to_human": connector,
        },
        llm=get_llm_model("simple_model", streaming=True), # set to True and False
        stream_response=True,
    )
    # configure input
    agent.subscribe_source("/from_human", connector)

    runner = AgentRunner(agents=[agent])
    runner.run_and_wait_for_shutdown()

if __name__ == "__main__":
    main()
```
terminal 2
```bash
ros2 topic echo /to_human rai_interfaces/msg/HRIMessage
```
terminal 3
```bash
ros2 topic pub /from_human rai_interfaces/msg/HRIMessage "{\"text\": \"Move the arm to 0, 0, 0?\"}" --once
```
