### PR TITLE
fix: Increase `move_to_point` tool timeout

### DIFF
--- a/src/rai_core/rai/tools/ros2/manipulation/custom.py
+++ b/src/rai_core/rai/tools/ros2/manipulation/custom.py
@@ -117,7 +117,7 @@ class MoveToPointTool(BaseROS2Tool):
         self.connector.node.get_logger().debug(
             f"Calling ManipulatorMoveTo service with request: x={request.target_pose.pose.position.x:.2f}, y={request.target_pose.pose.position.y:.2f}, z={request.target_pose.pose.position.z:.2f}"
         )
-        response = get_future_result(future, timeout_sec=5.0)
+        response = get_future_result(future, timeout_sec=20.0)
         if response is None:
             return f"Service call failed for point ({x:.2f}, {y:.2f}, {z:.2f})."
 


### PR DESCRIPTION
## Purpose

- In the manipulation demo, most of the `move_to_point` tool calls fail because the timeout is reached, even though the arm performs the desired movement.

## Proposed Changes

Increase the service call timeout in `move_to_point` tool from unrealistic 5.0 seconds to 20 seconds.

## Issues

N/A

## Testing

Ran the manipulation demo and asked the agent to pick up a carrot.
