### PR TITLE
fix: path convert tool calling bench

### DIFF
--- a/src/rai_bench/pyproject.toml
+++ b/src/rai_bench/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rai-bench"
-version = "0.1.1"
+version = "0.1.2"
 description = "Package for running and creating benchmarks."
 authors = ["Jakub Matejczyk <jakub.matejczyk@robotec.ai>", "Magdalena Kotynia <magdalena.kotynia@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_bench/rai_bench/examples/tool_calling_agent.py
+++ b/src/rai_bench/rai_bench/examples/tool_calling_agent.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
     run_benchmark(
         llm=llm,
-        out_dir=args.out_dir,
+        out_dir=experiment_dir,
         tasks=tasks,
         bench_logger=bench_logger,
     )


### PR DESCRIPTION
## Purpose
Path was not converted properly when passed from user args in tool calling bench

## Proposed Changes

## Issues

## Testing

```python
python src/rai_bench/rai_bench/examples/tool_calling_agent.py --model-name qwen2.5:7b --vendor ollama --extra-tool-calls 5 --task-types basic
```