### PR TITLE
fix: use rai without rai_interfaces

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.0.0.a2"
+version = "2.0.2"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_core/rai/communication/ros2/connectors/hri_connector.py
+++ b/src/rai_core/rai/communication/ros2/connectors/hri_connector.py
@@ -23,9 +23,9 @@ from rai.communication import HRIConnector
 from rai.communication.ros2.connectors.base import ROS2BaseConnector
 from rai.communication.ros2.messages import ROS2HRIMessage
 
-if importlib.util.find_spec("rai_interfaces.msg") is None:
+if importlib.util.find_spec("rai_interfaces") is None:
     logging.warning(
-        "This feature is based on rai_interfaces.msg. Make sure rai_interfaces is installed."
+        "This feature is based on rai_interfaces. Make sure rai_interfaces is installed."
     )
 
 

--- a/src/rai_core/rai/communication/ros2/messages.py
+++ b/src/rai_core/rai/communication/ros2/messages.py
@@ -28,7 +28,7 @@ from sensor_msgs.msg import Image as ROS2Image
 from rai.communication.base_connector import BaseMessage
 from rai.communication.hri_connector import HRIMessage
 
-if importlib.util.find_spec("rai_interfaces.msg") is None:
+if importlib.util.find_spec("rai_interfaces") is None:
     logging.warning("rai_interfaces is not installed, ROS 2 HRIMessage will not work.")
 else:
     import rai_interfaces.msg


### PR DESCRIPTION
## Purpose

While testing RAI installed with pip, I've come across a problem when running a very simple example:
```python
from rai.communication.ros2 import ROS2Connector
  File "/home/mmajek/projects/rai_pip/.venv/lib/python3.12/site-packages/rai/communication/ros2/messages.py", line 31, in <module>
    if importlib.util.find_spec("rai_interfaces.msg") is None:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib.util>", line 92, in find_spec
ModuleNotFoundError: No module named 'rai_interfaces'
```

## Proposed Changes

Implements `safe_find_spec` to catch an error if package cannot be imported.

## Issues

#607

## Testing

-   How was it tested, what were the results?
