### PR TITLE
fix: print help if no arguments build-whoami

### DIFF
--- a/src/rai_whoami/pyproject.toml
+++ b/src/rai_whoami/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rai_whoami"
-version = "0.0.2"
+version = "0.0.4"
 description = "Package to extract embodiment information from robot documentation"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_whoami/pyproject.toml
+++ b/src/rai_whoami/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rai_whoami"
-version = "0.0.1"
+version = "0.0.2"
 description = "Package to extract embodiment information from robot documentation"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>"]
 readme = "README.md"
@@ -23,7 +23,7 @@ faiss-cpu = "*"
 pypdf = "^5.4.0"
 
 [tool.poetry.scripts]
-build-whoami = "rai_whoami.build_whoami:build_whoami"
+build-whoami = "rai_whoami.build_whoami:main"
 
 
 [build-system]

--- a/src/rai_whoami/rai_whoami/build_whoami.py
+++ b/src/rai_whoami/rai_whoami/build_whoami.py
@@ -43,7 +43,7 @@ def build_whoami(args: argparse.Namespace) -> None:
     info.to_directory(args.output_dir)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("documentation_dir", type=Path)
     parser.add_argument("--build-vector-db", default=False, action="store_true")
@@ -54,3 +54,7 @@ if __name__ == "__main__":
     if args.output_dir is None:
         args.output_dir = args.documentation_dir / "generated"
     build_whoami(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

When testing rai-whoami installed with pip I've come across a cryptic error when build-whoami command was used without arguments. 

## Proposed Changes

build-whoami now prints the help provided by argparse

## Issues

#607 

## Testing

-   How was it tested, what were the results?
