### PR TITLE
ci: install rai packages in docs ci

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install --with docs
 
       - name: Install rai packages
-        run: pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
+        run: poetry run pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
 
       - name: Build docs
         shell: bash

--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install python dependencies
         run: poetry install --with docs
 
+      - name: Install rai packages
+        run: pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
+
       - name: Build docs
         shell: bash
         run: |

--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install python dependencies
         run: poetry install --with docs
 
+      - name: Install rai packages
+        run: pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
+
       - name: Build and Deploy
         shell: bash
         run: |

--- a/.github/workflows/mkdocs-publish.yml
+++ b/.github/workflows/mkdocs-publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install --with docs
 
       - name: Install rai packages
-        run: pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
+        run: poetry run pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps
 
       - name: Build and Deploy
         shell: bash


### PR DESCRIPTION
## Purpose

mkdocs needs all the rai package installed to be available to mkdocstrings. Installing all the packages with the dependencies take a lot of time and doesn't fit on GitHub runners.

## Proposed Changes

Install rai_ packages with --no-deps flag.

## Issues

-   Links to relevant issues

## Testing

-   How was it tested, what were the results?
