### PR TITLE
feat: Dual agent + tracing tags

### DIFF
--- a/src/rai_bench/rai_bench/__init__.py
+++ b/src/rai_bench/rai_bench/__init__.py
@@ -14,6 +14,7 @@
 from .test_models import (
     ManipulationO3DEBenchmarkConfig,
     ToolCallingAgentBenchmarkConfig,
+    test_dual_agents,
     test_models,
 )
 from .utils import (
@@ -30,5 +31,6 @@ __all__ = [
     "get_llm_for_benchmark",
     "parse_manipulation_o3de_benchmark_args",
     "parse_tool_calling_benchmark_args",
+    "test_dual_agents",
     "test_models",
 ]

--- a/src/rai_bench/rai_bench/agents.py
+++ b/src/rai_bench/rai_bench/agents.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from functools import partial
+from typing import List, Optional
+
+from langchain.chat_models.base import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+)
+from langchain_core.tools import BaseTool
+from langgraph.graph import START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.prebuilt.tool_node import tools_condition
+from rai.agents.langchain.core.conversational_agent import State, agent
+from rai.agents.langchain.core.tool_runner import ToolRunner
+
+
+def multimodal_to_tool_bridge(state: State):
+    """Node of langchain workflow designed to bridge
+    nodes with llms. Removing images for context
+    """
+
+    cleaned_messages: List[BaseMessage] = []
+    for msg in state["messages"]:
+        if isinstance(msg, HumanMessage):
+            # Remove images but keep the direct request
+            if isinstance(msg.content, list):
+                # Extract text only
+                text_parts = [
+                    part.get("text", "")
+                    for part in msg.content
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ]
+                if text_parts:
+                    cleaned_messages.append(HumanMessage(content=" ".join(text_parts)))
+            else:
+                cleaned_messages.append(msg)
+        elif isinstance(msg, AIMessage):
+            # Keep AI messages for context
+            cleaned_messages.append(msg)
+
+    state["messages"] = cleaned_messages
+    return state
+
+
+def create_multimodal_to_tool_agent(
+    multimodal_llm: BaseChatModel,
+    tool_llm: BaseChatModel,
+    tools: List[BaseTool],
+    multimodal_system_prompt: str,
+    tool_system_prompt: str,
+    logger: Optional[logging.Logger] = None,
+    debug: bool = False,
+) -> CompiledStateGraph:
+    """
+    Creates an agent flow where inputs first go to a multimodal LLM,
+    then its output is passed to a tool-calling LLM.
+    Can be usefull when multimodal llm does not provide tool calling.
+
+    Args:
+        tools: List of tools available to the tool agent
+
+    Returns:
+        Compiled state graph
+    """
+    _logger = None
+    if logger:
+        _logger = logger
+    else:
+        _logger = logging.getLogger(__name__)
+
+    _logger.info("Creating multimodal to tool agent flow")
+
+    tool_llm_with_tools = tool_llm.bind_tools(tools)
+    tool_node = ToolRunner(tools=tools, logger=_logger)
+
+    workflow = StateGraph(State)
+    workflow.add_node(
+        "thinker",
+        partial(agent, multimodal_llm, _logger, multimodal_system_prompt),
+    )
+    # context bridge for altering the
+    workflow.add_node(
+        "context_bridge",
+        multimodal_to_tool_bridge,
+    )
+    workflow.add_node(
+        "tool_agent",
+        partial(agent, tool_llm_with_tools, _logger, tool_system_prompt),
+    )
+    workflow.add_node("tools", tool_node)
+
+    workflow.add_edge(START, "thinker")
+    workflow.add_edge("thinker", "context_bridge")
+    workflow.add_edge("context_bridge", "tool_agent")
+
+    workflow.add_conditional_edges(
+        "tool_agent",
+        tools_condition,
+    )
+
+    # Tool node goes back to tool agent
+    workflow.add_edge("tools", "tool_agent")
+
+    app = workflow.compile(debug=debug)
+    _logger.info("Multimodal to tool agent flow created")
+    return app

--- a/src/rai_bench/rai_bench/base_benchmark.py
+++ b/src/rai_bench/rai_bench/base_benchmark.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
+from uuid import UUID
 
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel, Field
@@ -110,13 +111,15 @@ class BaseBenchmark(ABC):
             writer.writerow(row)
 
     @abstractmethod
-    def run_next(self, agent: CompiledStateGraph) -> None:
+    def run_next(self, agent: CompiledStateGraph, experiment_id: UUID) -> None:
         """Run the next task/scenario of the benchmark.
 
         Parameters
         ----------
         agent : CompiledStateGraph
             LangChain tool calling agent.
+        experiment_id : uuid.UUID
+            uniqe identifier for whole experiment for tracing purposes.
         """
         pass
 

--- a/src/rai_bench/rai_bench/examples/dual_agent.py
+++ b/src/rai_bench/rai_bench/examples/dual_agent.py
@@ -15,6 +15,7 @@ from langchain_community.chat_models import ChatOllama
 from langchain_openai import ChatOpenAI
 
 from rai_bench import (
+    ManipulationO3DEBenchmarkConfig,
     ToolCallingAgentBenchmarkConfig,
     test_dual_agents,
 )
@@ -34,11 +35,19 @@ if __name__ == "__main__":
         repeats=15,
     )
 
+    man_conf = ManipulationO3DEBenchmarkConfig(
+        o3de_config_path="src/rai_bench/rai_bench/manipulation_o3de/predefined/configs/o3de_config.yaml",  # path to your o3de config
+        levels=[  # define what difficulty of tasks to include in benchmark
+            "trivial",
+        ],
+        repeats=1,  # how many times to repeat
+    )
+
     out_dir = "src/rai_bench/rai_bench/experiments/dual_agents/"
 
     test_dual_agents(
         multimodal_llms=[m_llm],
         tool_calling_models=[tool_llm],
-        benchmark_configs=[tool_conf],
+        benchmark_configs=[man_conf, tool_conf],
         out_dir=out_dir,
     )

--- a/src/rai_bench/rai_bench/examples/dual_agent.py
+++ b/src/rai_bench/rai_bench/examples/dual_agent.py
@@ -1,0 +1,44 @@
+# # Copyright (C) 2025 Robotec.AI
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #         http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+from langchain_community.chat_models import ChatOllama
+from langchain_openai import ChatOpenAI
+
+from rai_bench import (
+    ToolCallingAgentBenchmarkConfig,
+    test_dual_agents,
+)
+
+if __name__ == "__main__":
+    # Define models you want to benchmark
+    model_name = "gemma3:4b"
+    m_llm = ChatOllama(
+        model=model_name, base_url="http://localhost:11434", keep_alive=30
+    )
+
+    tool_llm = ChatOpenAI(model="gpt-4o-mini", base_url="https://api.openai.com/v1/")
+    # Define benchmarks that will be used
+    tool_conf = ToolCallingAgentBenchmarkConfig(
+        extra_tool_calls=0,  # how many extra tool calls allowed to still pass
+        task_types=["spatial_reasoning"],
+        repeats=15,
+    )
+
+    out_dir = "src/rai_bench/rai_bench/experiments/dual_agents/"
+
+    test_dual_agents(
+        multimodal_llms=[m_llm],
+        tool_calling_models=[tool_llm],
+        benchmark_configs=[tool_conf],
+        out_dir=out_dir,
+    )

--- a/src/rai_bench/rai_bench/examples/manipulation_o3de.py
+++ b/src/rai_bench/rai_bench/examples/manipulation_o3de.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from rai_bench import define_benchmark_logger, parse_manipulation_o3de_benchmark_args
 from rai_bench.manipulation_o3de import get_scenarios, run_benchmark
+from rai_bench.utils import get_llm_for_benchmark
 
 if __name__ == "__main__":
     args = parse_manipulation_o3de_benchmark_args()
@@ -26,9 +27,13 @@ if __name__ == "__main__":
     # import ready scenarios
     scenarios = get_scenarios(logger=bench_logger, levels=args.levels)
 
-    run_benchmark(
+    llm = get_llm_for_benchmark(
         model_name=args.model_name,
         vendor=args.vendor,
+    )
+
+    run_benchmark(
+        llm=llm,
         out_dir=experiment_dir,
         o3de_config_path=args.o3de_config_path,
         scenarios=scenarios,

--- a/src/rai_bench/rai_bench/examples/tool_calling_agent.py
+++ b/src/rai_bench/rai_bench/examples/tool_calling_agent.py
@@ -22,6 +22,7 @@ from rai_bench.tool_calling_agent import (
     get_tasks,
     run_benchmark,
 )
+from rai_bench.utils import get_llm_for_benchmark
 
 if __name__ == "__main__":
     args = parse_tool_calling_benchmark_args()
@@ -36,9 +37,14 @@ if __name__ == "__main__":
     )
     for task in tasks:
         task.set_logger(bench_logger)
-    run_benchmark(
+
+    llm = get_llm_for_benchmark(
         model_name=args.model_name,
         vendor=args.vendor,
+    )
+
+    run_benchmark(
+        llm=llm,
         out_dir=args.out_dir,
         tasks=tasks,
         bench_logger=bench_logger,

--- a/src/rai_bench/rai_bench/manipulation_o3de/__init__.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .benchmark import run_benchmark
+from .benchmark import run_benchmark, run_benchmark_dual_agent
 from .predefined.scenarios import get_scenarios
 
-__all__ = ["get_scenarios", "run_benchmark"]
+__all__ = ["get_scenarios", "run_benchmark", "run_benchmark_dual_agent"]

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -261,7 +261,12 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
             config: RunnableConfig = {
                 "run_id": run_id,
                 "callbacks": callbacks,
-                "tags": [scenario.level, self.model_name],
+                "tags": [
+                    f"experiment-id:{experiment_id}",
+                    "benchmark:manipulation-o3de",
+                    self.model_name,
+                    f"scenario-difficulty:{scenario.level}",
+                ],
                 "recursion_limit": 50,
             }
             tool_calls_num = 0
@@ -303,7 +308,8 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
                 self.logger.error(msg=f"Task timeout: {e}")
             except GraphRecursionError as e:
                 self.logger.error(msg=f"Reached recursion limit {e}")
-
+            except Exception as e:
+                self.logger.error(msg=f"Unexpected errot occured: {e}")
             te = time.perf_counter()
             try:
                 score = scenario.task.calculate_score(self.simulation_bridge)
@@ -318,6 +324,7 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
                     scene_config_path=scenario.scene_config_path,
                     model_name=self.model_name,
                     score=score,
+                    level=scenario.level,
                     total_time=total_time,
                     number_of_tool_calls=tool_calls_num,
                 )

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -16,7 +16,7 @@ import statistics
 import time
 import uuid
 from pathlib import Path
-from typing import List, TypeVar
+from typing import List, Optional, TypeVar
 
 import rclpy
 from langchain.tools import BaseTool
@@ -465,12 +465,14 @@ def run_benchmark_dual_agent(
     o3de_config_path: str,
     experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
+    m_system_prompt: Optional[str] = None,
+    tool_system_prompt: Optional[str] = None,
 ):
     connector, o3de, benchmark, tools = _setup_benchmark_environment(
         o3de_config_path, model_name, scenarios, out_dir, bench_logger
     )
-    tool_system_prompt = (
-        "Based on the conversation call the tool with appropriate arguments"
+    basic_tool_system_prompt = (
+        "Based on the conversation call the tools with appropriate arguments"
     )
     try:
         for scenario in scenarios:
@@ -478,8 +480,14 @@ def run_benchmark_dual_agent(
                 multimodal_llm=multimodal_llm,
                 tool_llm=tool_calling_llm,
                 tools=tools,
-                multimodal_system_prompt=scenario.task.system_prompt,
-                tool_system_prompt=tool_system_prompt,
+                multimodal_system_prompt=(
+                    m_system_prompt if m_system_prompt else scenario.task.system_prompt
+                ),
+                tool_system_prompt=(
+                    tool_system_prompt
+                    if tool_system_prompt
+                    else basic_tool_system_prompt
+                ),
                 logger=bench_logger,
                 debug=True,
             )

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -52,6 +52,7 @@ from rai_bench.manipulation_o3de.results_tracking import (
     ScenarioResult,
 )
 from rai_bench.results_processing.langfuse_scores_tracing import ScoreTracingHandler
+from rai_bench.utils import get_llm_model_name
 from rai_sim.o3de.o3de_bridge import (
     O3DEngineArmManipulationBridge,
     O3DExROS2SimulationConfig,
@@ -422,15 +423,14 @@ def _setup_benchmark_environment(
 
 def run_benchmark(
     llm: BaseChatModel,
-    model_name: str,
     out_dir: Path,
     o3de_config_path: str,
     scenarios: List[Scenario],
-    experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
+    experiment_id: uuid.UUID = uuid.uuid4(),
 ):
     connector, o3de, benchmark, tools = _setup_benchmark_environment(
-        o3de_config_path, model_name, scenarios, out_dir, bench_logger
+        o3de_config_path, get_llm_model_name(llm), scenarios, out_dir, bench_logger
     )
     try:
         for scenario in scenarios:
@@ -459,17 +459,20 @@ def run_benchmark(
 def run_benchmark_dual_agent(
     multimodal_llm: BaseChatModel,
     tool_calling_llm: BaseChatModel,
-    model_name: str,
     out_dir: Path,
     scenarios: List[Scenario],
     o3de_config_path: str,
-    experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
+    experiment_id: uuid.UUID = uuid.uuid4(),
     m_system_prompt: Optional[str] = None,
     tool_system_prompt: Optional[str] = None,
 ):
     connector, o3de, benchmark, tools = _setup_benchmark_environment(
-        o3de_config_path, model_name, scenarios, out_dir, bench_logger
+        o3de_config_path,
+        get_llm_model_name(multimodal_llm),
+        scenarios,
+        out_dir,
+        bench_logger,
     )
     basic_tool_system_prompt = (
         "Based on the conversation call the tools with appropriate arguments"
@@ -489,7 +492,6 @@ def run_benchmark_dual_agent(
                     else basic_tool_system_prompt
                 ),
                 logger=bench_logger,
-                debug=True,
             )
 
             benchmark.run_next(agent=agent, experiment_id=experiment_id)

--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -34,7 +34,6 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from rai.agents.langchain.core import (
     create_conversational_agent,
-    create_multimodal_to_tool_agent,
 )
 from rai.communication.ros2.connectors import ROS2Connector
 from rai.messages import HumanMultimodalMessage
@@ -46,6 +45,7 @@ from rai.tools.ros2 import (
 )
 from rai_open_set_vision.tools import GetGrabbingPointTool
 
+from rai_bench.agents import create_multimodal_to_tool_agent
 from rai_bench.base_benchmark import BaseBenchmark, RunSummary, TimeoutException
 from rai_bench.manipulation_o3de.interfaces import Task
 from rai_bench.manipulation_o3de.results_tracking import (

--- a/src/rai_bench/rai_bench/manipulation_o3de/predefined/scenarios.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/predefined/scenarios.py
@@ -89,6 +89,7 @@ def trivial_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=move_to_left_tasks,
         scene_configs=scene_configs,
         scene_configs_paths=scene_configs_paths,
+        level="trivial",
     )
 
     return [*easy_move_to_left_scenarios, *easy_place_objects_scenarios]
@@ -175,6 +176,7 @@ def easy_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=[task],
         scene_configs=scene_configs,
         scene_configs_paths=scene_configs_paths,
+        level="easy",
     )
 
     return [
@@ -253,6 +255,7 @@ def medium_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         scene_configs=medium_scene_configs,
         scene_configs_paths=medium_scene_configs_paths,
         logger=logger,
+        level="medium",
     )
 
     # place cubes
@@ -262,6 +265,7 @@ def medium_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         scene_configs=medium_scene_configs,
         scene_configs_paths=medium_scene_configs_paths,
         logger=logger,
+        level="medium",
     )
 
     # build tower task
@@ -376,6 +380,7 @@ def hard_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=move_to_left_tasks,
         scene_configs=hard_scene_configs,
         scene_configs_paths=hard_scene_configs_paths,
+        level="hard",
     )
 
     # place cubes
@@ -384,6 +389,7 @@ def hard_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=[task],
         scene_configs=hard_scene_configs,
         scene_configs_paths=hard_scene_configs_paths,
+        level="hard",
     )
 
     # build tower task
@@ -400,6 +406,7 @@ def hard_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=build_tower_tasks,
         scene_configs=medium_scene_configs,
         scene_configs_paths=medium_scene_configs_paths,
+        level="hard",
     )
 
     # group object task
@@ -483,6 +490,7 @@ def very_hard_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         scene_configs=hard_scene_configs,
         scene_configs_paths=hard_scene_configs_paths,
         logger=logger,
+        level="very_hard",
     )
 
     # group object task
@@ -503,6 +511,7 @@ def very_hard_scenarios(logger: logging.Logger | None) -> List[Scenario]:
         tasks=group_object_tasks,
         scene_configs=hard_scene_configs,
         scene_configs_paths=hard_scene_configs_paths,
+        level="very_hard",
     )
     return [
         *build_tower_scenarios,

--- a/src/rai_bench/rai_bench/manipulation_o3de/results_tracking.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/results_tracking.py
@@ -27,6 +27,7 @@ class ScenarioResult(BaseModel):
     score: float = Field(
         ..., description="Value between 0 and 1, describing the task score."
     )
+    level: str = Field(..., description="Difficulty of the scenario")
     total_time: float = Field(..., description="Total time taken to complete the task.")
     number_of_tool_calls: int = Field(
         ..., description="Number of tool calls made during the task."

--- a/src/rai_bench/rai_bench/test_models.py
+++ b/src/rai_bench/rai_bench/test_models.py
@@ -116,26 +116,26 @@ def test_dual_agents(
                             multimodal_llm=m_llm,
                             tool_calling_llm=tool_llm,
                             model_name=m_llm.get_name(),
-                            out_dir=curr_out_dir,
+                            out_dir=Path(curr_out_dir),
                             tasks=tool_calling_tasks,
                             experiment_id=experiment_id,
                             bench_logger=bench_logger,
                         )
-                    # NOTE manipualtion ahs not been tested yet for dual agent
-                    # elif isinstance(bench_conf, ManipulationO3DEBenchmarkConfig):
-                    #     manipulation_o3de_scenarios = manipulation_o3de.get_scenarios(
-                    #         levels=bench_conf.levels,
-                    #         logger=bench_logger,
-                    #     )
-                    #     manipulation_o3de.run_benchmark_dual_agent(
-                    #         llm=llm,
-                    #         model_name=model_name,
-                    #         out_dir=Path(curr_out_dir),
-                    #         o3de_config_path=bench_conf.o3de_config_path,
-                    #         scenarios=manipulation_o3de_scenarios,
-                    #         experiment_id=experiment_id,
-                    #         bench_logger=bench_logger,
-                    #     )
+                    elif isinstance(bench_conf, ManipulationO3DEBenchmarkConfig):
+                        manipulation_o3de_scenarios = manipulation_o3de.get_scenarios(
+                            levels=bench_conf.levels,
+                            logger=bench_logger,
+                        )
+                        manipulation_o3de.run_benchmark_dual_agent(
+                            multimodal_llm=m_llm,
+                            tool_calling_llm=tool_llm,
+                            model_name=m_llm.get_name(),
+                            out_dir=Path(curr_out_dir),
+                            o3de_config_path=bench_conf.o3de_config_path,
+                            scenarios=manipulation_o3de_scenarios,
+                            experiment_id=experiment_id,
+                            bench_logger=bench_logger,
+                        )
                 except Exception as e:
                     bench_logger.critical(f"BENCHMARK RUN FAILED: {e}")
                     raise e
@@ -188,7 +188,7 @@ def test_models(
                             tool_calling_agent.run_benchmark(
                                 llm=llm,
                                 model_name=model_name,
-                                out_dir=curr_out_dir,
+                                out_dir=Path(curr_out_dir),
                                 tasks=tool_calling_tasks,
                                 experiment_id=experiment_id,
                                 bench_logger=bench_logger,

--- a/src/rai_bench/rai_bench/test_models.py
+++ b/src/rai_bench/rai_bench/test_models.py
@@ -123,7 +123,6 @@ def test_dual_agents(
                             tool_calling_llm=tool_llm,
                             m_system_prompt=m_system_prompt,
                             tool_system_prompt=tool_system_prompt,
-                            model_name=get_llm_model_name(m_llm),
                             out_dir=Path(curr_out_dir),
                             tasks=tool_calling_tasks,
                             experiment_id=experiment_id,
@@ -137,7 +136,6 @@ def test_dual_agents(
                         manipulation_o3de.run_benchmark_dual_agent(
                             multimodal_llm=m_llm,
                             tool_calling_llm=tool_llm,
-                            model_name=m_llm.get_name(),
                             out_dir=Path(curr_out_dir),
                             o3de_config_path=bench_conf.o3de_config_path,
                             scenarios=manipulation_o3de_scenarios,
@@ -195,7 +193,6 @@ def test_models(
                             )
                             tool_calling_agent.run_benchmark(
                                 llm=llm,
-                                model_name=model_name,
                                 out_dir=Path(curr_out_dir),
                                 tasks=tool_calling_tasks,
                                 experiment_id=experiment_id,
@@ -210,7 +207,6 @@ def test_models(
                             )
                             manipulation_o3de.run_benchmark(
                                 llm=llm,
-                                model_name=model_name,
                                 out_dir=Path(curr_out_dir),
                                 o3de_config_path=bench_conf.o3de_config_path,
                                 scenarios=manipulation_o3de_scenarios,

--- a/src/rai_bench/rai_bench/test_models.py
+++ b/src/rai_bench/rai_bench/test_models.py
@@ -23,7 +23,11 @@ from pydantic import BaseModel
 
 import rai_bench.manipulation_o3de as manipulation_o3de
 import rai_bench.tool_calling_agent as tool_calling_agent
-from rai_bench.utils import define_benchmark_logger, get_llm_for_benchmark
+from rai_bench.utils import (
+    define_benchmark_logger,
+    get_llm_for_benchmark,
+    get_llm_model_name,
+)
 
 
 class BenchmarkConfig(BaseModel):
@@ -80,6 +84,8 @@ def test_dual_agents(
     tool_calling_models: List[BaseChatModel],
     benchmark_configs: List[BenchmarkConfig],
     out_dir: str,
+    m_system_prompt: Optional[str] = None,
+    tool_system_prompt: Optional[str] = None,
 ):
     if len(multimodal_llms) != len(tool_calling_models):
         raise ValueError(
@@ -100,7 +106,7 @@ def test_dual_agents(
                     + "/"
                     + bench_conf.name
                     + "/"
-                    + m_llm.get_name()
+                    + get_llm_model_name(m_llm)
                     + "/"
                     + str(u)
                 )
@@ -115,7 +121,9 @@ def test_dual_agents(
                         tool_calling_agent.run_benchmark_dual_agent(
                             multimodal_llm=m_llm,
                             tool_calling_llm=tool_llm,
-                            model_name=m_llm.get_name(),
+                            m_system_prompt=m_system_prompt,
+                            tool_system_prompt=tool_system_prompt,
+                            model_name=get_llm_model_name(m_llm),
                             out_dir=Path(curr_out_dir),
                             tasks=tool_calling_tasks,
                             experiment_id=experiment_id,

--- a/src/rai_bench/rai_bench/tool_calling_agent/__init__.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .benchmark import run_benchmark
+from .benchmark import run_benchmark, run_benchmark_dual_agent
 from .predefined.tasks import get_tasks
 
-__all__ = ["get_tasks", "run_benchmark"]
+__all__ = ["get_tasks", "run_benchmark", "run_benchmark_dual_agent"]

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -25,10 +25,10 @@ from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from rai.agents.langchain.core import (
     create_conversational_agent,
-    create_multimodal_to_tool_agent,
 )
 from rai.messages import HumanMultimodalMessage
 
+from rai_bench.agents import create_multimodal_to_tool_agent
 from rai_bench.base_benchmark import BaseBenchmark, TimeoutException
 from rai_bench.results_processing.langfuse_scores_tracing import ScoreTracingHandler
 from rai_bench.tool_calling_agent.interfaces import (

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -18,15 +18,12 @@ import uuid
 from pathlib import Path
 from typing import Iterator, List, Sequence, Tuple
 
-from langchain_aws import ChatBedrock
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage
 from langchain_core.runnables.config import RunnableConfig
-from langchain_ollama import ChatOllama
-from langchain_openai import ChatOpenAI
 from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
-from rai.agents.langchain.core.conversational_agent import (
+from rai.agents.langchain.core import (
     create_conversational_agent,
     create_multimodal_to_tool_agent,
 )
@@ -99,7 +96,8 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
                 f"task-complexity:{task.complexity}",
                 f"extra-tool-calls:{task.extra_tool_calls}",
             ],
-            "recursion_limit": len(agent.get_graph().nodes) * task.max_tool_calls_number,
+            "recursion_limit": len(agent.get_graph().nodes)
+            * task.max_tool_calls_number,
         }
 
         ts = time.perf_counter()
@@ -207,21 +205,18 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
 
 
 def run_benchmark(
-    llm: ChatOpenAI | ChatBedrock | ChatOllama,
+    llm: BaseChatModel,
     model_name: str,
-    out_dir: str,
+    out_dir: Path,
     tasks: List[Task],
     experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
 ):
-    experiment_dir = Path(out_dir)
-    experiment_dir.mkdir(parents=True, exist_ok=True)
-
     benchmark = ToolCallingAgentBenchmark(
         tasks=tasks,
         logger=bench_logger,
         model_name=model_name,
-        results_dir=experiment_dir,
+        results_dir=out_dir,
     )
 
     for task in tasks:
@@ -242,19 +237,16 @@ def run_benchmark_dual_agent(
     multimodal_llm: BaseChatModel,
     tool_calling_llm: BaseChatModel,
     model_name: str,
-    out_dir: str,
+    out_dir: Path,
     tasks: List[Task],
     experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
 ):
-    experiment_dir = Path(out_dir)
-    experiment_dir.mkdir(parents=True, exist_ok=True)
-
     benchmark = ToolCallingAgentBenchmark(
         tasks=tasks,
         logger=bench_logger,
         model_name=model_name,
-        results_dir=experiment_dir,
+        results_dir=out_dir,
     )
     tool_system_prompt = (
         "Based on the conversation call the tool with appropriate arguments"

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -139,7 +139,8 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
             self.logger.error(msg=f"Task timeout: {e}")
         except GraphRecursionError as e:
             self.logger.error(msg=f"Reached recursion limit {e}")
-
+        except Exception as e:
+            self.logger.error(msg=f"Unexpected error occured: {e}")
         tool_calls = task.get_tool_calls_from_messages(messages=messages)
         score = task.validate(tool_calls=tool_calls)
         te = time.perf_counter()

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -41,6 +41,7 @@ from rai_bench.tool_calling_agent.results_tracking import (
 from rai_bench.tool_calling_agent.tasks.spatial import (
     SpatialReasoningAgentTask,
 )
+from rai_bench.utils import get_llm_model_name
 
 
 class ToolCallingAgentBenchmark(BaseBenchmark):
@@ -207,16 +208,15 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
 
 def run_benchmark(
     llm: BaseChatModel,
-    model_name: str,
     out_dir: Path,
     tasks: List[Task],
-    experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
+    experiment_id: uuid.UUID = uuid.uuid4(),
 ):
     benchmark = ToolCallingAgentBenchmark(
         tasks=tasks,
         logger=bench_logger,
-        model_name=model_name,
+        model_name=get_llm_model_name(llm),
         results_dir=out_dir,
     )
 
@@ -237,18 +237,17 @@ def run_benchmark(
 def run_benchmark_dual_agent(
     multimodal_llm: BaseChatModel,
     tool_calling_llm: BaseChatModel,
-    model_name: str,
     out_dir: Path,
     tasks: List[Task],
-    experiment_id: uuid.UUID,
     bench_logger: logging.Logger,
+    experiment_id: uuid.UUID = uuid.uuid4(),
     m_system_prompt: Optional[str] = None,
     tool_system_prompt: Optional[str] = None,
 ):
     benchmark = ToolCallingAgentBenchmark(
         tasks=tasks,
         logger=bench_logger,
-        model_name=model_name,
+        model_name=get_llm_model_name(multimodal_llm),
         results_dir=out_dir,
     )
 

--- a/src/rai_bench/rai_bench/tool_calling_agent/validators.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/validators.py
@@ -49,7 +49,7 @@ class OrderedCallsValidator(Validator):
         # was used before in other task
         subtask_iter = iter(enumerate(self.subtasks))
         if len(tool_calls) < 1:
-            self.logger.error("Not a single tool call to validate")
+            self.logger.debug("Not a single tool call to validate")
             self.passed = False
             return False, tool_calls
 
@@ -69,7 +69,7 @@ class OrderedCallsValidator(Validator):
                     self.extra_calls_used = i + 1 - self.required_calls
                     return True, tool_calls[i + 1 :]
 
-            self.logger.error(f"Validation failed for task {u + 1}")
+            self.logger.debug(f"Validation failed for task {u + 1}")
             self.passed = False
             if len(tool_calls) > self.required_calls:
                 self.extra_calls_used += len(tool_calls) - self.required_calls
@@ -96,7 +96,7 @@ class NotOrderedCallsValidator(Validator):
     def validate(self, tool_calls: List[ToolCall]) -> Tuple[bool, List[ToolCall]]:
         self.reset()
         if len(tool_calls) < 1:
-            self.logger.error("Not a single tool call to validate")
+            self.logger.debug("Not a single tool call to validate")
             self.passed = False
             return False, tool_calls
 
@@ -137,7 +137,7 @@ class NotOrderedCallsValidator(Validator):
             self.extra_calls_used = len(tool_calls) - self.required_calls
             return True, []
 
-        self.logger.error(
+        self.logger.debug(
             f"Validation failed for tasks: {[idx + 1 for idx in to_be_done_idx]}"
         )
         self.passed = False

--- a/src/rai_bench/rai_bench/utils.py
+++ b/src/rai_bench/rai_bench/utils.py
@@ -16,7 +16,11 @@ import argparse
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
+from langchain_aws import ChatBedrock
+from langchain_ollama import ChatOllama
+from langchain_openai import ChatOpenAI
 from rai.initialization import get_llm_model_direct
 
 
@@ -120,18 +124,19 @@ def define_benchmark_logger(out_dir: Path) -> logging.Logger:
     bench_logger = logging.getLogger("Benchmark logger")
     for handler in bench_logger.handlers:
         bench_logger.removeHandler(handler)
-    bench_logger.setLevel(logging.INFO)
+    bench_logger.setLevel(logging.DEBUG)
     bench_logger.addHandler(file_handler)
 
     return bench_logger
 
 
 def get_llm_for_benchmark(
-    model_name: str,
-    vendor: str,
-):
+    model_name: str, vendor: str, **kwargs: Any
+) -> ChatOpenAI | ChatBedrock | ChatOllama:
     if vendor == "ollama":
-        llm = get_llm_model_direct(model_name=model_name, vendor=vendor, keep_alive=20)
+        llm = get_llm_model_direct(
+            model_name=model_name, vendor=vendor, keep_alive=20, **kwargs
+        )
     else:
-        llm = get_llm_model_direct(model_name=model_name, vendor=vendor)
+        llm = get_llm_model_direct(model_name=model_name, vendor=vendor, **kwargs)
     return llm

--- a/src/rai_bench/rai_bench/utils.py
+++ b/src/rai_bench/rai_bench/utils.py
@@ -115,7 +115,7 @@ def define_benchmark_logger(out_dir: Path) -> logging.Logger:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     file_handler = logging.FileHandler(log_file)
-    file_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(logging.INFO)
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
@@ -124,7 +124,7 @@ def define_benchmark_logger(out_dir: Path) -> logging.Logger:
     bench_logger = logging.getLogger("Benchmark logger")
     for handler in bench_logger.handlers:
         bench_logger.removeHandler(handler)
-    bench_logger.setLevel(logging.DEBUG)
+    bench_logger.setLevel(logging.INFO)
     bench_logger.addHandler(file_handler)
 
     return bench_logger

--- a/src/rai_core/rai/agents/langchain/core/__init__.py
+++ b/src/rai_core/rai/agents/langchain/core/__init__.py
@@ -15,7 +15,6 @@
 from .conversational_agent import State as ConversationalAgentState
 from .conversational_agent import (
     create_conversational_agent,
-    create_multimodal_to_tool_agent,
 )
 from .react_agent import (
     ReActAgentState,
@@ -29,7 +28,6 @@ __all__ = [
     "ReActAgentState",
     "ToolRunner",
     "create_conversational_agent",
-    "create_multimodal_to_tool_agent",
     "create_react_runnable",
     "create_state_based_runnable",
 ]

--- a/src/rai_core/rai/agents/langchain/core/__init__.py
+++ b/src/rai_core/rai/agents/langchain/core/__init__.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from .conversational_agent import State as ConversationalAgentState
-from .conversational_agent import create_conversational_agent
+from .conversational_agent import (
+    create_conversational_agent,
+    create_multimodal_to_tool_agent,
+)
 from .react_agent import (
     ReActAgentState,
     create_react_runnable,
@@ -26,6 +29,7 @@ __all__ = [
     "ReActAgentState",
     "ToolRunner",
     "create_conversational_agent",
+    "create_multimodal_to_tool_agent",
     "create_react_runnable",
     "create_state_based_runnable",
 ]

--- a/src/rai_core/rai/agents/langchain/core/__init__.py
+++ b/src/rai_core/rai/agents/langchain/core/__init__.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from .conversational_agent import State as ConversationalAgentState
-from .conversational_agent import (
-    create_conversational_agent,
-)
+from .conversational_agent import create_conversational_agent
 from .react_agent import (
     ReActAgentState,
     create_react_runnable,

--- a/src/rai_core/rai/agents/langchain/core/conversational_agent.py
+++ b/src/rai_core/rai/agents/langchain/core/conversational_agent.py
@@ -18,7 +18,12 @@ from functools import partial
 from typing import List, Optional, TypedDict
 
 from langchain.chat_models.base import BaseChatModel
-from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
 from langchain_core.tools import BaseTool
 from langgraph.graph import START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -61,7 +66,7 @@ def create_conversational_agent(
     tools: List[BaseTool],
     system_prompt: str | SystemMessage,
     logger: Optional[logging.Logger] = None,
-    debug=False,
+    debug: bool = False,
 ) -> CompiledStateGraph:
     _logger = None
     if logger:
@@ -88,4 +93,103 @@ def create_conversational_agent(
 
     app = workflow.compile(debug=debug)
     _logger.info("State based agent created")
+    return app
+
+
+def multimodal_to_tool_bridge(state: State):
+    # Instead of narrative, preserve the original user request
+    # Just remove images, keep the direct request format
+
+    cleaned_messages: List[BaseMessage] = []
+    for msg in state["messages"]:
+        if isinstance(msg, HumanMessage):
+            # Remove images but keep the direct request
+            if isinstance(msg.content, list):
+                # Extract text only
+                text_parts = [
+                    part.get("text", "")
+                    for part in msg.content
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ]
+                if text_parts:
+                    cleaned_messages.append(HumanMessage(content=" ".join(text_parts)))
+            else:
+                cleaned_messages.append(msg)
+        elif isinstance(msg, AIMessage):
+            # Keep AI messages for context
+            cleaned_messages.append(msg)
+
+    state["messages"] = cleaned_messages
+    return state
+
+
+def create_multimodal_to_tool_agent(
+    multimodal_llm: BaseChatModel,
+    tool_llm: BaseChatModel,
+    tools: List[BaseTool],
+    multimodal_system_prompt: str,
+    tool_system_prompt: str,
+    logger: Optional[logging.Logger] = None,
+    debug: bool = False,
+) -> CompiledStateGraph:
+    """
+    Creates an agent flow where inputs first go to a multimodal LLM,
+    then its output is passed to a tool-calling LLM.
+    Can be usefull when multimodal llm does not provide tool calling.
+
+    Args:
+        multimodal_llm: LLM capable of processing images and text
+        tool_llm: LLM optimized for tool calling
+        tools: List of tools available to the tool agent
+        multimodal_system_prompt: System prompt for multimodal LLM
+        tool_system_prompt: System prompt for tool LLM
+        logger: Optional logger
+        debug: Whether to enable debug mode
+
+    Returns:
+        Compiled state graph
+    """
+    # Set up logging
+    _logger = None
+    if logger:
+        _logger = logger
+    else:
+        _logger = logging.getLogger(__name__)
+
+    _logger.info("Creating multimodal to tool agent flow")
+
+    tool_llm_with_tools = tool_llm.bind_tools(tools)
+    tool_node = ToolRunner(tools=tools, logger=_logger)
+
+    workflow = StateGraph(State)
+    workflow.add_node(
+        "thinker",
+        partial(agent, multimodal_llm, _logger, multimodal_system_prompt),
+    )
+    # context bridge for altering the
+    workflow.add_node(
+        "context_bridge",
+        multimodal_to_tool_bridge,
+    )
+    workflow.add_node(
+        "tool_agent",
+        partial(agent, tool_llm_with_tools, _logger, tool_system_prompt),
+    )
+    workflow.add_node("tools", tool_node)
+
+    workflow.add_edge(START, "thinker")
+    workflow.add_edge("thinker", "context_bridge")
+    workflow.add_edge("context_bridge", "tool_agent")
+
+    workflow.add_conditional_edges(
+        "tool_agent",
+        tools_condition,
+    )
+
+    # Tool node goes back to tool agent
+    workflow.add_edge("tools", "tool_agent")
+
+    # Compile the workflow
+    app = workflow.compile(debug=debug)
+    _logger.info("Multimodal to tool agent flow created")
     return app

--- a/src/rai_core/rai/agents/langchain/core/conversational_agent.py
+++ b/src/rai_core/rai/agents/langchain/core/conversational_agent.py
@@ -19,9 +19,7 @@ from typing import List, Optional, TypedDict
 
 from langchain.chat_models.base import BaseChatModel
 from langchain_core.messages import (
-    AIMessage,
     BaseMessage,
-    HumanMessage,
     SystemMessage,
 )
 from langchain_core.tools import BaseTool
@@ -93,96 +91,4 @@ def create_conversational_agent(
 
     app = workflow.compile(debug=debug)
     _logger.info("State based agent created")
-    return app
-
-
-def multimodal_to_tool_bridge(state: State):
-    """Node of langchain workflow designed to bridge
-    nodes with llms. Removing images for context
-    """
-
-    cleaned_messages: List[BaseMessage] = []
-    for msg in state["messages"]:
-        if isinstance(msg, HumanMessage):
-            # Remove images but keep the direct request
-            if isinstance(msg.content, list):
-                # Extract text only
-                text_parts = [
-                    part.get("text", "")
-                    for part in msg.content
-                    if isinstance(part, dict) and part.get("type") == "text"
-                ]
-                if text_parts:
-                    cleaned_messages.append(HumanMessage(content=" ".join(text_parts)))
-            else:
-                cleaned_messages.append(msg)
-        elif isinstance(msg, AIMessage):
-            # Keep AI messages for context
-            cleaned_messages.append(msg)
-
-    state["messages"] = cleaned_messages
-    return state
-
-
-def create_multimodal_to_tool_agent(
-    multimodal_llm: BaseChatModel,
-    tool_llm: BaseChatModel,
-    tools: List[BaseTool],
-    multimodal_system_prompt: str,
-    tool_system_prompt: str,
-    logger: Optional[logging.Logger] = None,
-    debug: bool = False,
-) -> CompiledStateGraph:
-    """
-    Creates an agent flow where inputs first go to a multimodal LLM,
-    then its output is passed to a tool-calling LLM.
-    Can be usefull when multimodal llm does not provide tool calling.
-
-    Args:
-        tools: List of tools available to the tool agent
-
-    Returns:
-        Compiled state graph
-    """
-    _logger = None
-    if logger:
-        _logger = logger
-    else:
-        _logger = logging.getLogger(__name__)
-
-    _logger.info("Creating multimodal to tool agent flow")
-
-    tool_llm_with_tools = tool_llm.bind_tools(tools)
-    tool_node = ToolRunner(tools=tools, logger=_logger)
-
-    workflow = StateGraph(State)
-    workflow.add_node(
-        "thinker",
-        partial(agent, multimodal_llm, _logger, multimodal_system_prompt),
-    )
-    # context bridge for altering the
-    workflow.add_node(
-        "context_bridge",
-        multimodal_to_tool_bridge,
-    )
-    workflow.add_node(
-        "tool_agent",
-        partial(agent, tool_llm_with_tools, _logger, tool_system_prompt),
-    )
-    workflow.add_node("tools", tool_node)
-
-    workflow.add_edge(START, "thinker")
-    workflow.add_edge("thinker", "context_bridge")
-    workflow.add_edge("context_bridge", "tool_agent")
-
-    workflow.add_conditional_edges(
-        "tool_agent",
-        tools_condition,
-    )
-
-    # Tool node goes back to tool agent
-    workflow.add_edge("tools", "tool_agent")
-
-    app = workflow.compile(debug=debug)
-    _logger.info("Multimodal to tool agent flow created")
     return app

--- a/src/rai_core/rai/agents/langchain/core/conversational_agent.py
+++ b/src/rai_core/rai/agents/langchain/core/conversational_agent.py
@@ -97,8 +97,9 @@ def create_conversational_agent(
 
 
 def multimodal_to_tool_bridge(state: State):
-    # Instead of narrative, preserve the original user request
-    # Just remove images, keep the direct request format
+    """Node of langchain workflow designed to bridge
+    nodes with llms. Removing images for context
+    """
 
     cleaned_messages: List[BaseMessage] = []
     for msg in state["messages"]:
@@ -138,18 +139,11 @@ def create_multimodal_to_tool_agent(
     Can be usefull when multimodal llm does not provide tool calling.
 
     Args:
-        multimodal_llm: LLM capable of processing images and text
-        tool_llm: LLM optimized for tool calling
         tools: List of tools available to the tool agent
-        multimodal_system_prompt: System prompt for multimodal LLM
-        tool_system_prompt: System prompt for tool LLM
-        logger: Optional logger
-        debug: Whether to enable debug mode
 
     Returns:
         Compiled state graph
     """
-    # Set up logging
     _logger = None
     if logger:
         _logger = logger
@@ -189,7 +183,6 @@ def create_multimodal_to_tool_agent(
     # Tool node goes back to tool agent
     workflow.add_edge("tools", "tool_agent")
 
-    # Compile the workflow
     app = workflow.compile(debug=debug)
     _logger.info("Multimodal to tool agent flow created")
     return app


### PR DESCRIPTION
## Purpose
Enable usage of agents that compose of 2 llms. This can be usefull for testing the model which does not have tool calling capabilities. In such case we can use it in combination with llm that can make these calls.

Also this PR proposes changes to tracing to help debug and check results 
## Proposed Changes
- New way of creating agents -> `create_multimodal_to_tool_agent` function. It defines 2 llm like stated above, with addition of context bridge that removes images from context when passing it to 2nd model. This approach is needed when testing the 1st model on spatial reasoning tasks, as we ensure that the tool call is based only on  1st model's answer.

I know it's not a general solution for pairing llms but i think every task would require  slightly  different approach to defining  the langchain workflow. So when new workflow will be needed, just build something similar like in proposed function.

- new example file for showing how to run dual agent

- added tags to tracing for both tool-calling-agent and manipulation-o3de benchmarks
-  recursion limit in tool-calling-agent now scaling with number of langchain nodes, as more nodes = more recursion

## Issues
- https://github.com/RobotecAI/rai/issues/464
-   Links to relevant issues

## Testing
1. Run with tracing enabled 
```python 
python src/rai_bench/rai_bench/examples/dual_agent.py 
```
2. check the traces, if they are tagged clearly
