### PR TITLE
feat: basic tasks extension

### DIFF
--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -87,7 +87,7 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
         )
         callbacks = self.score_tracing_handler.get_callbacks()
         run_id = uuid.uuid4()
-        # NOTE (jmatejcz) reccustion limit calculated as all_nodes_num -> one pass though whole node
+        # NOTE (jmatejcz) recursion limit calculated as all_nodes_num -> one pass though whole node
         # plus (task.max_tool_calls_number-1 because the first pass is already added in)
         # times number of nodes - 2 because we dont cout start and end node
         # this can be to much for larger graphs that dont use all nodes on extra calls

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -87,6 +87,14 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
         )
         callbacks = self.score_tracing_handler.get_callbacks()
         run_id = uuid.uuid4()
+        # NOTE (jmatejcz) reccustion limit calculated as all_nodes_num -> one pass though whole node
+        # plus (task.max_tool_calls_number-1 because the first pass is already added in)
+        # times number of nodes - 2 because we dont cout start and end node
+        # this can be to much for larger graphs that dont use all nodes on extra calls
+        # in such ase adjust this value
+        recurssion_limit = len(agent.get_graph().nodes) + (
+            task.max_tool_calls_number - 1
+        ) * (len(agent.get_graph().nodes) - 2)
         config: RunnableConfig = {
             "run_id": run_id,
             "callbacks": callbacks,
@@ -97,9 +105,9 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
                 f"task-complexity:{task.complexity}",
                 f"extra-tool-calls:{task.extra_tool_calls}",
             ],
-            "recursion_limit": len(agent.get_graph().nodes)
-            * task.max_tool_calls_number,
+            "recursion_limit": recurssion_limit,
         }
+        self.logger.debug(f"recurssion limit: {recurssion_limit}")
 
         ts = time.perf_counter()
         messages: List[BaseMessage] = []

--- a/src/rai_bench/rai_bench/tool_calling_agent/interfaces.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/interfaces.py
@@ -121,6 +121,30 @@ class SubTask(ABC):
     def _check_nested_fields(
         self, field_path: str, args: Dict[str, Any], expected_value: Any
     ) -> bool:
+        """Check if a nested field in the arguments matches the expected value.
+
+        Parameters
+        ----------
+        field_path : str
+            Dot-separated path to the field (e.g., "header.frame_id").
+            Including indexes for lists possible (e.g., "data[0].value").
+        args : Dict[str, Any]
+            The arguments dictionary to check.
+        expected_value : Any
+            The expected value for the field.
+
+        Returns
+        -------
+        bool
+            True if the field matches the expected value, False otherwise.
+
+
+        Raises
+        ------
+        SubTaskValidationError
+            If the field is not found or does not match the expected value.
+        """
+
         keys = field_path.split(".")
         value: Any = args
         for key in keys:

--- a/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
@@ -53,6 +53,455 @@ from rai_bench.tool_calling_agent.messages.topics import AudioMessage, HRIMessag
 # the dict contains custom as well as couple other common interfaces
 
 COMMON_INTERFACES: Dict[str, str] = {
+    "std_srvs/srv/Empty": """# Empty service - no request or response
+---
+""",
+    "std_srvs/srv/Trigger": """# Simple service to trigger an action
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages
+""",
+    "std_srvs/srv/SetBool": """bool data # e.g. for hardware enabling / disabling
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages
+""",
+    "std_srvs/srv/SetString": """string data
+---
+bool success
+string message
+""",
+    "lifecycle_msgs/srv/ChangeState": """Transition transition
+	uint8 id
+	string label
+---
+bool success
+""",
+    "lifecycle_msgs/srv/GetState": """---
+State current_state
+	uint8 id
+	string label
+""",
+    "lifecycle_msgs/srv/GetAvailableStates": """---
+State[] available_states
+	uint8 id
+	string label
+""",
+    "lifecycle_msgs/srv/GetAvailableTransitions": """---
+TransitionDescription[] available_transitions
+	Transition transition
+		uint8 id
+		string label
+	State start_state
+		uint8 id
+		string label
+	State goal_state
+		uint8 id
+		string label
+""",
+    "rcl_interfaces/msg/ParameterEvent": """# This message is published when parameters change for a node
+Parameter[] changed_parameters
+	string name
+	ParameterValue value
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+
+Parameter[] deleted_parameters
+	string name
+	ParameterValue value
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+
+string node
+""",
+    "rcl_interfaces/msg/Log": """# This message represents a log message published on the /rosout topic
+# severity level constants
+byte DEBUG=10
+byte INFO=20
+byte WARN=30
+byte ERROR=40
+byte FATAL=50
+
+# message fields
+builtin_interfaces/Time stamp
+	int32 sec
+	uint32 nanosec
+byte level
+string name      # name of the node
+string msg       # message text
+string file      # file the message came from
+string function  # function the message came from
+uint32 line      # line the message came from
+""",
+    "tf2_msgs/msg/TFMessage": """# An array of transforms with a header for the coordinate frame
+geometry_msgs/TransformStamped[] transforms
+	std_msgs/Header header
+		builtin_interfaces/Time stamp
+			int32 sec
+			uint32 nanosec
+		string frame_id
+	string child_frame_id
+	Transform transform
+		Vector3 translation
+			float64 x
+			float64 y
+			float64 z
+		Quaternion rotation
+			float64 x 0
+			float64 y 0
+			float64 z 0
+			float64 w 1
+""",
+    "sensor_msgs/msg/JointState": """# This is a message that holds data to describe the state of a set of torque controlled joints.
+#
+# The state of each joint (revolute or prismatic) is defined by:
+#  * the position of the joint (rad or m),
+#  * the velocity of the joint (rad/s or m/s) and
+#  * the effort that is applied in the joint (Nm or N).
+#
+# Each joint is uniquely identified by its name
+# The header specifies the time at which the joint states were recorded. All the joint states
+# in one message have to be recorded at the same time.
+#
+# This message consists of a multiple arrays, one for each part of the joint state.
+# The goal is to make each of the fields optional. When e.g. your joints have no
+# velocity or effort sensors, you can leave the velocity and effort arrays empty.
+#
+# All arrays in this message should have the same size.
+
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+string[] name
+float64[] position
+float64[] velocity
+float64[] effort
+""",
+    "std_msgs/msg/String": """# Please look at the Standard ROS Messages documentation before using this.
+# http://wiki.ros.org/std_msgs
+string data
+""",
+    "bond/msg/Status": """# An array of bond ids that this node is maintaining
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+string id        # unique identifier for the bond
+string instance_id # identifier for this instance of the node
+bool active      # whether the bond is currently active
+float32 heartbeat_timeout # timeout for heartbeat in seconds
+float32 heartbeat_period  # period for heartbeat messages in seconds
+""",
+    "diagnostic_msgs/msg/DiagnosticArray": """# This message contains a list of diagnostic statuses
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+
+DiagnosticStatus[] status
+	# Possible levels of operations
+	byte OK=0
+	byte WARN=1
+	byte ERROR=2
+	byte STALE=3
+
+	byte level           # level of operation enumerated above
+	string name          # a description of the test/component reporting
+	string message       # a description of the status
+	string hardware_id   # a hardware unique string
+	KeyValue[] values    # an array of values associated with the status
+		string key
+		string value
+""",
+    "sensor_msgs/msg/PointCloud2": """# This message holds a collection of N-dimensional points, which may
+# contain additional information such as normals, intensity, etc. The
+# point data is stored as a binary blob, its format described by the
+# contents of the \"fields\" array.
+
+# The point cloud data may be organized 2d (image-like) or 1d
+# (unordered). Point clouds organized as 2d images may be produced by
+# camera depth sensors such as stereo or time-of-flight.
+
+# Time of sensor data acquisition, and the coordinate frame ID (for 3d
+# points).
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+
+# 2D structure of the point cloud. If the cloud is unordered, height is
+# 1 and width is the length of the point cloud.
+uint32 height
+uint32 width
+
+# Describes the channels and their layout in the binary data blob.
+PointField[] fields
+	uint8 INT8    = 1
+	uint8 UINT8   = 2
+	uint8 INT16   = 3
+	uint8 UINT16  = 4
+	uint8 INT32   = 5
+	uint8 UINT32  = 6
+	uint8 FLOAT32 = 7
+	uint8 FLOAT64 = 8
+
+	string name      # Name of field
+	uint32 offset    # Offset from start of point struct
+	uint8  datatype  # Datatype enumeration, see above
+	uint32 count     # How many elements in the field
+
+bool    is_bigendian # Is this data bigendian?
+uint32  point_step   # Length of a point in bytes
+uint32  row_step     # Length of a row in bytes
+uint8[] data         # Actual point data, size is (row_step*height)
+
+bool is_dense        # True if there are no invalid points
+""",
+    "sensor_msgs/msg/LaserScan": """# Single scan from a planar laser range-finder
+#
+# If you have another ranging device with different behavior (e.g. a sonar
+# array), please find or create a different message, since applications
+# will make fairly laser-specific assumptions about this data
+
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+float32 angle_min        # start angle of the scan [rad]
+float32 angle_max        # end angle of the scan [rad]
+float32 angle_increment  # angular distance between measurements [rad]
+
+float32 time_increment   # time between measurements [seconds] - if your scanner
+                         # is moving, this will be used in interpolating position
+                         # of 3d points
+float32 scan_time        # time between scans [seconds]
+
+float32 range_min        # minimum range value [m]
+float32 range_max        # maximum range value [m]
+
+float32[] ranges         # range data [m] (Note: values < range_min or > range_max should be discarded)
+float32[] intensities    # intensity data [device-specific units].  If your
+                         # device does not provide intensities, please leave
+                         # the array empty.
+""",
+    "nav_msgs/msg/Odometry": """# This represents an estimate of a position and velocity in free space.
+# The pose in this message should be specified in the coordinate frame given by header.frame_id.
+# The twist in this message should be specified in the coordinate frame given by the child_frame_id
+std_msgs/Header header
+	builtin_interfaces/Time stamp
+		int32 sec
+		uint32 nanosec
+	string frame_id
+string child_frame_id
+geometry_msgs/PoseWithCovariance pose
+	Pose pose
+		Point position
+			float64 x
+			float64 y
+			float64 z
+		Quaternion orientation
+			float64 x 0
+			float64 y 0
+			float64 z 0
+			float64 w 1
+	float64[36] covariance # Row-major representation of the 6x6 covariance matrix
+geometry_msgs/TwistWithCovariance twist
+	Twist twist
+		Vector3  linear
+			float64 x
+			float64 y
+			float64 z
+		Vector3  angular
+			float64 x
+			float64 y
+			float64 z
+	float64[36] covariance # Row-major representation of the 6x6 covariance matrix
+""",
+    # Services from COMMON_SERVICES_AND_TYPES that are missing
+    "tf2_msgs/srv/FrameGraph": """---
+string frame_yaml
+""",
+    "composition_interfaces/srv/ListNodes": """---
+# All unique node names within the container
+string[] unique_names
+# Full node names corresponding to each unique node name
+string[] full_node_names
+""",
+    "composition_interfaces/srv/LoadNode": """LoadNodeRequest request
+	string package_name
+	string plugin_name
+	string node_name
+	string node_namespace
+	string[] remap_rules
+	Parameter[] parameters
+		string name
+		ParameterValue value
+			uint8 type
+			bool bool_value
+			int64 integer_value
+			float64 double_value
+			string string_value
+			byte[] byte_array_value
+			bool[] bool_array_value
+			int64[] integer_array_value
+			float64[] double_array_value
+			string[] string_array_value
+	string[] extra_arguments
+---
+bool success
+string error_message
+string full_node_name
+uint64 unique_id
+""",
+    "composition_interfaces/srv/UnloadNode": """uint64 unique_id
+---
+bool success
+string error_message
+""",
+    "rcl_interfaces/srv/DescribeParameters": """string[] names
+---
+ParameterDescriptor[] descriptors
+	string name
+	uint8 type
+	string description
+	string additional_constraints
+	bool read_only
+	bool dynamic_typing
+	ParameterValue floating_point_range
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+	ParameterValue integer_range
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+""",
+    "rcl_interfaces/srv/GetParameterTypes": """string[] names
+---
+uint8[] types
+# Possible parameter types:
+uint8 PARAMETER_NOT_SET=0
+uint8 PARAMETER_BOOL=1
+uint8 PARAMETER_INTEGER=2
+uint8 PARAMETER_DOUBLE=3
+uint8 PARAMETER_STRING=4
+uint8 PARAMETER_BYTE_ARRAY=5
+uint8 PARAMETER_BOOL_ARRAY=6
+uint8 PARAMETER_INTEGER_ARRAY=7
+uint8 PARAMETER_DOUBLE_ARRAY=8
+uint8 PARAMETER_STRING_ARRAY=9
+""",
+    "rcl_interfaces/srv/GetParameters": """string[] names
+---
+ParameterValue[] values
+	uint8 type
+	bool bool_value
+	int64 integer_value
+	float64 double_value
+	string string_value
+	byte[] byte_array_value
+	bool[] bool_array_value
+	int64[] integer_array_value
+	float64[] double_array_value
+	string[] string_array_value
+""",
+    "rcl_interfaces/srv/ListParameters": """ListParametersRequest request
+	string[] prefixes
+	uint64 depth
+---
+ListParametersResult result
+	string[] names
+	string[] prefixes
+""",
+    "rcl_interfaces/srv/SetParametersAtomically": """Parameter[] parameters
+	string name
+	ParameterValue value
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+---
+SetParametersResult result
+	bool successful
+	string reason
+""",
+    "gazebo_msgs/srv/GetWorldProperties": """# Service to get world properties
+---
+string[] model_names
+string[] light_names
+bool rendering_enabled
+bool physics_enabled
+bool physics_paused
+float64 sim_time
+""",
+    "gazebo_msgs/srv/GetModelState": """string model_name
+string relative_entity_name  # return pose relative to this entity
+                             # an empty string will return world relative pose
+---
+geometry_msgs/Pose pose
+	Point position
+		float64 x
+		float64 y
+		float64 z
+	Quaternion orientation
+		float64 x 0
+		float64 y 0
+		float64 z 0
+		float64 w 1
+geometry_msgs/Twist twist
+	Vector3  linear
+		float64 x
+		float64 y
+		float64 z
+	Vector3  angular
+		float64 x
+		float64 y
+		float64 z
+bool success
+string status_message
+""",
     "gazebo_msgs/srv/DeleteEntity": """string name                       # Name of the Gazebo entity to be deleted. This can be either
                                   # a model or a light.
 ---
@@ -2932,8 +3381,6 @@ COMMON_TOPICS_AND_TYPES: Dict[str, str] = {
     "/depth_image5": "sensor_msgs/msg/Image",
     "/pointcloud": "sensor_msgs/msg/PointCloud2",
     "/scan": "sensor_msgs/msg/LaserScan",
-    "/odom": "nav_msgs/msg/Odometry",
-    "/odometry/filtered": "nav_msgs/msg/Odometry",
 }
 
 MANIPULATION_TOPICS_AND_TYPES: Dict[str, str] = {

--- a/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
@@ -53,6 +53,33 @@ from rai_bench.tool_calling_agent.messages.topics import AudioMessage, HRIMessag
 # the dict contains custom as well as couple other common interfaces
 
 COMMON_INTERFACES: Dict[str, str] = {
+    "gazebo_msgs/srv/DeleteEntity": """string name                       # Name of the Gazebo entity to be deleted. This can be either
+                                  # a model or a light.
+---
+bool success                      # Return true if deletion is successful.
+string status_message             # Comments if available.
+""",
+    "gazebo_msgs/srv/SpawnEntity": """string name                       # Name of the entity to be spawned (optional).
+string xml                        # Entity XML description as a string, either URDF or SDF.
+string robot_namespace            # Spawn robot and all ROS interfaces under this namespace
+geometry_msgs/Pose initial_pose   # Initial entity pose.
+	Point position
+		float64 x
+		float64 y
+		float64 z
+	Quaternion orientation
+		float64 x 0
+		float64 y 0
+		float64 z 0
+		float64 w 1
+string reference_frame            # initial_pose is defined relative to the frame of this entity.
+                                  # If left empty or "world" or "map", then gazebo world frame is
+                                  # used.
+                                  # If non-existent entity is specified, an error is returned
+                                  # and the entity is not spawned.
+---
+bool success                      # Return true if spawned successfully.
+string status_message             # Comments if available.""",
     "rcl_interfaces/srv/SetParameters": """# A list of parameters to set.
 Parameter[] parameters
 	string name

--- a/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/mocked_ros2_interfaces.py
@@ -53,6 +53,23 @@ from rai_bench.tool_calling_agent.messages.topics import AudioMessage, HRIMessag
 # the dict contains custom as well as couple other common interfaces
 
 COMMON_INTERFACES: Dict[str, str] = {
+    "rcl_interfaces/srv/SetParameters": """# A list of parameters to set.
+Parameter[] parameters
+	string name
+	ParameterValue value
+		uint8 type
+		bool bool_value
+		int64 integer_value
+		float64 double_value
+		string string_value
+		byte[] byte_array_value
+		bool[] bool_array_value
+		int64[] integer_array_value
+		float64[] double_array_value
+		string[] string_array_value
+
+---
+# Indicates whether setting each parameter succeeded or not and why.""",
     "sensor_msgs/msg/CameraInfo": """
 # This message defines meta information for a camera. It should be in a
 # camera namespace on topic "camera_info" and accompanied by up to five

--- a/src/rai_bench/rai_bench/tool_calling_agent/mocked_tools.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/mocked_tools.py
@@ -365,7 +365,7 @@ class ServiceValidator:
         try:
             model.model_validate(args)
         except ValidationError as e:
-            raise ValueError(f"Pydantic validation failed: {e}")
+            raise ValueError(f"Pydantic validation failed: {e}") from e
 
     def validate(self, service_type: str, args: Dict[str, Any]):
         """
@@ -380,7 +380,7 @@ class ServiceValidator:
         if service_type in self.custom_models:
             self.validate_with_custom(service_type, args)
         else:
-            return self.validate_with_ros2(service_type, args)
+            self.validate_with_ros2(service_type, args)
 
 
 class MockCallROS2ServiceTool(CallROS2ServiceTool):
@@ -402,6 +402,18 @@ class MockCallROS2ServiceTool(CallROS2ServiceTool):
         service_args: Optional[Dict[str, Any]] = None,
         timeout_sec: float = 1.0,
     ) -> str:
+        """
+        Execute the mocked ROS2 service call with validation of service type and its args.
+
+        Parameters
+        ----------
+        service_name : str
+            Name of the service to call
+        service_type : str
+            Type of the service
+        service_args : Optional[Dict[str, Any]], optional
+            Arguments for the service call, by default None
+        """
         if service_name not in self.available_services:
             raise ValueError(
                 f"Service {service_name} is not available within {timeout_sec} seconds. Check if the service exists."

--- a/src/rai_bench/rai_bench/tool_calling_agent/mocked_tools.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/mocked_tools.py
@@ -270,8 +270,10 @@ class MockGetROS2MessageInterfaceTool(GetROS2MessageInterfaceTool):
 
 class ServiceValidator:
     """
-    Hybrid validator that uses ROS 2 native types when available,
-    falls back to Pydantic models of custom interfaces
+    Validator that is responsible for checking if gicen service type exists
+    and if it is used correctly.
+    Validator uses ROS 2 native types when available,
+    falls back to Pydantic models of custom interfaces when not.
     """
 
     def __init__(self, custom_models: Dict[str, Type[BaseModel]]):

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -134,7 +134,6 @@ spawn_entity_subtask = CheckServiceFieldsToolCallSubTask(
     expected_service_type="gazebo_msgs/srv/SpawnEntity",
     expected_fields={
         "name": "test_box",
-        "xml": str,
     },
 )
 
@@ -167,7 +166,7 @@ grounding_dino_config_subtask = CheckServiceFieldsToolCallSubTask(
     expected_service="/grounding_dino/set_parameters",
     expected_service_type="rcl_interfaces/srv/SetParameters",
     expected_fields={
-        "parameters.0.name": "detection_threshold",
+        "parameters.0.name": "confidence_threshold",
         "parameters.0.value.type": 3,
         "parameters.0.value.double_value": 0.7,
     },
@@ -205,7 +204,6 @@ spawn_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
     expected_service_type="gazebo_msgs/srv/SpawnEntity",
     expected_fields={
         "name": "box1",
-        "xml": str,
         "initial_pose.position.x": 0.2,
         "initial_pose.position.y": 0.2,
         "initial_pose.position.z": 0.2,
@@ -217,7 +215,6 @@ spawn_entity_subtask2 = CheckServiceFieldsToolCallSubTask(
     expected_service_type="gazebo_msgs/srv/SpawnEntity",
     expected_fields={
         "name": "box2",
-        "xml": str,
         "initial_pose.position.x": 0.4,
         "initial_pose.position.y": 0.4,
         "initial_pose.position.z": 0.2,

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import List, Literal
 
 from rai_bench.tool_calling_agent.interfaces import (
@@ -23,6 +22,23 @@ from rai_bench.tool_calling_agent.subtasks import (
     CheckServiceFieldsToolCallSubTask,
 )
 from rai_bench.tool_calling_agent.tasks.basic import (
+    BOX1_ENTITY,
+    BOX1_POSITION,
+    BOX2_ENTITY,
+    BOX2_POSITION,
+    COLOR_IMAGE_TOPIC,
+    DEFAULT_DINO_CONFIDENCE,
+    DEFAULT_FPS,
+    DEFAULT_PUBLISH_FREQUENCY,
+    DEFAULT_SAM_CONFIDENCE,
+    DEPTH_IMAGE_TOPIC,
+    GET_SPAWNABLE_NAMES_SERVICE,
+    GET_WORLD_PROPERTIES_TYPE,
+    LIST_PARAMETERS_TYPE,
+    POINTCLOUD_TOPIC,
+    ROBOT_DESCRIPTION_TOPIC,
+    ROBOT_STATE_PUBLISHER_LIST_PARAMS,
+    TOMATO_ENTITY,
     CheckSpawnableEntitiesTask,
     ConfigureVisionPipelineTask,
     GetAllROS2CamerasTask,
@@ -40,71 +56,10 @@ from rai_bench.tool_calling_agent.tasks.basic import (
 )
 from rai_bench.tool_calling_agent.validators import (
     NotOrderedCallsValidator,
-    OneFromManyValidator,
     OrderedCallsValidator,
 )
 
-COLOR_IMAGE_TOPIC = "/color_image5"
-DEPTH_IMAGE_TOPIC = "/depth_image5"
-COLOR_CAMERA_INFO_TOPIC = "/color_camera_info5"
-DEPTH_CAMERA_INFO_TOPIC = "/depth_camera_info5"
-ROBOT_DESCRIPTION_TOPIC = "/robot_description"
-POINTCLOUD_TOPIC = "/pointcloud"
-SCAN_TOPIC = "/scan"
-
-ROBOT_STATE_PUBLISHER_LIST_PARAMS = "/robot_state_publisher/list_parameters"
-ROBOT_STATE_PUBLISHER_GET_PARAMS = "/robot_state_publisher/get_parameters"
-ROBOT_STATE_PUBLISHER_SET_PARAMS = "/robot_state_publisher/set_parameters"
-ROBOT_STATE_PUBLISHER_SET_PARAMS_ATOMICALLY = (
-    "/robot_state_publisher/set_parameters_atomically"
-)
-
-SPAWN_ENTITY_SERVICE = "/spawn_entity"
-DELETE_ENTITY_SERVICE = "/delete_entity"
-GET_SPAWNABLE_NAMES_SERVICE = "/get_available_spawnable_names"
-GROUNDED_SAM_SET_PARAMS = "/grounded_sam/set_parameters"
-GROUNDED_SAM_SET_PARAMS_ATOMICALLY = "/grounded_sam/set_parameters_atomically"
-GROUNDING_DINO_SET_PARAMS = "/grounding_dino/set_parameters"
-GROUNDING_DINO_SET_PARAMS_ATOMICALLY = "/grounding_dino/set_parameters_atomically"
-O3DE_SET_PARAMS = "/o3de_ros2_node/set_parameters"
-O3DE_SET_PARAMS_ATOMICALLY = "/o3de_ros2_node/set_parameters_atomically"
-
-LIST_PARAMETERS_TYPE = "rcl_interfaces/srv/ListParameters"
-SET_PARAMETERS_TYPE = "rcl_interfaces/srv/SetParameters"
-SET_PARAMETERS_ATOMICALLY_TYPE = "rcl_interfaces/srv/SetParametersAtomically"
-GET_PARAMETERS_TYPE = "rcl_interfaces/srv/GetParameters"
-SPAWN_ENTITY_TYPE = "gazebo_msgs/srv/SpawnEntity"
-DELETE_ENTITY_TYPE = "gazebo_msgs/srv/DeleteEntity"
-GET_WORLD_PROPERTIES_TYPE = "gazebo_msgs/srv/GetWorldProperties"
-
-DEFAULT_PUBLISH_FREQUENCY = 30.0
-DEFAULT_FPS = 30
-DEFAULT_SAM_CONFIDENCE = 0.8
-DEFAULT_DINO_CONFIDENCE = 0.7
-SAM_CONFIDENCE_2 = 0.6
-DINO_CONFIDENCE_2 = 0.6
-FPS_2 = 10
-
-TOMATO_ENTITY = "tomato"
-BOX1_ENTITY = "box1"
-BOX2_ENTITY = "box2"
-BOX1_POSITION = (0.2, 0.2, 0.2)
-BOX2_POSITION = (0.4, 0.4, 0.2)
-
-CAMERA_TOPICS_AND_TYPES = [
-    f"topic: {COLOR_CAMERA_INFO_TOPIC}\ntype: sensor_msgs/msg/CameraInfo\n",
-    f"topic: {COLOR_IMAGE_TOPIC}\ntype: sensor_msgs/msg/Image\n",
-    f"topic: {DEPTH_CAMERA_INFO_TOPIC}\ntype: sensor_msgs/msg/CameraInfo\n",
-    f"topic: {DEPTH_IMAGE_TOPIC}\ntype: sensor_msgs/msg/Image\n",
-]
-
-CAMERA_TOPICS = [
-    COLOR_CAMERA_INFO_TOPIC,
-    COLOR_IMAGE_TOPIC,
-    DEPTH_CAMERA_INFO_TOPIC,
-    DEPTH_IMAGE_TOPIC,
-]
-########## SUBTASKS #################################################################
+########## SUBTASKS FOR TASKS WITHOUT REFACTORED VALIDATORS #################################################################
 get_topics_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
 )
@@ -120,14 +75,9 @@ depth_image5_subtask = CheckArgsToolCallSubTask(
     expected_optional_args={"timeout_sec": int},
 )
 
-color_camera_info5_subtask = CheckArgsToolCallSubTask(
+receive_pointcloud_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": COLOR_CAMERA_INFO_TOPIC},
-    expected_optional_args={"timeout_sec": int},
-)
-depth_camera_info5_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": DEPTH_CAMERA_INFO_TOPIC},
+    expected_args={"topic": POINTCLOUD_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
@@ -136,30 +86,6 @@ receive_robot_desc_subtask = CheckArgsToolCallSubTask(
     expected_args={"topic": ROBOT_DESCRIPTION_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
-
-receive_pointcloud_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": POINTCLOUD_TOPIC},
-    expected_optional_args={"timeout_sec": int},
-)
-
-robot_description_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": ROBOT_DESCRIPTION_TOPIC},
-    expected_optional_args={"timeout_sec": int},
-)
-
-scan_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": SCAN_TOPIC},
-    expected_optional_args={"timeout_sec": int},
-)
-pointcloud_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": POINTCLOUD_TOPIC},
-    expected_optional_args={"timeout_sec": int},
-)
-
 
 get_services_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_services_names_and_types", expected_args={}
@@ -172,13 +98,6 @@ list_parameters_subtask = CheckServiceFieldsToolCallSubTask(
     expected_fields={"": {}},
 )
 
-get_parameters_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=ROBOT_STATE_PUBLISHER_GET_PARAMS,
-    expected_service_type=GET_PARAMETERS_TYPE,
-    expected_fields={"names.0": "publish_frequency"},
-)
-
 check_spawnable_entities_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GET_SPAWNABLE_NAMES_SERVICE,
@@ -186,154 +105,11 @@ check_spawnable_entities_subtask = CheckServiceFieldsToolCallSubTask(
     expected_fields={"": {}},
 )
 
-spawn_entity_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=SPAWN_ENTITY_SERVICE,
-    expected_service_type=SPAWN_ENTITY_TYPE,
-    expected_fields={
-        "name": TOMATO_ENTITY,
-    },
-)
-
-set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=ROBOT_STATE_PUBLISHER_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "publish_frequency",
-        "parameters.0.value.type": "3",
-        "parameters.0.value.double_value": DEFAULT_PUBLISH_FREQUENCY,
-    },
-)
-set_robot_state_params_atomically_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=ROBOT_STATE_PUBLISHER_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "publish_frequency",
-        "parameters.0.value.type": "3",
-        "parameters.0.value.double_value": DEFAULT_PUBLISH_FREQUENCY,
-    },
-)
-
-
-set_grounded_sam_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDED_SAM_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DEFAULT_SAM_CONFIDENCE,
-    },
-)
-set_grounded_sam_atomically_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DEFAULT_SAM_CONFIDENCE,
-    },
-)
-
-set_grounded_dino_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDING_DINO_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DEFAULT_DINO_CONFIDENCE,
-    },
-)
-set_grounding_dino_atomically_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DEFAULT_DINO_CONFIDENCE,
-    },
-)
-
-set_o3de_fps_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=O3DE_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "fps",
-        "parameters.0.value.type": 2,
-        "parameters.0.value.integer_value": DEFAULT_FPS,
-    },
-)
-set_o3de_fps_atomically_subtask = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=O3DE_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "fps",
-        "parameters.0.value.type": 2,
-        "parameters.0.value.integer_value": DEFAULT_FPS,
-    },
-)
-
-
-delete_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=DELETE_ENTITY_SERVICE,
-    expected_service_type=DELETE_ENTITY_TYPE,
-    expected_fields={
-        "name": BOX1_ENTITY,
-    },
-)
-delete_entity_subtask2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=DELETE_ENTITY_SERVICE,
-    expected_service_type=DELETE_ENTITY_TYPE,
-    expected_fields={
-        "name": BOX2_ENTITY,
-    },
-)
-spawn_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=SPAWN_ENTITY_SERVICE,
-    expected_service_type=SPAWN_ENTITY_TYPE,
-    expected_fields={
-        "name": BOX1_ENTITY,
-        "initial_pose.position.x": BOX1_POSITION[0],
-        "initial_pose.position.y": BOX1_POSITION[1],
-        "initial_pose.position.z": BOX1_POSITION[2],
-    },
-)
-spawn_entity_subtask2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=SPAWN_ENTITY_SERVICE,
-    expected_service_type=SPAWN_ENTITY_TYPE,
-    expected_fields={
-        "name": BOX2_ENTITY,
-        "initial_pose.position.x": BOX2_POSITION[0],
-        "initial_pose.position.y": BOX2_POSITION[1],
-        "initial_pose.position.z": BOX2_POSITION[2],
-    },
-)
-
-delete_both_val = NotOrderedCallsValidator(
-    subtasks=[delete_entity_subtask1, delete_entity_subtask2]
-)
-spawn_both_val = NotOrderedCallsValidator(
-    subtasks=[spawn_entity_subtask1, spawn_entity_subtask2]
-)
-######### VALIDATORS #########################################################################################
+######### VALIDATORS FOR TASKS WITHOUT REFACTORED VALIDATORS #########################################################################################
 topics_ord_val = OrderedCallsValidator(subtasks=[get_topics_subtask])
 
 color_image_ord_val = OrderedCallsValidator(subtasks=[color_image5_subtask])
 depth_image_ord_val = OrderedCallsValidator(subtasks=[depth_image5_subtask])
-
-color_camera_info_ord_val = OrderedCallsValidator(subtasks=[color_camera_info5_subtask])
-depth_camera_info_ord_val = OrderedCallsValidator(subtasks=[depth_camera_info5_subtask])
 
 all_camera_images_notord_val = NotOrderedCallsValidator(
     subtasks=[
@@ -342,29 +118,13 @@ all_camera_images_notord_val = NotOrderedCallsValidator(
     ]
 )
 
-
 get_pointcloud_ord_val = OrderedCallsValidator(subtasks=[receive_pointcloud_subtask])
 get_robot_desc_ord_val = OrderedCallsValidator(subtasks=[receive_robot_desc_subtask])
 
-set_param_val = OneFromManyValidator(
-    subtasks=[set_robot_state_params_subtask, set_robot_state_params_atomically_subtask]
-)
 services_ord_val = OrderedCallsValidator(subtasks=[get_services_subtask])
 list_parameters_val = OrderedCallsValidator(subtasks=[list_parameters_subtask])
-get_parameters_val = OrderedCallsValidator(subtasks=[get_parameters_subtask])
 check_spawnable_entities_val = OrderedCallsValidator(
     subtasks=[check_spawnable_entities_subtask]
-)
-spawn_entity_val = OrderedCallsValidator(subtasks=[spawn_entity_subtask])
-
-set_grounded_sam_opt_val = OneFromManyValidator(
-    subtasks=[set_grounded_sam_subtask, set_grounded_sam_atomically_subtask]
-)
-set_grounded_dino_opt_val = OneFromManyValidator(
-    subtasks=[set_grounded_dino_subtask, set_grounding_dino_atomically_subtask]
-)
-set_o3de_fps_opt_val = OneFromManyValidator(
-    subtasks=[set_o3de_fps_subtask, set_o3de_fps_atomically_subtask]
 )
 
 
@@ -399,72 +159,67 @@ def get_basic_tasks(
                 tasks.extend(
                     [
                         GetROS2RGBCameraTask(
-                            validators=[color_image_ord_val],
                             task_args=task_args,
+                            validators=[color_image_ord_val],
                         ),
                         GetROS2TopicsTask(
-                            validators=[topics_ord_val],
                             task_args=task_args,
+                            validators=[topics_ord_val],
                         ),
                         GetROS2DepthCameraTask(
-                            validators=[depth_image_ord_val],
                             task_args=task_args,
+                            validators=[depth_image_ord_val],
                         ),
                         GetAllROS2CamerasTask(
-                            validators=[all_camera_images_notord_val],
                             task_args=task_args,
+                            validators=[all_camera_images_notord_val],
                         ),
                         GetPointcloudTask(
-                            validators=[get_pointcloud_ord_val], task_args=task_args
+                            task_args=task_args,
+                            validators=[get_pointcloud_ord_val],
                         ),
                         GetRobotDescriptionTask(
-                            validators=[get_robot_desc_ord_val], task_args=task_args
+                            task_args=task_args,
+                            validators=[get_robot_desc_ord_val],
                         ),
                         GetROS2ServicesTask(
-                            validators=[services_ord_val],
                             task_args=task_args,
+                            validators=[services_ord_val],
                         ),
                         ListRobotParametersTask(
+                            task_args=task_args,
                             validators=[list_parameters_val],
-                            task_args=task_args,
-                        ),
-                        GetSpecificParameterTask(
-                            parameter="publish_frequency",
-                            validators=[get_parameters_val],
-                            task_args=task_args,
                         ),
                         CheckSpawnableEntitiesTask(
+                            task_args=task_args,
                             validators=[check_spawnable_entities_val],
+                        ),
+                        # Tasks with refactored validators - now use defaults
+                        GetSpecificParameterTask(
+                            parameter="publish_frequency",
                             task_args=task_args,
                         ),
                         SpawnEntityTask(
                             entity=TOMATO_ENTITY,
-                            validators=[spawn_entity_val],
                             task_args=task_args,
                         ),
                         SetRobotParameterTask(
                             value=DEFAULT_PUBLISH_FREQUENCY,
-                            validators=[set_param_val],
                             task_args=task_args,
                         ),
                         SetRobotParameterTask(
-                            value=25.0, validators=[set_param_val], task_args=task_args
+                            value=25.0,
+                            task_args=task_args,
                         ),
                         ConfigureVisionPipelineTask(
                             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
                             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
                             fps=DEFAULT_FPS,
-                            validators=[
-                                set_grounded_sam_opt_val,
-                                set_grounded_dino_opt_val,
-                                set_o3de_fps_opt_val,
-                            ],
                             task_args=task_args,
                         ),
                         RespawnEntitiesTask(
                             names=[BOX1_ENTITY, BOX2_ENTITY],
                             coords=[BOX1_POSITION, BOX2_POSITION],
-                            validators=[delete_both_val, spawn_both_val],
                             task_args=task_args,
                         ),
                     ]

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -81,6 +81,9 @@ DEFAULT_PUBLISH_FREQUENCY = 30.0
 DEFAULT_FPS = 30
 DEFAULT_SAM_CONFIDENCE = 0.8
 DEFAULT_DINO_CONFIDENCE = 0.7
+SAM_CONFIDENCE_2 = 0.6
+DINO_CONFIDENCE_2 = 0.6
+FPS_2 = 10
 
 TOMATO_ENTITY = "tomato"
 BOX1_ENTITY = "box1"
@@ -214,7 +217,7 @@ set_robot_state_params_atomically_subtask = CheckServiceFieldsToolCallSubTask(
 )
 
 
-set_grounded_sam_subtask = CheckServiceFieldsToolCallSubTask(
+set_grounded_sam_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDED_SAM_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -224,7 +227,7 @@ set_grounded_sam_subtask = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.double_value": DEFAULT_SAM_CONFIDENCE,
     },
 )
-set_grounded_sam_atomically_subtask = CheckServiceFieldsToolCallSubTask(
+set_grounded_sam_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -235,7 +238,7 @@ set_grounded_sam_atomically_subtask = CheckServiceFieldsToolCallSubTask(
     },
 )
 
-set_grounding_dino_subtask = CheckServiceFieldsToolCallSubTask(
+set_grounded_dino_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDING_DINO_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -245,7 +248,7 @@ set_grounding_dino_subtask = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.double_value": DEFAULT_DINO_CONFIDENCE,
     },
 )
-set_grounding_dino_atomically_subtask = CheckServiceFieldsToolCallSubTask(
+set_grounding_dino_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -256,7 +259,7 @@ set_grounding_dino_atomically_subtask = CheckServiceFieldsToolCallSubTask(
     },
 )
 
-set_o3de_fps_subtask = CheckServiceFieldsToolCallSubTask(
+set_o3de_fps_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=O3DE_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -266,7 +269,7 @@ set_o3de_fps_subtask = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.integer_value": DEFAULT_FPS,
     },
 )
-set_o3de_fps_atomically_subtask = CheckServiceFieldsToolCallSubTask(
+set_o3de_fps_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=O3DE_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -276,6 +279,70 @@ set_o3de_fps_atomically_subtask = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.integer_value": DEFAULT_FPS,
     },
 )
+
+set_grounded_sam_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=GROUNDED_SAM_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
+    expected_fields={
+        "parameters.0.name": "confidence_threshold",
+        "parameters.0.value.type": 3,
+        "parameters.0.value.double_value": SAM_CONFIDENCE_2,
+    },
+)
+set_grounded_sam_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
+    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
+    expected_fields={
+        "parameters.0.name": "confidence_threshold",
+        "parameters.0.value.type": 3,
+        "parameters.0.value.double_value": SAM_CONFIDENCE_2,
+    },
+)
+
+set_grounding_dino_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=GROUNDING_DINO_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
+    expected_fields={
+        "parameters.0.name": "confidence_threshold",
+        "parameters.0.value.type": 3,
+        "parameters.0.value.double_value": DINO_CONFIDENCE_2,
+    },
+)
+set_grounding_dino_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
+    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
+    expected_fields={
+        "parameters.0.name": "confidence_threshold",
+        "parameters.0.value.type": 3,
+        "parameters.0.value.double_value": DINO_CONFIDENCE_2,
+    },
+)
+
+set_o3de_fps_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=O3DE_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
+    expected_fields={
+        "parameters.0.name": "fps",
+        "parameters.0.value.type": 2,
+        "parameters.0.value.integer_value": FPS_2,
+    },
+)
+set_o3de_fps_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service=O3DE_SET_PARAMS_ATOMICALLY,
+    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
+    expected_fields={
+        "parameters.0.name": "fps",
+        "parameters.0.value.type": 2,
+        "parameters.0.value.integer_value": FPS_2,
+    },
+)
+
 
 delete_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
@@ -353,12 +420,25 @@ check_spawnable_entities_val = OrderedCallsValidator(
 )
 spawn_entity_val = OrderedCallsValidator(subtasks=[spawn_entity_subtask])
 
-vision_pipeline_config_val = NotOrderedCallsValidator(
-    subtasks=[
-        set_grounded_sam_atomically_subtask,
-        set_grounding_dino_atomically_subtask,
-        set_o3de_fps_atomically_subtask,
-    ]
+set_grounded_sam_opt_val_1 = OptionalValidator(
+    subtasks=[set_grounded_sam_subtask_1, set_grounded_sam_atomically_subtask_1]
+)
+set_grounded_dino_opt_val_1 = OptionalValidator(
+    subtasks=[set_grounded_dino_subtask_1, set_grounding_dino_atomically_subtask_1]
+)
+set_o3de_fps_opt_val_1 = OptionalValidator(
+    subtasks=[set_o3de_fps_subtask_1, set_o3de_fps_atomically_subtask_1]
+)
+
+
+set_grounded_sam_opt_val_2 = OptionalValidator(
+    subtasks=[set_grounded_sam_subtask_2, set_grounded_sam_atomically_subtask_2]
+)
+set_grounded_dino_opt_val_2 = OptionalValidator(
+    subtasks=[set_grounding_dino_subtask_2, set_grounding_dino_atomically_subtask_2]
+)
+set_o3de_fps_opt_val_2 = OptionalValidator(
+    subtasks=[set_o3de_fps_subtask_2, set_o3de_fps_atomically_subtask_2]
 )
 
 
@@ -448,14 +528,22 @@ def get_basic_tasks(
                             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
                             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
                             fps=DEFAULT_FPS,
-                            validators=[vision_pipeline_config_val],
+                            validators=[
+                                set_grounded_sam_opt_val_1,
+                                set_grounded_dino_opt_val_1,
+                                set_o3de_fps_opt_val_1,
+                            ],
                             task_args=task_args,
                         ),
                         ConfigureVisionPipelineTask(
                             sam_confidence_threshold=0.6,
                             dino_confidence_threshold=0.6,
                             fps=10,
-                            validators=[vision_pipeline_config_val],
+                            validators=[
+                                set_grounded_sam_opt_val_2,
+                                set_grounded_dino_opt_val_2,
+                                set_o3de_fps_opt_val_2,
+                            ],
                             task_args=task_args,
                         ),
                         RespawnEntitiesTask(

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -20,16 +20,21 @@ from rai_bench.tool_calling_agent.interfaces import (
 )
 from rai_bench.tool_calling_agent.subtasks import (
     CheckArgsToolCallSubTask,
+    CheckServiceFieldsToolCallSubTask,
 )
 from rai_bench.tool_calling_agent.tasks.basic import (
-    AssessSensorDataQualityTask,
-    CheckRobotHealthTask,
+    CheckSpawnableEntitiesTask,
     GetAllROS2CamerasTask,
     GetPointcloudTask,
     GetRobotDescriptionTask,
     GetROS2DepthCameraTask,
     GetROS2RGBCameraTask,
+    GetROS2ServicesTask,
     GetROS2TopicsTask,
+    GetSpecificParameterTask,
+    ListRobotParametersTask,
+    SetRobotParameterTask,
+    SpawnEntityTask,
 )
 from rai_bench.tool_calling_agent.validators import (
     NotOrderedCallsValidator,
@@ -37,6 +42,7 @@ from rai_bench.tool_calling_agent.validators import (
 )
 
 ########## SUBTASKS #################################################################
+
 get_topics_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
 )
@@ -53,13 +59,13 @@ depth_image5_subtask = CheckArgsToolCallSubTask(
 )
 
 color_camera_info5_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="get_ros2_image",
-    expected_args={"topic": "/color_image5"},
+    expected_tool_name="receive_ros2_message",
+    expected_args={"topic": "/color_camera_info5"},
     expected_optional_args={"timeout_sec": int},
 )
 depth_camera_info5_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="get_ros2_image",
-    expected_args={"topic": "/depth_image5"},
+    expected_tool_name="receive_ros2_message",
+    expected_args={"topic": "/depth_camera_info5"},
     expected_optional_args={"timeout_sec": int},
 )
 
@@ -75,61 +81,14 @@ receive_pointcloud_subtask = CheckArgsToolCallSubTask(
     expected_optional_args={"timeout_sec": int},
 )
 
-# System health subtasks
-diagnostics_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/diagnostics"},
-    expected_optional_args={"timeout_sec": int},
-)
-rosout_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/rosout"},
-    expected_optional_args={"timeout_sec": int},
-)
-joint_states_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/joint_states"},
-    expected_optional_args={"timeout_sec": int},
-)
 
-# Odometry subtasks
-odom_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/odom"},
-    expected_optional_args={"timeout_sec": int},
-)
-filtered_odom_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/odometry/filtered"},
-    expected_optional_args={"timeout_sec": int},
-)
-
-# Transform subtasks
-tf_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/tf"},
-    expected_optional_args={"timeout_sec": int},
-)
-tf_static_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/tf_static"},
-    expected_optional_args={"timeout_sec": int},
-)
-
-
-# Robot description subtasks
 robot_description_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
     expected_args={"topic": "/robot_description"},
     expected_optional_args={"timeout_sec": int},
 )
-robot_description_semantic_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description_semantic"},
-    expected_optional_args={"timeout_sec": int},
-)
 
-# Sensor data subtasks
+
 scan_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
     expected_args={"topic": "/scan"},
@@ -142,42 +101,53 @@ pointcloud_subtask = CheckArgsToolCallSubTask(
 )
 
 
-# Robot description subtasks
-robot_description_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description"},
-    expected_optional_args={"timeout_sec": int},
-)
-robot_description_semantic_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description_semantic"},
-    expected_optional_args={"timeout_sec": int},
+get_services_subtask = CheckArgsToolCallSubTask(
+    expected_tool_name="get_ros2_services_names_and_types", expected_args={}
 )
 
-# Sensor data subtasks
-scan_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/scan"},
-    expected_optional_args={"timeout_sec": int},
-)
-pointcloud_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/pointcloud"},
-    expected_optional_args={"timeout_sec": int},
+list_parameters_subtask = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service="/robot_state_publisher/list_parameters",
+    expected_service_type="rcl_interfaces/srv/ListParameters",
+    expected_fields={"": {}},
 )
 
-# Robot description subtasks
-robot_description_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description"},
-    expected_optional_args={"timeout_sec": int},
-)
-robot_description_semantic_subtask = CheckArgsToolCallSubTask(
-    expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description_semantic"},
-    expected_optional_args={"timeout_sec": int},
+get_parameters_subtask = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service="/robot_state_publisher/get_parameters",
+    expected_service_type="rcl_interfaces/srv/GetParameters",
+    expected_fields={"names.0": "publish_frequency"},
 )
 
+check_spawnable_entities_subtask = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service="/get_available_spawnable_names",
+    expected_service_type="gazebo_msgs/srv/GetModelList",
+    expected_fields={"": {}},
+)
+
+spawn_entity_subtask = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service="/spawn_entity",
+    expected_service_type="gazebo_msgs/srv/SpawnEntity",
+    expected_fields={
+        "name": "test_box",
+        "xml": str,
+    },
+)
+
+set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
+    expected_tool_name="call_ros2_service",
+    expected_service="/robot_state_publisher/set_parameters",
+    expected_service_type="rcl_interfaces/srv/SetParameters",
+    expected_fields={
+        "parameters.0.name": "publish_frequency",
+        "parameters.0.value.type": "3",
+        "parameters.0.value.double_value": 30.0,
+    },
+)
+
+set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
 ######### VALIDATORS #########################################################################################
 topics_ord_val = OrderedCallsValidator(subtasks=[get_topics_subtask])
 
@@ -187,12 +157,12 @@ depth_image_ord_val = OrderedCallsValidator(subtasks=[depth_image5_subtask])
 color_camera_info_ord_val = OrderedCallsValidator(subtasks=[color_camera_info5_subtask])
 depth_camera_info_ord_val = OrderedCallsValidator(subtasks=[depth_camera_info5_subtask])
 
-color_image_with_info_ord_val = NotOrderedCallsValidator(
-    subtasks=[color_image5_subtask, color_camera_info5_subtask]
-)
-depth_image_with_info_ord_val = NotOrderedCallsValidator(
-    subtasks=[depth_image5_subtask, color_camera_info5_subtask]
-)
+# color_image_with_info_ord_val = NotOrderedCallsValidator(
+#     subtasks=[color_image5_subtask, color_camera_info5_subtask]
+# )
+# depth_image_with_info_ord_val = NotOrderedCallsValidator(
+#     subtasks=[depth_image5_subtask, color_camera_info5_subtask]
+# )
 
 all_camera_images_notord_val = NotOrderedCallsValidator(
     subtasks=[
@@ -200,44 +170,19 @@ all_camera_images_notord_val = NotOrderedCallsValidator(
         depth_image5_subtask,
     ]
 )
-all_camera_info_notord_val = NotOrderedCallsValidator(
-    subtasks=[
-        color_camera_info5_subtask,
-        depth_camera_info5_subtask,
-    ]
-)
-all_camera_images_with_info_notord_val = NotOrderedCallsValidator(
-    subtasks=[
-        color_image5_subtask,
-        depth_image5_subtask,
-        color_camera_info5_subtask,
-        depth_camera_info5_subtask,
-    ]
-)
 
-joint_states_ord_val = OrderedCallsValidator(subtasks=[joint_states_subtask])
-diagnostics_ord_val = OrderedCallsValidator(subtasks=[diagnostics_subtask])
 
 get_pointcloud_ord_val = OrderedCallsValidator(subtasks=[receive_pointcloud_subtask])
 get_robot_desc_ord_val = OrderedCallsValidator(subtasks=[receive_robot_desc_subtask])
 
-robot_health_val = NotOrderedCallsValidator(
-    subtasks=[diagnostics_subtask, joint_states_subtask, rosout_subtask]
-)
 
-odometry_comparison_val = NotOrderedCallsValidator(
-    subtasks=[odom_subtask, filtered_odom_subtask]
+services_ord_val = OrderedCallsValidator(subtasks=[get_services_subtask])
+list_parameters_val = OrderedCallsValidator(subtasks=[list_parameters_subtask])
+get_parameters_val = OrderedCallsValidator(subtasks=[get_parameters_subtask])
+check_spawnable_entities_val = OrderedCallsValidator(
+    subtasks=[check_spawnable_entities_subtask]
 )
-sensor_data_val = NotOrderedCallsValidator(
-    subtasks=[
-        scan_subtask,
-        receive_pointcloud_subtask,
-        color_image5_subtask,
-        depth_image5_subtask,
-        color_camera_info5_subtask,
-        depth_camera_info5_subtask,
-    ]
-)
+spawn_entity_val = OrderedCallsValidator(subtasks=[spawn_entity_subtask])
 
 
 def get_basic_tasks(
@@ -292,13 +237,28 @@ def get_basic_tasks(
                         GetRobotDescriptionTask(
                             validators=[get_robot_desc_ord_val], task_args=task_args
                         ),
-                        CheckRobotHealthTask(
-                            validators=[robot_health_val],
+                        GetROS2ServicesTask(
+                            validators=[services_ord_val],
                             task_args=task_args,
                         ),
-                        AssessSensorDataQualityTask(
-                            validators=[sensor_data_val],
+                        ListRobotParametersTask(
+                            validators=[list_parameters_val],
                             task_args=task_args,
+                        ),
+                        GetSpecificParameterTask(
+                            validators=[get_parameters_val],
+                            task_args=task_args,
+                        ),
+                        CheckSpawnableEntitiesTask(
+                            validators=[check_spawnable_entities_val],
+                            task_args=task_args,
+                        ),
+                        SpawnEntityTask(
+                            validators=[spawn_entity_val],
+                            task_args=task_args,
+                        ),
+                        SetRobotParameterTask(
+                            validators=[set_param_val], task_args=task_args
                         ),
                     ]
                 )

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -43,6 +43,62 @@ from rai_bench.tool_calling_agent.validators import (
     OrderedCallsValidator,
 )
 
+# Topic Names
+COLOR_IMAGE_TOPIC = "/color_image5"
+DEPTH_IMAGE_TOPIC = "/depth_image5"
+COLOR_CAMERA_INFO_TOPIC = "/color_camera_info5"
+DEPTH_CAMERA_INFO_TOPIC = "/depth_camera_info5"
+ROBOT_DESCRIPTION_TOPIC = "/robot_description"
+POINTCLOUD_TOPIC = "/pointcloud"
+SCAN_TOPIC = "/scan"
+
+# Service Names
+ROBOT_STATE_PUBLISHER_LIST_PARAMS = "/robot_state_publisher/list_parameters"
+ROBOT_STATE_PUBLISHER_GET_PARAMS = "/robot_state_publisher/get_parameters"
+ROBOT_STATE_PUBLISHER_SET_PARAMS = "/robot_state_publisher/set_parameters"
+SPAWN_ENTITY_SERVICE = "/spawn_entity"
+DELETE_ENTITY_SERVICE = "/delete_entity"
+GET_SPAWNABLE_NAMES_SERVICE = "/get_available_spawnable_names"
+GROUNDED_SAM_SET_PARAMS = "/grounded_sam/set_parameters"
+GROUNDING_DINO_SET_PARAMS = "/grounding_dino/set_parameters"
+O3DE_SET_PARAMS = "/o3de_ros2_node/set_parameters"
+
+# Service Types
+LIST_PARAMETERS_TYPE = "rcl_interfaces/srv/ListParameters"
+SET_PARAMETERS_TYPE = "rcl_interfaces/srv/SetParameters"
+GET_PARAMETERS_TYPE = "rcl_interfaces/srv/GetParameters"
+SPAWN_ENTITY_TYPE = "gazebo_msgs/srv/SpawnEntity"
+DELETE_ENTITY_TYPE = "gazebo_msgs/srv/DeleteEntity"
+GET_WORLD_PROPERTIES_TYPE = "gazebo_msgs/srv/GetWorldProperties"
+
+# Default Values
+DEFAULT_PUBLISH_FREQUENCY = 30.0
+DEFAULT_FPS = 30
+DEFAULT_SAM_CONFIDENCE = 0.8
+DEFAULT_DINO_CONFIDENCE = 0.7
+
+# Entity Names and Positions
+TOMATO_ENTITY = "tomato"
+BOX1_ENTITY = "box1"
+BOX2_ENTITY = "box2"
+BOX1_POSITION = (0.2, 0.2, 0.2)
+BOX2_POSITION = (0.4, 0.4, 0.2)
+
+# CAMERA Topics and Types
+CAMERA_TOPICS_AND_TYPES = [
+    f"topic: {COLOR_CAMERA_INFO_TOPIC}\ntype: sensor_msgs/msg/CameraInfo\n",
+    f"topic: {COLOR_IMAGE_TOPIC}\ntype: sensor_msgs/msg/Image\n",
+    f"topic: {DEPTH_CAMERA_INFO_TOPIC}\ntype: sensor_msgs/msg/CameraInfo\n",
+    f"topic: {DEPTH_IMAGE_TOPIC}\ntype: sensor_msgs/msg/Image\n",
+]
+
+CAMERA_TOPICS = [
+    COLOR_CAMERA_INFO_TOPIC,
+    COLOR_IMAGE_TOPIC,
+    DEPTH_CAMERA_INFO_TOPIC,
+    DEPTH_IMAGE_TOPIC,
+]
+
 ########## SUBTASKS #################################################################
 
 get_topics_subtask = CheckArgsToolCallSubTask(
@@ -51,54 +107,54 @@ get_topics_subtask = CheckArgsToolCallSubTask(
 
 color_image5_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_image",
-    expected_args={"topic": "/color_image5"},
+    expected_args={"topic": COLOR_IMAGE_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 depth_image5_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_image",
-    expected_args={"topic": "/depth_image5"},
+    expected_args={"topic": DEPTH_IMAGE_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
 color_camera_info5_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/color_camera_info5"},
+    expected_args={"topic": COLOR_CAMERA_INFO_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 depth_camera_info5_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/depth_camera_info5"},
+    expected_args={"topic": DEPTH_CAMERA_INFO_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
 receive_robot_desc_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description"},
+    expected_args={"topic": ROBOT_DESCRIPTION_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
 receive_pointcloud_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/pointcloud"},
+    expected_args={"topic": POINTCLOUD_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
 
 robot_description_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/robot_description"},
+    expected_args={"topic": ROBOT_DESCRIPTION_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
 
 scan_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/scan"},
+    expected_args={"topic": SCAN_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 pointcloud_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
-    expected_args={"topic": "/pointcloud"},
+    expected_args={"topic": POINTCLOUD_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
 
@@ -109,42 +165,42 @@ get_services_subtask = CheckArgsToolCallSubTask(
 
 list_parameters_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/robot_state_publisher/list_parameters",
-    expected_service_type="rcl_interfaces/srv/ListParameters",
+    expected_service=ROBOT_STATE_PUBLISHER_LIST_PARAMS,
+    expected_service_type=LIST_PARAMETERS_TYPE,
     expected_fields={"": {}},
 )
 
 get_parameters_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/robot_state_publisher/get_parameters",
-    expected_service_type="rcl_interfaces/srv/GetParameters",
+    expected_service=ROBOT_STATE_PUBLISHER_GET_PARAMS,
+    expected_service_type=GET_PARAMETERS_TYPE,
     expected_fields={"names.0": "publish_frequency"},
 )
 
 check_spawnable_entities_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/get_available_spawnable_names",
-    expected_service_type="gazebo_msgs/srv/GetWorldProperties",
+    expected_service=GET_SPAWNABLE_NAMES_SERVICE,
+    expected_service_type=GET_WORLD_PROPERTIES_TYPE,
     expected_fields={"": {}},
 )
 
 spawn_entity_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/spawn_entity",
-    expected_service_type="gazebo_msgs/srv/SpawnEntity",
+    expected_service=SPAWN_ENTITY_SERVICE,
+    expected_service_type=SPAWN_ENTITY_TYPE,
     expected_fields={
-        "name": "tomato",
+        "name": TOMATO_ENTITY,
     },
 )
 
 set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/robot_state_publisher/set_parameters",
-    expected_service_type="rcl_interfaces/srv/SetParameters",
+    expected_service=ROBOT_STATE_PUBLISHER_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
     expected_fields={
         "parameters.0.name": "publish_frequency",
         "parameters.0.value.type": "3",
-        "parameters.0.value.double_value": 30.0,
+        "parameters.0.value.double_value": DEFAULT_PUBLISH_FREQUENCY,
     },
 )
 
@@ -152,72 +208,72 @@ set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
 
 grounded_sam_config_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/grounded_sam/set_parameters",
-    expected_service_type="rcl_interfaces/srv/SetParameters",
+    expected_service=GROUNDED_SAM_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
     expected_fields={
         "parameters.0.name": "confidence_threshold",
         "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": 0.8,
+        "parameters.0.value.double_value": DEFAULT_SAM_CONFIDENCE,
     },
 )
 
 grounding_dino_config_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/grounding_dino/set_parameters",
-    expected_service_type="rcl_interfaces/srv/SetParameters",
+    expected_service=GROUNDING_DINO_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
     expected_fields={
         "parameters.0.name": "confidence_threshold",
         "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": 0.7,
+        "parameters.0.value.double_value": DEFAULT_DINO_CONFIDENCE,
     },
 )
 o3de_fps_config_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/o3de_ros2_node/set_parameters",
-    expected_service_type="rcl_interfaces/srv/SetParameters",
+    expected_service=O3DE_SET_PARAMS,
+    expected_service_type=SET_PARAMETERS_TYPE,
     expected_fields={
         "parameters.0.name": "fps",
         "parameters.0.value.type": 2,
-        "parameters.0.value.integer_value": 30,
+        "parameters.0.value.integer_value": DEFAULT_FPS,
     },
 )
 
 delete_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/delete_entity",
-    expected_service_type="gazebo_msgs/srv/DeleteEntity",
+    expected_service=DELETE_ENTITY_SERVICE,
+    expected_service_type=DELETE_ENTITY_TYPE,
     expected_fields={
-        "name": "box1",
+        "name": BOX1_ENTITY,
     },
 )
 delete_entity_subtask2 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/delete_entity",
-    expected_service_type="gazebo_msgs/srv/DeleteEntity",
+    expected_service=DELETE_ENTITY_SERVICE,
+    expected_service_type=DELETE_ENTITY_TYPE,
     expected_fields={
-        "name": "box2",
+        "name": BOX2_ENTITY,
     },
 )
 spawn_entity_subtask1 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/spawn_entity",
-    expected_service_type="gazebo_msgs/srv/SpawnEntity",
+    expected_service=SPAWN_ENTITY_SERVICE,
+    expected_service_type=SPAWN_ENTITY_TYPE,
     expected_fields={
-        "name": "box1",
-        "initial_pose.position.x": 0.2,
-        "initial_pose.position.y": 0.2,
-        "initial_pose.position.z": 0.2,
+        "name": BOX1_ENTITY,
+        "initial_pose.position.x": BOX1_POSITION[0],
+        "initial_pose.position.y": BOX1_POSITION[1],
+        "initial_pose.position.z": BOX1_POSITION[2],
     },
 )
 spawn_entity_subtask2 = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
-    expected_service="/spawn_entity",
-    expected_service_type="gazebo_msgs/srv/SpawnEntity",
+    expected_service=SPAWN_ENTITY_SERVICE,
+    expected_service_type=SPAWN_ENTITY_TYPE,
     expected_fields={
-        "name": "box2",
-        "initial_pose.position.x": 0.4,
-        "initial_pose.position.y": 0.4,
-        "initial_pose.position.z": 0.2,
+        "name": BOX2_ENTITY,
+        "initial_pose.position.x": BOX2_POSITION[0],
+        "initial_pose.position.y": BOX2_POSITION[1],
+        "initial_pose.position.z": BOX2_POSITION[2],
     },
 )
 
@@ -235,13 +291,6 @@ depth_image_ord_val = OrderedCallsValidator(subtasks=[depth_image5_subtask])
 
 color_camera_info_ord_val = OrderedCallsValidator(subtasks=[color_camera_info5_subtask])
 depth_camera_info_ord_val = OrderedCallsValidator(subtasks=[depth_camera_info5_subtask])
-
-# color_image_with_info_ord_val = NotOrderedCallsValidator(
-#     subtasks=[color_image5_subtask, color_camera_info5_subtask]
-# )
-# depth_image_with_info_ord_val = NotOrderedCallsValidator(
-#     subtasks=[depth_image5_subtask, color_camera_info5_subtask]
-# )
 
 all_camera_images_notord_val = NotOrderedCallsValidator(
     subtasks=[
@@ -342,20 +391,22 @@ def get_basic_tasks(
                             task_args=task_args,
                         ),
                         SpawnEntityTask(
-                            entity="tomato",
+                            entity=TOMATO_ENTITY,
                             validators=[spawn_entity_val],
                             task_args=task_args,
                         ),
                         SetRobotParameterTask(
-                            value=30.0, validators=[set_param_val], task_args=task_args
+                            value=DEFAULT_PUBLISH_FREQUENCY,
+                            validators=[set_param_val],
+                            task_args=task_args,
                         ),
                         SetRobotParameterTask(
                             value=25.0, validators=[set_param_val], task_args=task_args
                         ),
                         ConfigureVisionPipelineTask(
-                            sam_confidence_threshold=0.8,
-                            dino_confidence_threshold=0.5,
-                            fps=30,
+                            sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
+                            dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
+                            fps=DEFAULT_FPS,
                             validators=[vision_pipeline_config_val],
                             task_args=task_args,
                         ),
@@ -367,8 +418,8 @@ def get_basic_tasks(
                             task_args=task_args,
                         ),
                         RespawnEntitiesTask(
-                            names=["box1", "box2"],
-                            coords=[(0.2, 0.2, 0.2), (0.4, 0.4, 0.2)],
+                            names=[BOX1_ENTITY, BOX2_ENTITY],
+                            coords=[BOX1_POSITION, BOX2_POSITION],
                             validators=[delete_both_val, spawn_both_val],
                             task_args=task_args,
                         ),

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -40,7 +40,7 @@ from rai_bench.tool_calling_agent.tasks.basic import (
 )
 from rai_bench.tool_calling_agent.validators import (
     NotOrderedCallsValidator,
-    OptionalValidator,
+    OneFromManyValidator,
     OrderedCallsValidator,
 )
 
@@ -409,7 +409,7 @@ all_camera_images_notord_val = NotOrderedCallsValidator(
 get_pointcloud_ord_val = OrderedCallsValidator(subtasks=[receive_pointcloud_subtask])
 get_robot_desc_ord_val = OrderedCallsValidator(subtasks=[receive_robot_desc_subtask])
 
-set_param_val = OptionalValidator(
+set_param_val = OneFromManyValidator(
     subtasks=[set_robot_state_params_subtask, set_robot_state_params_atomically_subtask]
 )
 services_ord_val = OrderedCallsValidator(subtasks=[get_services_subtask])
@@ -420,24 +420,24 @@ check_spawnable_entities_val = OrderedCallsValidator(
 )
 spawn_entity_val = OrderedCallsValidator(subtasks=[spawn_entity_subtask])
 
-set_grounded_sam_opt_val_1 = OptionalValidator(
+set_grounded_sam_opt_val_1 = OneFromManyValidator(
     subtasks=[set_grounded_sam_subtask_1, set_grounded_sam_atomically_subtask_1]
 )
-set_grounded_dino_opt_val_1 = OptionalValidator(
+set_grounded_dino_opt_val_1 = OneFromManyValidator(
     subtasks=[set_grounded_dino_subtask_1, set_grounding_dino_atomically_subtask_1]
 )
-set_o3de_fps_opt_val_1 = OptionalValidator(
+set_o3de_fps_opt_val_1 = OneFromManyValidator(
     subtasks=[set_o3de_fps_subtask_1, set_o3de_fps_atomically_subtask_1]
 )
 
 
-set_grounded_sam_opt_val_2 = OptionalValidator(
+set_grounded_sam_opt_val_2 = OneFromManyValidator(
     subtasks=[set_grounded_sam_subtask_2, set_grounded_sam_atomically_subtask_2]
 )
-set_grounded_dino_opt_val_2 = OptionalValidator(
+set_grounded_dino_opt_val_2 = OneFromManyValidator(
     subtasks=[set_grounding_dino_subtask_2, set_grounding_dino_atomically_subtask_2]
 )
-set_o3de_fps_opt_val_2 = OptionalValidator(
+set_o3de_fps_opt_val_2 = OneFromManyValidator(
     subtasks=[set_o3de_fps_subtask_2, set_o3de_fps_atomically_subtask_2]
 )
 

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -43,7 +43,6 @@ from rai_bench.tool_calling_agent.validators import (
     OrderedCallsValidator,
 )
 
-# Topic Names
 COLOR_IMAGE_TOPIC = "/color_image5"
 DEPTH_IMAGE_TOPIC = "/depth_image5"
 COLOR_CAMERA_INFO_TOPIC = "/color_camera_info5"
@@ -52,7 +51,6 @@ ROBOT_DESCRIPTION_TOPIC = "/robot_description"
 POINTCLOUD_TOPIC = "/pointcloud"
 SCAN_TOPIC = "/scan"
 
-# Service Names
 ROBOT_STATE_PUBLISHER_LIST_PARAMS = "/robot_state_publisher/list_parameters"
 ROBOT_STATE_PUBLISHER_GET_PARAMS = "/robot_state_publisher/get_parameters"
 ROBOT_STATE_PUBLISHER_SET_PARAMS = "/robot_state_publisher/set_parameters"
@@ -63,7 +61,6 @@ GROUNDED_SAM_SET_PARAMS = "/grounded_sam/set_parameters"
 GROUNDING_DINO_SET_PARAMS = "/grounding_dino/set_parameters"
 O3DE_SET_PARAMS = "/o3de_ros2_node/set_parameters"
 
-# Service Types
 LIST_PARAMETERS_TYPE = "rcl_interfaces/srv/ListParameters"
 SET_PARAMETERS_TYPE = "rcl_interfaces/srv/SetParameters"
 GET_PARAMETERS_TYPE = "rcl_interfaces/srv/GetParameters"
@@ -71,20 +68,17 @@ SPAWN_ENTITY_TYPE = "gazebo_msgs/srv/SpawnEntity"
 DELETE_ENTITY_TYPE = "gazebo_msgs/srv/DeleteEntity"
 GET_WORLD_PROPERTIES_TYPE = "gazebo_msgs/srv/GetWorldProperties"
 
-# Default Values
 DEFAULT_PUBLISH_FREQUENCY = 30.0
 DEFAULT_FPS = 30
 DEFAULT_SAM_CONFIDENCE = 0.8
 DEFAULT_DINO_CONFIDENCE = 0.7
 
-# Entity Names and Positions
 TOMATO_ENTITY = "tomato"
 BOX1_ENTITY = "box1"
 BOX2_ENTITY = "box2"
 BOX1_POSITION = (0.2, 0.2, 0.2)
 BOX2_POSITION = (0.4, 0.4, 0.2)
 
-# CAMERA Topics and Types
 CAMERA_TOPICS_AND_TYPES = [
     f"topic: {COLOR_CAMERA_INFO_TOPIC}\ntype: sensor_msgs/msg/CameraInfo\n",
     f"topic: {COLOR_IMAGE_TOPIC}\ntype: sensor_msgs/msg/Image\n",
@@ -98,9 +92,7 @@ CAMERA_TOPICS = [
     DEPTH_CAMERA_INFO_TOPIC,
     DEPTH_IMAGE_TOPIC,
 ]
-
 ########## SUBTASKS #################################################################
-
 get_topics_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
 )
@@ -139,13 +131,11 @@ receive_pointcloud_subtask = CheckArgsToolCallSubTask(
     expected_optional_args={"timeout_sec": int},
 )
 
-
 robot_description_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",
     expected_args={"topic": ROBOT_DESCRIPTION_TOPIC},
     expected_optional_args={"timeout_sec": int},
 )
-
 
 scan_subtask = CheckArgsToolCallSubTask(
     expected_tool_name="receive_ros2_message",

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -217,7 +217,7 @@ set_robot_state_params_atomically_subtask = CheckServiceFieldsToolCallSubTask(
 )
 
 
-set_grounded_sam_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_grounded_sam_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDED_SAM_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -227,7 +227,7 @@ set_grounded_sam_subtask_1 = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.double_value": DEFAULT_SAM_CONFIDENCE,
     },
 )
-set_grounded_sam_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_grounded_sam_atomically_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -238,7 +238,7 @@ set_grounded_sam_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
     },
 )
 
-set_grounded_dino_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_grounded_dino_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDING_DINO_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -248,7 +248,7 @@ set_grounded_dino_subtask_1 = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.double_value": DEFAULT_DINO_CONFIDENCE,
     },
 )
-set_grounding_dino_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_grounding_dino_atomically_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -259,7 +259,7 @@ set_grounding_dino_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
     },
 )
 
-set_o3de_fps_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_o3de_fps_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=O3DE_SET_PARAMS,
     expected_service_type=SET_PARAMETERS_TYPE,
@@ -269,7 +269,7 @@ set_o3de_fps_subtask_1 = CheckServiceFieldsToolCallSubTask(
         "parameters.0.value.integer_value": DEFAULT_FPS,
     },
 )
-set_o3de_fps_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
+set_o3de_fps_atomically_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service=O3DE_SET_PARAMS_ATOMICALLY,
     expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
@@ -277,69 +277,6 @@ set_o3de_fps_atomically_subtask_1 = CheckServiceFieldsToolCallSubTask(
         "parameters.0.name": "fps",
         "parameters.0.value.type": 2,
         "parameters.0.value.integer_value": DEFAULT_FPS,
-    },
-)
-
-set_grounded_sam_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDED_SAM_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": SAM_CONFIDENCE_2,
-    },
-)
-set_grounded_sam_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": SAM_CONFIDENCE_2,
-    },
-)
-
-set_grounding_dino_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDING_DINO_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DINO_CONFIDENCE_2,
-    },
-)
-set_grounding_dino_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "confidence_threshold",
-        "parameters.0.value.type": 3,
-        "parameters.0.value.double_value": DINO_CONFIDENCE_2,
-    },
-)
-
-set_o3de_fps_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=O3DE_SET_PARAMS,
-    expected_service_type=SET_PARAMETERS_TYPE,
-    expected_fields={
-        "parameters.0.name": "fps",
-        "parameters.0.value.type": 2,
-        "parameters.0.value.integer_value": FPS_2,
-    },
-)
-set_o3de_fps_atomically_subtask_2 = CheckServiceFieldsToolCallSubTask(
-    expected_tool_name="call_ros2_service",
-    expected_service=O3DE_SET_PARAMS_ATOMICALLY,
-    expected_service_type=SET_PARAMETERS_ATOMICALLY_TYPE,
-    expected_fields={
-        "parameters.0.name": "fps",
-        "parameters.0.value.type": 2,
-        "parameters.0.value.integer_value": FPS_2,
     },
 )
 
@@ -420,25 +357,14 @@ check_spawnable_entities_val = OrderedCallsValidator(
 )
 spawn_entity_val = OrderedCallsValidator(subtasks=[spawn_entity_subtask])
 
-set_grounded_sam_opt_val_1 = OneFromManyValidator(
-    subtasks=[set_grounded_sam_subtask_1, set_grounded_sam_atomically_subtask_1]
+set_grounded_sam_opt_val = OneFromManyValidator(
+    subtasks=[set_grounded_sam_subtask, set_grounded_sam_atomically_subtask]
 )
-set_grounded_dino_opt_val_1 = OneFromManyValidator(
-    subtasks=[set_grounded_dino_subtask_1, set_grounding_dino_atomically_subtask_1]
+set_grounded_dino_opt_val = OneFromManyValidator(
+    subtasks=[set_grounded_dino_subtask, set_grounding_dino_atomically_subtask]
 )
-set_o3de_fps_opt_val_1 = OneFromManyValidator(
-    subtasks=[set_o3de_fps_subtask_1, set_o3de_fps_atomically_subtask_1]
-)
-
-
-set_grounded_sam_opt_val_2 = OneFromManyValidator(
-    subtasks=[set_grounded_sam_subtask_2, set_grounded_sam_atomically_subtask_2]
-)
-set_grounded_dino_opt_val_2 = OneFromManyValidator(
-    subtasks=[set_grounding_dino_subtask_2, set_grounding_dino_atomically_subtask_2]
-)
-set_o3de_fps_opt_val_2 = OneFromManyValidator(
-    subtasks=[set_o3de_fps_subtask_2, set_o3de_fps_atomically_subtask_2]
+set_o3de_fps_opt_val = OneFromManyValidator(
+    subtasks=[set_o3de_fps_subtask, set_o3de_fps_atomically_subtask]
 )
 
 
@@ -529,20 +455,9 @@ def get_basic_tasks(
                             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
                             fps=DEFAULT_FPS,
                             validators=[
-                                set_grounded_sam_opt_val_1,
-                                set_grounded_dino_opt_val_1,
-                                set_o3de_fps_opt_val_1,
-                            ],
-                            task_args=task_args,
-                        ),
-                        ConfigureVisionPipelineTask(
-                            sam_confidence_threshold=0.6,
-                            dino_confidence_threshold=0.6,
-                            fps=10,
-                            validators=[
-                                set_grounded_sam_opt_val_2,
-                                set_grounded_dino_opt_val_2,
-                                set_o3de_fps_opt_val_2,
+                                set_grounded_sam_opt_val,
+                                set_grounded_dino_opt_val,
+                                set_o3de_fps_opt_val,
                             ],
                             task_args=task_args,
                         ),

--- a/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/predefined/basic_tasks.py
@@ -124,7 +124,7 @@ get_parameters_subtask = CheckServiceFieldsToolCallSubTask(
 check_spawnable_entities_subtask = CheckServiceFieldsToolCallSubTask(
     expected_tool_name="call_ros2_service",
     expected_service="/get_available_spawnable_names",
-    expected_service_type="gazebo_msgs/srv/GetModelList",
+    expected_service_type="gazebo_msgs/srv/GetWorldProperties",
     expected_fields={"": {}},
 )
 
@@ -133,7 +133,7 @@ spawn_entity_subtask = CheckServiceFieldsToolCallSubTask(
     expected_service="/spawn_entity",
     expected_service_type="gazebo_msgs/srv/SpawnEntity",
     expected_fields={
-        "name": "test_box",
+        "name": "tomato",
     },
 )
 

--- a/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
@@ -415,7 +415,7 @@ class ConfigureVisionPipelineTask(BasicTask):
             f"Configure AI vision pipeline: set grounded_sam `confidence_threshold` "
             f"to {self.sam_confidence_threshold}, grounding_dino `confidence_threshold` "
             f"to {self.dino_confidence_threshold}, o3de_ros2_node `fps` to {self.fps}. "
-            "Ensure they are set atomically."
+            "Ensure that each parameter is set in separate service call and in the order specified above "
         )
 
     def get_prompt(self) -> str:

--- a/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
@@ -199,8 +199,6 @@ class GetRobotDescriptionTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()}"
         else:
             return (
                 f"{self.get_base_prompt()}. You can list available topics to find appropriate topic "
@@ -239,8 +237,6 @@ class GetROS2ServicesTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()} available in the ROS2 system"
         else:
             return (
                 f"{self.get_base_prompt()} available in the ROS2 system with their names and service types. "
@@ -258,8 +254,6 @@ class ListRobotParametersTask(BasicTask):
         base_prompt = "List robot state publisher parameters"
         if self.prompt_detail == "brief":
             return base_prompt
-        elif self.prompt_detail == "moderate":
-            return f"{base_prompt} available for configuration."
         else:
             return (
                 f"{self.get_base_prompt()} available for configuration. "
@@ -291,8 +285,6 @@ class GetSpecificParameterTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()} value from the robot state publisher."
         else:
             return (
                 f"{self.get_base_prompt()} value from the robot state publisher. "
@@ -379,8 +371,6 @@ class SpawnEntityTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()} in the simulation environment"
         else:
             return (
                 f"{self.get_base_prompt()} in the simulation environment. "
@@ -421,8 +411,6 @@ class ConfigureVisionPipelineTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()} using parameter services."
         else:
             return (
                 f"{self.get_base_prompt()} using parameter services. "
@@ -465,8 +453,6 @@ class RespawnEntitiesTask(BasicTask):
     def get_prompt(self) -> str:
         if self.prompt_detail == "brief":
             return self.get_base_prompt()
-        elif self.prompt_detail == "moderate":
-            return f"{self.get_base_prompt()} using entity management services. "
         else:
             return (
                 f"{self.get_base_prompt()} using entity management services. "

--- a/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
@@ -425,7 +425,7 @@ class ConfigureVisionPipelineTask(BasicTask):
         else:
             return (
                 f"{self.get_base_prompt()} using parameter services. "
-                "You can list parameter services for appropriate services "
+                "You can list parameter services to find appropriate services "
                 "check their type's interface and set appropriate parameters."
             )
 

--- a/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
@@ -45,7 +45,7 @@ PROACTIVE_ROS2_EXPERT_SYSTEM_PROMPT_2_SHOT = (
     + """
 Example of tool calls:
 - name: get_ros2_topics_names_and_types, args: {}
-- name: get_ros2_service_interface, args: {"service_type": "tf2_msgs/srv/LookupTransform"}"""
+- name: get_ros2_message_interface, args: {"msg_type": "tf2_msgs/srv/LookupTransform"}"""
 )
 
 PROACTIVE_ROS2_EXPERT_SYSTEM_PROMPT_5_SHOT = (

--- a/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/tasks/basic.py
@@ -414,7 +414,8 @@ class ConfigureVisionPipelineTask(BasicTask):
         return (
             f"Configure AI vision pipeline: set grounded_sam `confidence_threshold` "
             f"to {self.sam_confidence_threshold}, grounding_dino `confidence_threshold` "
-            f"to {self.dino_confidence_threshold}, o3de_ros2_node `fps` to {self.fps}"
+            f"to {self.dino_confidence_threshold}, o3de_ros2_node `fps` to {self.fps}. "
+            "Ensure they are set atomically."
         )
 
     def get_prompt(self) -> str:

--- a/src/rai_bench/rai_bench/tool_calling_agent/validators.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/validators.py
@@ -146,7 +146,7 @@ class NotOrderedCallsValidator(Validator):
         return False, []
 
 
-class OptionalValidator(Validator):
+class OneFromManyValidator(Validator):
     """
     Validator that passes when any one of the given subtasks passes.
     """

--- a/src/rai_bench/rai_bench/tool_calling_agent/validators.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/validators.py
@@ -144,3 +144,54 @@ class NotOrderedCallsValidator(Validator):
         if len(tool_calls) > self.required_calls:
             self.extra_calls_used = len(tool_calls) - self.required_calls
         return False, []
+
+
+class OptionalValidator(Validator):
+    """
+    Validator that passes when any one of the given subtasks passes.
+    """
+
+    def __init__(
+        self, subtasks: List[SubTask], logger: loggers_type | None = None
+    ) -> None:
+        super().__init__(subtasks=subtasks, logger=logger)
+        if len(self.subtasks) < 1:
+            raise ValueError("Validator must have at least 1 subtask.")
+
+    @property
+    def type(self) -> str:
+        return "optional"
+
+    @property
+    def required_calls(self) -> int:
+        # For optional validator, we only need 1 call to pass any subtask
+        return 1
+
+    def validate(self, tool_calls: List[ToolCall]) -> Tuple[bool, List[ToolCall]]:
+        self.reset()
+        if len(tool_calls) < 1:
+            self.logger.debug("Not a single tool call to validate")
+            self.passed = False
+            return False, tool_calls
+
+        for i, tool_call in enumerate(tool_calls):
+            # Check if this tool call matches any subtask
+            for u, subtask in enumerate(self.subtasks):
+                try:
+                    if subtask.validate(tool_call=tool_call):
+                        # Found a matching subtask - validation succeeds
+                        self.subtasks_passed[u] = True
+                        self.passed = True
+                        self.extra_calls_used = (
+                            len(tool_calls) - 1
+                        )  # We only needed 1 call
+                        return True, tool_calls[i + 1 :]
+                except SubTaskValidationError as e:
+                    # Store error but continue trying other subtasks
+                    self.add_subtask_errors(idx=u, msgs=[str(e)])
+
+        # No tool call matched any subtask
+        self.logger.debug("Validation failed - no tool call matched any subtask")
+        self.passed = False
+        self.extra_calls_used = len(tool_calls) - 1 if len(tool_calls) > 1 else 0
+        return False, []

--- a/tests/rai_bench/tool_calling_agent/test_mock_tools.py
+++ b/tests/rai_bench/tool_calling_agent/test_mock_tools.py
@@ -130,23 +130,6 @@ class TestServiceValidator:
         with pytest.raises(TypeError):
             validator.validate_with_ros2("rcl_interfaces/srv/SetParameters", args)
 
-    # def test_validate_with_ros2_getparameters_valid_args(
-    #     self, validator: ServiceValidator
-    # ):
-    #     """Test successful validation with valid GetParameters arguments"""
-    #     args: Dict[str, Any] = {"names": ["param1", "param2", "param3"]}
-
-    #     validator.validate_with_ros2("rcl_interfaces/srv/GetParameters", args)
-
-    # def test_validate_with_ros2_getparameters_invalid_args(
-    #     self, validator: ServiceValidator
-    # ):
-    #     """Test validation with invalid GetParameters arguments"""
-    #     args: Dict[str, Any] = {"names": "should_be_list_not_string"}
-
-    #     with pytest.raises(TypeError):
-    #         validator.validate_with_ros2("rcl_interfaces/srv/GetParameters", args)
-
     def test_validate_with_ros2_empty_args(self, validator: ServiceValidator):
         """Test validation with empty args (should use defaults)"""
         args: Dict[str, Any] = {}

--- a/tests/rai_bench/tool_calling_agent/test_mock_tools.py
+++ b/tests/rai_bench/tool_calling_agent/test_mock_tools.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Dict
+
+import pytest
+from rai.types.rai_interfaces import ManipulatorMoveToRequest
+from rcl_interfaces.srv import SetParameters
+
+from rai_bench.tool_calling_agent.mocked_tools import ServiceValidator
+
+
+class TestServiceValidator:
+    """Test suite for ServiceValidator using real ROS 2 interfaces and custom models"""
+
+    @pytest.fixture
+    def custom_models(self) -> Dict[str, Any]:
+        """Fixture providing actual custom Pydantic models"""
+        return {
+            "rai_interfaces/srv/ManipulatorMoveTo": ManipulatorMoveToRequest,
+        }
+
+    @pytest.fixture
+    def validator(self, custom_models: Dict[str, Any]) -> ServiceValidator:
+        """Fixture providing ServiceValidator instance with real models"""
+        return ServiceValidator(custom_models)
+
+    def test_get_ros2_service_class_caching(self, validator: ServiceValidator):
+        """Test that service classes are cached properly"""
+        # First call
+        result1 = validator.get_ros2_service_class("rcl_interfaces/srv/SetParameters")
+        # Second call (should use cache)
+        result2 = validator.get_ros2_service_class("rcl_interfaces/srv/SetParameters")
+
+        assert result1 == result2 == SetParameters
+        assert "rcl_interfaces/srv/SetParameters" in validator.ros2_services_cache
+
+    def test_get_ros2_service_class_invalid_format_too_few_parts(
+        self, validator: ServiceValidator
+    ):
+        """Test error handling for service type with too few parts"""
+        with pytest.raises(ValueError, match="is invalid"):
+            validator.get_ros2_service_class("invalid_format")
+
+    def test_get_ros2_service_class_invalid_format_wrong_middle_part(
+        self, validator: ServiceValidator
+    ):
+        """Test error handling for service type with wrong middle part"""
+        with pytest.raises(ValueError, match="is invalid"):
+            validator.get_ros2_service_class("rcl_interfaces/msg/SetParameters")
+
+    def test_get_ros2_service_class_nonexistent_package(
+        self, validator: ServiceValidator
+    ):
+        """Test error handling when package doesn't exist"""
+        with pytest.raises(ImportError):
+            validator.get_ros2_service_class("nonexistent_package/srv/TestService")
+
+    def test_get_ros2_service_class_nonexistent_service(
+        self, validator: ServiceValidator
+    ):
+        """Test error handling when service doesn't exist in package"""
+        with pytest.raises(AttributeError):
+            validator.get_ros2_service_class("rcl_interfaces/srv/NonexistentService")
+
+    def test_validate_with_ros2_setparameters_valid_args(
+        self, validator: ServiceValidator
+    ):
+        """Test successful validation with valid SetParameters arguments"""
+        args: Dict[str, Any] = {
+            "parameters": [
+                {
+                    "name": "test_param",
+                    "value": {
+                        "type": 2,  # PARAMETER_INTEGER
+                        "bool_value": False,
+                        "integer_value": 42,
+                        "double_value": 0.0,
+                        "string_value": "",
+                    },
+                }
+            ]
+        }
+
+        validator.validate_with_ros2("rcl_interfaces/srv/SetParameters", args)
+
+    def test_validate_with_ros2_setparameters_minimal_valid_args(
+        self, validator: ServiceValidator
+    ):
+        """Test validation with minimal valid SetParameters arguments"""
+        args: Dict[str, Any] = {
+            "parameters": [
+                {
+                    "name": "test_param",
+                    "value": {
+                        "type": 4,  # PARAMETER_STRING
+                        "string_value": "test_value",
+                    },
+                }
+            ]
+        }
+
+        validator.validate_with_ros2("rcl_interfaces/srv/SetParameters", args)
+
+    def test_validate_with_ros2_invalid_field_name(self, validator: ServiceValidator):
+        """Test validation with invalid field in SetParameters"""
+        args: Dict[str, Any] = {"parameters": [], "invalid_field": "should_not_exist"}
+
+        with pytest.raises(AttributeError):  # set_message_fields will raise
+            validator.validate_with_ros2("rcl_interfaces/srv/SetParameters", args)
+
+    def test_validate_with_ros2_wrong_parameter_type(self, validator: ServiceValidator):
+        """Test validation with wrong parameter structure"""
+        args: Dict[str, Any] = {
+            "parameters": [{"name": "test_param", "value": "should_be_dict_not_string"}]
+        }
+
+        with pytest.raises(TypeError):
+            validator.validate_with_ros2("rcl_interfaces/srv/SetParameters", args)
+
+    # def test_validate_with_ros2_getparameters_valid_args(
+    #     self, validator: ServiceValidator
+    # ):
+    #     """Test successful validation with valid GetParameters arguments"""
+    #     args: Dict[str, Any] = {"names": ["param1", "param2", "param3"]}
+
+    #     validator.validate_with_ros2("rcl_interfaces/srv/GetParameters", args)
+
+    # def test_validate_with_ros2_getparameters_invalid_args(
+    #     self, validator: ServiceValidator
+    # ):
+    #     """Test validation with invalid GetParameters arguments"""
+    #     args: Dict[str, Any] = {"names": "should_be_list_not_string"}
+
+    #     with pytest.raises(TypeError):
+    #         validator.validate_with_ros2("rcl_interfaces/srv/GetParameters", args)
+
+    def test_validate_with_ros2_empty_args(self, validator: ServiceValidator):
+        """Test validation with empty args (should use defaults)"""
+        args: Dict[str, Any] = {}
+
+        # Should work - ROS 2 messages have default values
+        validator.validate_with_ros2("rcl_interfaces/srv/GetParameters", args)
+
+    def test_validate_with_custom_model_valid_args(self, validator: ServiceValidator):
+        """Test successful validation with valid ManipulatorMoveTo arguments"""
+        args: Dict[str, Any] = {
+            "initial_gripper_state": True,
+            "final_gripper_state": False,
+            "target_pose": {
+                "header": {
+                    "stamp": {"sec": 0, "nanosec": 0},
+                    "frame_id": "base_link",
+                },
+                "pose": {
+                    "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+                    "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                },
+            },
+        }
+
+        validator.validate_with_custom("rai_interfaces/srv/ManipulatorMoveTo", args)
+
+    def test_validate_with_custom_manipulator_minimal_args(
+        self, validator: ServiceValidator
+    ):
+        """Test validation with minimal ManipulatorMoveTo arguments (using defaults)"""
+        args: Dict[str, Any] = {}  # All fields have defaults
+
+        validator.validate_with_custom("rai_interfaces/srv/ManipulatorMoveTo", args)
+
+    def test_validate_with_custom_manipulator_invalid_type(
+        self, validator: ServiceValidator
+    ):
+        """Test validation with invalid type for ManipulatorMoveTo"""
+        args: Dict[str, Any] = {
+            "initial_gripper_state": "should_be_bool_not_string",
+            "final_gripper_state": False,
+        }
+
+        with pytest.raises(ValueError, match="Pydantic validation failed"):
+            validator.validate_with_custom("rai_interfaces/srv/ManipulatorMoveTo", args)
+
+    def test_validate_with_custom_service_not_in_models(
+        self, validator: ServiceValidator
+    ):
+        """Test custom validation when service type not in custom models"""
+        args: Dict[str, Any] = {"some_field": "value"}
+
+        with pytest.raises(ValueError, match="is invalid custom type"):
+            validator.validate_with_custom("unknown/srv/Service", args)
+
+    def test_validate_routes_to_custom_when_available(
+        self, validator: ServiceValidator
+    ):
+        """Test that validate() uses custom models when service type is in custom_models"""
+        args = {"initial_gripper_state": True}
+
+        # Should route to custom validation (not ROS 2)
+        validator.validate("rai_interfaces/srv/ManipulatorMoveTo", args)
+
+    def test_validate_service_not_in_custom_or_ros2(self, validator: ServiceValidator):
+        """Test validation when service exists in neither custom models nor ROS 2"""
+        args = {"some_field": "value"}
+
+        with pytest.raises(ImportError):
+            validator.validate("nonexistent_package/srv/NonexistentService", args)

--- a/tests/rai_bench/tool_calling_agent/test_mock_tools.py
+++ b/tests/rai_bench/tool_calling_agent/test_mock_tools.py
@@ -17,7 +17,6 @@ from typing import Any, Dict
 
 import pytest
 from rai.types.rai_interfaces import ManipulatorMoveToRequest
-from rcl_interfaces.srv import SetParameters
 
 from rai_bench.tool_calling_agent.mocked_tools import ServiceValidator
 
@@ -36,44 +35,6 @@ class TestServiceValidator:
     def validator(self, custom_models: Dict[str, Any]) -> ServiceValidator:
         """Fixture providing ServiceValidator instance with real models"""
         return ServiceValidator(custom_models)
-
-    def test_get_ros2_service_class_caching(self, validator: ServiceValidator):
-        """Test that service classes are cached properly"""
-        # First call
-        result1 = validator.get_ros2_service_class("rcl_interfaces/srv/SetParameters")
-        # Second call (should use cache)
-        result2 = validator.get_ros2_service_class("rcl_interfaces/srv/SetParameters")
-
-        assert result1 == result2 == SetParameters
-        assert "rcl_interfaces/srv/SetParameters" in validator.ros2_services_cache
-
-    def test_get_ros2_service_class_invalid_format_too_few_parts(
-        self, validator: ServiceValidator
-    ):
-        """Test error handling for service type with too few parts"""
-        with pytest.raises(ValueError, match="is invalid"):
-            validator.get_ros2_service_class("invalid_format")
-
-    def test_get_ros2_service_class_invalid_format_wrong_middle_part(
-        self, validator: ServiceValidator
-    ):
-        """Test error handling for service type with wrong middle part"""
-        with pytest.raises(ValueError, match="is invalid"):
-            validator.get_ros2_service_class("rcl_interfaces/msg/SetParameters")
-
-    def test_get_ros2_service_class_nonexistent_package(
-        self, validator: ServiceValidator
-    ):
-        """Test error handling when package doesn't exist"""
-        with pytest.raises(ImportError):
-            validator.get_ros2_service_class("nonexistent_package/srv/TestService")
-
-    def test_get_ros2_service_class_nonexistent_service(
-        self, validator: ServiceValidator
-    ):
-        """Test error handling when service doesn't exist in package"""
-        with pytest.raises(AttributeError):
-            validator.get_ros2_service_class("rcl_interfaces/srv/NonexistentService")
 
     def test_validate_with_ros2_setparameters_valid_args(
         self, validator: ServiceValidator

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -64,11 +64,11 @@ from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     get_robot_desc_ord_val,
     list_parameters_val,
     services_ord_val,
-    set_grounded_dino_opt_val_1,
+    set_grounded_dino_opt_val,
     set_grounded_dino_opt_val_2,
-    set_grounded_sam_opt_val_1,
+    set_grounded_sam_opt_val,
     set_grounded_sam_opt_val_2,
-    set_o3de_fps_opt_val_1,
+    set_o3de_fps_opt_val,
     set_o3de_fps_opt_val_2,
     set_param_val,
     spawn_both_val,
@@ -946,9 +946,9 @@ class TestConfigureVisionPipelineTask:
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
             validators=[
-                set_grounded_sam_opt_val_1,
-                set_grounded_dino_opt_val_1,
-                set_o3de_fps_opt_val_1,
+                set_grounded_sam_opt_val,
+                set_grounded_dino_opt_val,
+                set_o3de_fps_opt_val,
             ],
             task_args=task_args,
         )
@@ -1063,9 +1063,9 @@ class TestConfigureVisionPipelineTask:
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
             validators=[
-                set_grounded_sam_opt_val_1,
-                set_grounded_dino_opt_val_1,
-                set_o3de_fps_opt_val_1,
+                set_grounded_sam_opt_val,
+                set_grounded_dino_opt_val,
+                set_o3de_fps_opt_val,
             ],
             task_args=task_args,
         )
@@ -1112,9 +1112,9 @@ class TestConfigureVisionPipelineTask:
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
             validators=[
-                set_grounded_sam_opt_val_1,
-                set_grounded_dino_opt_val_1,
-                set_o3de_fps_opt_val_1,
+                set_grounded_sam_opt_val,
+                set_grounded_dino_opt_val,
+                set_o3de_fps_opt_val,
             ],
             task_args=task_args,
         )
@@ -1140,9 +1140,9 @@ class TestConfigureVisionPipelineTask:
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
             validators=[
-                set_grounded_sam_opt_val_1,
-                set_grounded_dino_opt_val_1,
-                set_o3de_fps_opt_val_1,
+                set_grounded_sam_opt_val,
+                set_grounded_dino_opt_val,
+                set_o3de_fps_opt_val,
             ],
             task_args=task_args,
         )

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -764,7 +764,7 @@ class TestCheckSpawnableEntitiesTask:
                 "name": "call_ros2_service",
                 "args": {
                     "service_name": "/wrong_service_name",  # Wrong service name
-                    "service_type": "gazebo_msgs/srv/GetModelList",
+                    "service_type": "gazebo_msgs/srv/GetWorldProperties",
                     "service_args": {},
                 },
             }

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -1,0 +1,697 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List
+
+import pytest
+
+from rai_bench.tool_calling_agent.interfaces import (
+    TaskArgs,
+)
+from rai_bench.tool_calling_agent.subtasks import (
+    CheckArgsToolCallSubTask,
+    CheckServiceFieldsToolCallSubTask,
+)
+from rai_bench.tool_calling_agent.tasks.basic import (
+    GetAllROS2CamerasTask,
+    GetPointcloudTask,
+    GetRobotDescriptionTask,
+    GetROS2DepthCameraTask,
+    GetROS2RGBCameraTask,
+    GetROS2TopicsTask,
+    SetRobotParameterTask,
+)
+from rai_bench.tool_calling_agent.validators import (
+    NotOrderedCallsValidator,
+    OrderedCallsValidator,
+)
+
+
+@pytest.fixture
+def task_args() -> TaskArgs:
+    """Create basic task arguments for testing."""
+    return TaskArgs(
+        extra_tool_calls=0,
+        prompt_detail="brief",
+        examples_in_system_prompt=0,
+    )
+
+
+class TestSetParameterTask:
+    """Test SetRobotParameterTask validation."""
+
+    def test_set_parameter_task_valid(self, task_args: TaskArgs) -> None:
+        set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
+            expected_tool_name="call_ros2_service",
+            expected_service="/robot_state_publisher/set_parameters",
+            expected_service_type="rcl_interfaces/srv/SetParameters",
+            expected_fields={
+                "parameters.0.name": "publish_frequency",
+                "parameters.0.value.type": 3,
+                "parameters.0.value.double_value": 30.0,
+            },
+        )
+        set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_services_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_service_interface",
+                "args": {"service_type": "rcl_interfaces/srv/SetParameters"},
+            },
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": "/robot_state_publisher/get_parameters",
+                    "service_type": "rcl_interfaces/srv/GetParameters",
+                    "service_args": {"names": ["publish_frequency"]},
+                },
+            },
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": "/robot_state_publisher/set_parameters",
+                    "service_type": "rcl_interfaces/srv/SetParameters",
+                    "service_args": {
+                        "parameters": [
+                            {
+                                "name": "publish_frequency",
+                                "value": {
+                                    "type": 3,
+                                    "double_value": 30.0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ]
+
+        task = SetRobotParameterTask(validators=[set_param_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0  # All validators should pass
+
+    def test_set_parameter_task_wrong_parameter_type(self, task_args: TaskArgs) -> None:
+        set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
+            expected_tool_name="call_ros2_service",
+            expected_service="/robot_state_publisher/set_parameters",
+            expected_service_type="rcl_interfaces/srv/SetParameters",
+            expected_fields={
+                "parameters.0.name": "publish_frequency",
+                "parameters.0.value.type": 3,  # Expecting double
+                "parameters.0.value.double_value": 30.0,
+            },
+        )
+        set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": "/robot_state_publisher/set_parameters",
+                    "service_type": "rcl_interfaces/srv/SetParameters",
+                    "service_args": {
+                        "parameters": [
+                            {
+                                "name": "publish_frequency",
+                                "value": {
+                                    "type": 2,  # Wrong type (integer instead of double)
+                                    "integer_value": 30,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ]
+
+        task = SetRobotParameterTask(validators=[set_param_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0  # Validator should fail
+
+    def test_set_parameter_task_wrong_parameter_name(self, task_args: TaskArgs) -> None:
+        set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
+            expected_tool_name="call_ros2_service",
+            expected_service="/robot_state_publisher/set_parameters",
+            expected_service_type="rcl_interfaces/srv/SetParameters",
+            expected_fields={
+                "parameters.0.name": "publish_frequency",
+                "parameters.0.value.type": 3,
+                "parameters.0.value.double_value": 30.0,
+            },
+        )
+        set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": "/robot_state_publisher/set_parameters",
+                    "service_type": "rcl_interfaces/srv/SetParameters",
+                    "service_args": {
+                        "parameters": [
+                            {
+                                "name": "wrong_parameter_name",  # Wrong parameter name
+                                "value": {
+                                    "type": 3,
+                                    "double_value": 30.0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ]
+
+        task = SetRobotParameterTask(validators=[set_param_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0  # Validator should fail
+
+    def test_set_parameter_task_wrong_tools(self, task_args: TaskArgs) -> None:
+        set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
+            expected_tool_name="call_ros2_service",
+            expected_service="/robot_state_publisher/set_parameters",
+            expected_service_type="rcl_interfaces/srv/SetParameters",
+            expected_fields={
+                "parameters.0.name": "publish_frequency",
+                "parameters.0.value.type": 3,
+                "parameters.0.value.double_value": 30.0,
+            },
+        )
+        set_param_val = OrderedCallsValidator(subtasks=[set_robot_state_params_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_services_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_service_interface",
+                "args": {"service_type": "rcl_interfaces/srv/SetParameters"},
+            },
+            {"name": "get_ros2_services_names_and_types", "args": {}},
+            {"name": "get_ros2_services_names_and_types", "args": {}},
+        ]
+
+        task = SetRobotParameterTask(validators=[set_param_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0  # Validator should fail
+
+
+class TestGetTopicsTask:
+    """Test GetROS2TopicsTask validation."""
+
+    def test_get_topics_task_valid(self, task_args: TaskArgs) -> None:
+        get_topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        topics_val = OrderedCallsValidator(subtasks=[get_topics_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}}
+        ]
+
+        task = GetROS2TopicsTask(validators=[topics_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_topics_task_wrong_tool(self, task_args: TaskArgs) -> None:
+        """Test get ROS2 topics task with wrong tool name."""
+        get_topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        topics_val = OrderedCallsValidator(subtasks=[get_topics_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "wrong_tool_name", "args": {}}  # Wrong tool name
+        ]
+
+        task = GetROS2TopicsTask(validators=[topics_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+    def test_get_topics_task_unexpected_args(self, task_args: TaskArgs) -> None:
+        get_topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        topics_val = OrderedCallsValidator(subtasks=[get_topics_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_topics_names_and_types",
+                "args": {"unexpected": "arg"},
+            }  # Unexpected args
+        ]
+
+        task = GetROS2TopicsTask(validators=[topics_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+
+class TestGetRGBCameraTask:
+    """Test GetROS2RGBCameraTask validation."""
+
+    def test_get_rgb_camera_task_valid(self, task_args: TaskArgs) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        color_image_val = OrderedCallsValidator(subtasks=[color_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[color_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_rgb_camera_task_wrong_topic(self, task_args: TaskArgs) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        color_image_val = OrderedCallsValidator(subtasks=[color_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/wrong_topic", "timeout_sec": 5},  # Wrong topic
+            }
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[color_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+    def test_get_rgb_camera_task_missing_required_arg(
+        self, task_args: TaskArgs
+    ) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        color_image_val = OrderedCallsValidator(subtasks=[color_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_image",
+                "args": {"timeout_sec": 5},  # Missing required topic arg
+            }
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[color_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+    def test_get_rgb_camera_task_wrong_timeout_type(self, task_args: TaskArgs) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        color_image_val = OrderedCallsValidator(subtasks=[color_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_image",
+                "args": {
+                    "topic": "/color_image5",
+                    "timeout_sec": "not_an_int",
+                },  # Wrong type
+            }
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[color_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+
+class TestGetDepthCameraTask:
+    """Test GetROS2DepthCameraTask validation."""
+
+    def test_get_depth_camera_task_valid(self, task_args: TaskArgs) -> None:
+        depth_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_image_val = OrderedCallsValidator(subtasks=[depth_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/depth_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetROS2DepthCameraTask(validators=[depth_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_depth_camera_task_wrong_topic(self, task_args: TaskArgs) -> None:
+        depth_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_image_val = OrderedCallsValidator(subtasks=[depth_image_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_image",
+                "args": {
+                    "topic": "/color_image5",
+                    "timeout_sec": 5,
+                },  # Wrong topic (color instead of depth)
+            }
+        ]
+
+        task = GetROS2DepthCameraTask(validators=[depth_image_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+
+class TestGetAllCamerasTask:
+    """Test GetAllROS2CamerasTask validation."""
+
+    def test_get_all_cameras_task_valid(self, task_args: TaskArgs) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        all_cameras_val = NotOrderedCallsValidator(
+            subtasks=[color_image_subtask, depth_image_subtask]
+        )
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            },
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/depth_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetAllROS2CamerasTask(validators=[all_cameras_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_all_cameras_task_missing_depth(self, task_args: TaskArgs) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        all_cameras_val = NotOrderedCallsValidator(
+            subtasks=[color_image_subtask, depth_image_subtask]
+        )
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            }
+            # Missing depth camera call
+        ]
+
+        task = GetAllROS2CamerasTask(validators=[all_cameras_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+    def test_get_all_cameras_task_wrong_order_should_pass(
+        self, task_args: TaskArgs
+    ) -> None:
+        color_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_image_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        all_cameras_val = NotOrderedCallsValidator(
+            subtasks=[color_image_subtask, depth_image_subtask]
+        )
+
+        tool_calls: List[Dict[str, Any]] = [
+            # Reversed order - depth first, then color
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/depth_image5", "timeout_sec": 5},
+            },
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetAllROS2CamerasTask(validators=[all_cameras_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0  # Should pass with NotOrderedCallsValidator
+
+
+class TestGetPointcloudTask:
+    """Test GetPointcloudTask validation."""
+
+    def test_get_pointcloud_task_valid(self, task_args: TaskArgs) -> None:
+        pointcloud_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="receive_ros2_message",
+            expected_args={"topic": "/pointcloud"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        pointcloud_val = OrderedCallsValidator(subtasks=[pointcloud_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "receive_ros2_message",
+                "args": {"topic": "/pointcloud", "timeout_sec": 10},
+            },
+        ]
+
+        task = GetPointcloudTask(validators=[pointcloud_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_pointcloud_task_wrong_topic(self, task_args: TaskArgs) -> None:
+        pointcloud_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="receive_ros2_message",
+            expected_args={"topic": "/pointcloud"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        pointcloud_val = OrderedCallsValidator(subtasks=[pointcloud_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "receive_ros2_message",
+                "args": {
+                    "topic": "/wrong_pointcloud_topic",
+                    "timeout_sec": 10,
+                },  # Wrong topic
+            }
+        ]
+
+        task = GetPointcloudTask(validators=[pointcloud_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+
+class TestGetRobotDescriptionTask:
+    """Test GetRobotDescriptionTask validation."""
+
+    def test_get_robot_description_task_valid(self, task_args: TaskArgs) -> None:
+        robot_desc_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="receive_ros2_message",
+            expected_args={"topic": "/robot_description"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        robot_desc_val = OrderedCallsValidator(subtasks=[robot_desc_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "receive_ros2_message",
+                "args": {"topic": "/robot_description", "timeout_sec": 10},
+            },
+        ]
+
+        task = GetRobotDescriptionTask(validators=[robot_desc_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0
+
+    def test_get_robot_description_task_wrong_tool_name(
+        self, task_args: TaskArgs
+    ) -> None:
+        robot_desc_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="receive_ros2_message",
+            expected_args={"topic": "/robot_description"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        robot_desc_val = OrderedCallsValidator(subtasks=[robot_desc_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "get_ros2_message",  # Wrong tool name (missing "receive_")
+                "args": {"topic": "/robot_description", "timeout_sec": 10},
+            }
+        ]
+
+        task = GetRobotDescriptionTask(validators=[robot_desc_val], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
+
+class TestMultiValidatorScoring:
+    """Test scoring with multiple validators to ensure proper fraction calculation."""
+
+    def test_three_validators_all_pass(self, task_args: TaskArgs) -> None:
+        # Create 3 simple validators that should all pass
+        topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        color_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        depth_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/depth_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+
+        val1 = OrderedCallsValidator(subtasks=[topics_subtask])
+        val2 = OrderedCallsValidator(subtasks=[color_subtask])
+        val3 = OrderedCallsValidator(subtasks=[depth_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            },
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/depth_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[val1, val2, val3], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 1.0  # 3/3 validators pass
+
+    def test_three_validators_two_pass(self, task_args: TaskArgs) -> None:
+        topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        color_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/color_image5"},
+            expected_optional_args={"timeout_sec": int},
+        )
+        wrong_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/wrong_topic"},  # This will fail
+            expected_optional_args={"timeout_sec": int},
+        )
+
+        val1 = OrderedCallsValidator(subtasks=[topics_subtask])
+        val2 = OrderedCallsValidator(subtasks=[color_subtask])
+        val3 = OrderedCallsValidator(subtasks=[wrong_subtask])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+            {
+                "name": "get_ros2_image",
+                "args": {"topic": "/color_image5", "timeout_sec": 5},
+            },
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[val1, val2, val3], task_args=task_args)
+        score = task.validate(tool_calls)
+        # Should be 2/3 = 0.6666...
+        assert abs(score - 0.6666666666666666) < 0.01
+
+    def test_three_validators_one_pass(self, task_args: TaskArgs) -> None:
+        topics_subtask = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_topics_names_and_types", expected_args={}
+        )
+        wrong_subtask1 = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/wrong_topic1"},  # This will fail
+            expected_optional_args={"timeout_sec": int},
+        )
+        wrong_subtask2 = CheckArgsToolCallSubTask(
+            expected_tool_name="get_ros2_image",
+            expected_args={"topic": "/wrong_topic2"},  # This will fail
+            expected_optional_args={"timeout_sec": int},
+        )
+
+        val1 = OrderedCallsValidator(subtasks=[topics_subtask])
+        val2 = OrderedCallsValidator(subtasks=[wrong_subtask1])
+        val3 = OrderedCallsValidator(subtasks=[wrong_subtask2])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[val1, val2, val3], task_args=task_args)
+        score = task.validate(tool_calls)
+        # Should be 1/3 = 0.3333...
+        assert abs(score - 0.3333333333333333) < 0.01
+
+    def test_three_validators_none_pass(self, task_args: TaskArgs) -> None:
+        wrong_subtask1 = CheckArgsToolCallSubTask(
+            expected_tool_name="wrong_tool1", expected_args={}
+        )
+        wrong_subtask2 = CheckArgsToolCallSubTask(
+            expected_tool_name="wrong_tool2", expected_args={}
+        )
+        wrong_subtask3 = CheckArgsToolCallSubTask(
+            expected_tool_name="wrong_tool3", expected_args={}
+        )
+
+        val1 = OrderedCallsValidator(subtasks=[wrong_subtask1])
+        val2 = OrderedCallsValidator(subtasks=[wrong_subtask2])
+        val3 = OrderedCallsValidator(subtasks=[wrong_subtask3])
+
+        tool_calls: List[Dict[str, Any]] = [
+            {"name": "get_ros2_topics_names_and_types", "args": {}},
+        ]
+
+        task = GetROS2RGBCameraTask(validators=[val1, val2, val3], task_args=task_args)
+        score = task.validate(tool_calls)
+        assert score == 0.0  # 0/3 validators pass

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -19,14 +19,11 @@ import pytest
 from rai_bench.tool_calling_agent.interfaces import (
     TaskArgs,
 )
-
-# Import the constants and validators from the tasks module
 from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     BOX1_ENTITY,
     BOX1_POSITION,
     BOX2_ENTITY,
     BOX2_POSITION,
-    # Constants
     COLOR_IMAGE_TOPIC,
     DEFAULT_DINO_CONFIDENCE,
     DEFAULT_FPS,

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -32,11 +32,15 @@ from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     DELETE_ENTITY_SERVICE,
     DELETE_ENTITY_TYPE,
     DEPTH_IMAGE_TOPIC,
+    DINO_CONFIDENCE_2,
+    FPS_2,
     GET_PARAMETERS_TYPE,
     GET_SPAWNABLE_NAMES_SERVICE,
     GET_WORLD_PROPERTIES_TYPE,
     GROUNDED_SAM_SET_PARAMS,
+    GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
     GROUNDING_DINO_SET_PARAMS,
+    GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
     LIST_PARAMETERS_TYPE,
     O3DE_SET_PARAMS,
     POINTCLOUD_TOPIC,
@@ -44,6 +48,8 @@ from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     ROBOT_STATE_PUBLISHER_GET_PARAMS,
     ROBOT_STATE_PUBLISHER_LIST_PARAMS,
     ROBOT_STATE_PUBLISHER_SET_PARAMS,
+    SAM_CONFIDENCE_2,
+    SET_PARAMETERS_ATOMICALLY_TYPE,
     SET_PARAMETERS_TYPE,
     SPAWN_ENTITY_SERVICE,
     SPAWN_ENTITY_TYPE,
@@ -58,11 +64,16 @@ from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     get_robot_desc_ord_val,
     list_parameters_val,
     services_ord_val,
+    set_grounded_dino_opt_val_1,
+    set_grounded_dino_opt_val_2,
+    set_grounded_sam_opt_val_1,
+    set_grounded_sam_opt_val_2,
+    set_o3de_fps_opt_val_1,
+    set_o3de_fps_opt_val_2,
     set_param_val,
     spawn_both_val,
     spawn_entity_val,
     topics_ord_val,
-    vision_pipeline_config_val,
 )
 from rai_bench.tool_calling_agent.tasks.basic import (
     CheckSpawnableEntitiesTask,
@@ -880,8 +891,8 @@ class TestConfigureVisionPipelineTask:
             {
                 "name": "call_ros2_service",
                 "args": {
-                    "service_name": GROUNDED_SAM_SET_PARAMS,
-                    "service_type": SET_PARAMETERS_TYPE,
+                    "service_name": GROUNDED_SAM_SET_PARAMS_ATOMICALLY,
+                    "service_type": SET_PARAMETERS_ATOMICALLY_TYPE,
                     "service_args": {
                         "parameters": [
                             {
@@ -898,8 +909,8 @@ class TestConfigureVisionPipelineTask:
             {
                 "name": "call_ros2_service",
                 "args": {
-                    "service_name": GROUNDING_DINO_SET_PARAMS,
-                    "service_type": SET_PARAMETERS_TYPE,
+                    "service_name": GROUNDING_DINO_SET_PARAMS_ATOMICALLY,
+                    "service_type": SET_PARAMETERS_ATOMICALLY_TYPE,
                     "service_args": {
                         "parameters": [
                             {
@@ -934,7 +945,11 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[vision_pipeline_config_val],
+            validators=[
+                set_grounded_sam_opt_val_1,
+                set_grounded_dino_opt_val_1,
+                set_o3de_fps_opt_val_1,
+            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -944,46 +959,6 @@ class TestConfigureVisionPipelineTask:
         self, task_args: TaskArgs
     ) -> None:
         """Test configure vision pipeline task with second configuration."""
-        # Create custom validators for the second configuration
-        from rai_bench.tool_calling_agent.subtasks import (
-            CheckServiceFieldsToolCallSubTask,
-        )
-        from rai_bench.tool_calling_agent.validators import NotOrderedCallsValidator
-
-        grounded_sam_subtask = CheckServiceFieldsToolCallSubTask(
-            expected_tool_name="call_ros2_service",
-            expected_service=GROUNDED_SAM_SET_PARAMS,
-            expected_service_type=SET_PARAMETERS_TYPE,
-            expected_fields={
-                "parameters.0.name": "confidence_threshold",
-                "parameters.0.value.type": 3,
-                "parameters.0.value.double_value": 0.6,
-            },
-        )
-        grounding_dino_subtask = CheckServiceFieldsToolCallSubTask(
-            expected_tool_name="call_ros2_service",
-            expected_service=GROUNDING_DINO_SET_PARAMS,
-            expected_service_type=SET_PARAMETERS_TYPE,
-            expected_fields={
-                "parameters.0.name": "confidence_threshold",
-                "parameters.0.value.type": 3,
-                "parameters.0.value.double_value": 0.6,
-            },
-        )
-        o3de_fps_subtask = CheckServiceFieldsToolCallSubTask(
-            expected_tool_name="call_ros2_service",
-            expected_service=O3DE_SET_PARAMS,
-            expected_service_type=SET_PARAMETERS_TYPE,
-            expected_fields={
-                "parameters.0.name": "fps",
-                "parameters.0.value.type": 2,
-                "parameters.0.value.integer_value": 10,
-            },
-        )
-        vision_pipeline_val = NotOrderedCallsValidator(
-            subtasks=[grounded_sam_subtask, grounding_dino_subtask, o3de_fps_subtask]
-        )
-
         tool_calls: List[Dict[str, Any]] = [
             {"name": "get_ros2_services_names_and_types", "args": {}},
             {
@@ -999,7 +974,10 @@ class TestConfigureVisionPipelineTask:
                         "parameters": [
                             {
                                 "name": "confidence_threshold",
-                                "value": {"type": 3, "double_value": 0.6},
+                                "value": {
+                                    "type": 3,
+                                    "double_value": SAM_CONFIDENCE_2,
+                                },
                             }
                         ]
                     },
@@ -1014,7 +992,10 @@ class TestConfigureVisionPipelineTask:
                         "parameters": [
                             {
                                 "name": "confidence_threshold",
-                                "value": {"type": 3, "double_value": 0.6},
+                                "value": {
+                                    "type": 3,
+                                    "double_value": DINO_CONFIDENCE_2,
+                                },
                             }
                         ]
                     },
@@ -1029,7 +1010,7 @@ class TestConfigureVisionPipelineTask:
                         "parameters": [
                             {
                                 "name": "fps",
-                                "value": {"type": 2, "integer_value": 10},
+                                "value": {"type": 2, "integer_value": FPS_2},
                             }
                         ]
                     },
@@ -1038,10 +1019,14 @@ class TestConfigureVisionPipelineTask:
         ]
 
         task = ConfigureVisionPipelineTask(
-            sam_confidence_threshold=0.6,
-            dino_confidence_threshold=0.6,
-            fps=10,
-            validators=[vision_pipeline_val],
+            sam_confidence_threshold=SAM_CONFIDENCE_2,
+            dino_confidence_threshold=DINO_CONFIDENCE_2,
+            fps=FPS_2,
+            validators=[
+                set_grounded_sam_opt_val_2,
+                set_grounded_dino_opt_val_2,
+                set_o3de_fps_opt_val_2,
+            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1052,7 +1037,6 @@ class TestConfigureVisionPipelineTask:
     ) -> None:
         """Test configure vision pipeline task with missing service calls."""
 
-        # Only calling one service instead of all three
         tool_calls: List[Dict[str, Any]] = [
             {
                 "name": "call_ros2_service",
@@ -1078,11 +1062,92 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[vision_pipeline_config_val],
+            validators=[
+                set_grounded_sam_opt_val_1,
+                set_grounded_dino_opt_val_1,
+                set_o3de_fps_opt_val_1,
+            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
-        assert score == 0.0
+        assert abs(score - 0.3333333333333333) < 0.01
+
+    def test_configure_vision_pipeline_task_setting_in_one_call(
+        self, task_args: TaskArgs
+    ) -> None:
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": GROUNDED_SAM_SET_PARAMS,
+                    "service_type": SET_PARAMETERS_TYPE,
+                    "service_args": {
+                        "parameters": [
+                            {
+                                "name": "confidence_threshold",
+                                "value": {
+                                    "type": 3,
+                                    "double_value": DEFAULT_SAM_CONFIDENCE,
+                                },
+                            },
+                            {
+                                "name": "fps",
+                                "value": {"type": 2, "integer_value": FPS_2},
+                            },
+                            {
+                                "name": "confidence_threshold",
+                                "value": {
+                                    "type": 3,
+                                    "double_value": DEFAULT_DINO_CONFIDENCE,
+                                },
+                            },
+                        ]
+                    },
+                },
+            }
+        ]
+
+        task = ConfigureVisionPipelineTask(
+            sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
+            dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
+            fps=DEFAULT_FPS,
+            validators=[
+                set_grounded_sam_opt_val_1,
+                set_grounded_dino_opt_val_1,
+                set_o3de_fps_opt_val_1,
+            ],
+            task_args=task_args,
+        )
+        score = task.validate(tool_calls)
+        assert abs(score - 0.3333333333333333) < 0.01
+
+    def test_configure_vision_pipeline_task_empty_call(
+        self, task_args: TaskArgs
+    ) -> None:
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": GROUNDED_SAM_SET_PARAMS,
+                    "service_type": SET_PARAMETERS_TYPE,
+                    "service_args": {"parameters": []},
+                },
+            }
+        ]
+
+        task = ConfigureVisionPipelineTask(
+            sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
+            dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
+            fps=DEFAULT_FPS,
+            validators=[
+                set_grounded_sam_opt_val_1,
+                set_grounded_dino_opt_val_1,
+                set_o3de_fps_opt_val_1,
+            ],
+            task_args=task_args,
+        )
+        score = task.validate(tool_calls)
+        assert score == 0
 
 
 class TestRespawnEntitiesTask:

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -160,6 +160,38 @@ class TestSetParameterTask:
         score = task.validate(tool_calls)
         assert score == 0.0
 
+    def test_set_parameter_task_wrong_parameter_missing_type(
+        self, task_args: TaskArgs
+    ) -> None:
+        tool_calls: List[Dict[str, Any]] = [
+            {
+                "name": "call_ros2_service",
+                "args": {
+                    "service_name": ROBOT_STATE_PUBLISHER_SET_PARAMS,
+                    "service_type": SET_PARAMETERS_TYPE,
+                    "service_args": {
+                        "parameters": [
+                            {
+                                "name": "publish_frequency",
+                                "value": {
+                                    # missing type field
+                                    "integer_value": 30,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ]
+
+        task = SetRobotParameterTask(
+            value=DEFAULT_PUBLISH_FREQUENCY,
+            validators=[set_param_val],
+            task_args=task_args,
+        )
+        score = task.validate(tool_calls)
+        assert score == 0.0
+
     def test_set_parameter_task_wrong_parameter_name(self, task_args: TaskArgs) -> None:
         tool_calls: List[Dict[str, Any]] = [
             {

--- a/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_predefined_tasks.py
@@ -20,6 +20,17 @@ from rai_bench.tool_calling_agent.interfaces import (
     TaskArgs,
 )
 from rai_bench.tool_calling_agent.predefined.basic_tasks import (
+    all_camera_images_notord_val,
+    check_spawnable_entities_val,
+    color_image_ord_val,
+    depth_image_ord_val,
+    get_pointcloud_ord_val,
+    get_robot_desc_ord_val,
+    list_parameters_val,
+    services_ord_val,
+    topics_ord_val,
+)
+from rai_bench.tool_calling_agent.tasks.basic import (
     BOX1_ENTITY,
     BOX1_POSITION,
     BOX2_ENTITY,
@@ -54,28 +65,6 @@ from rai_bench.tool_calling_agent.predefined.basic_tasks import (
     SPAWN_ENTITY_SERVICE,
     SPAWN_ENTITY_TYPE,
     TOMATO_ENTITY,
-    all_camera_images_notord_val,
-    check_spawnable_entities_val,
-    color_image_ord_val,
-    delete_both_val,
-    depth_image_ord_val,
-    get_parameters_val,
-    get_pointcloud_ord_val,
-    get_robot_desc_ord_val,
-    list_parameters_val,
-    services_ord_val,
-    set_grounded_dino_opt_val,
-    set_grounded_dino_opt_val_2,
-    set_grounded_sam_opt_val,
-    set_grounded_sam_opt_val_2,
-    set_o3de_fps_opt_val,
-    set_o3de_fps_opt_val_2,
-    set_param_val,
-    spawn_both_val,
-    spawn_entity_val,
-    topics_ord_val,
-)
-from rai_bench.tool_calling_agent.tasks.basic import (
     CheckSpawnableEntitiesTask,
     ConfigureVisionPipelineTask,
     GetAllROS2CamerasTask,
@@ -133,9 +122,9 @@ class TestSetParameterTask:
             },
         ]
 
+        # Test with refactored task (uses internal validators)
         task = SetRobotParameterTask(
             value=DEFAULT_PUBLISH_FREQUENCY,
-            validators=[set_param_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -165,7 +154,6 @@ class TestSetParameterTask:
 
         task = SetRobotParameterTask(
             value=DEFAULT_PUBLISH_FREQUENCY,
-            validators=[set_param_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -197,7 +185,6 @@ class TestSetParameterTask:
 
         task = SetRobotParameterTask(
             value=DEFAULT_PUBLISH_FREQUENCY,
-            validators=[set_param_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -227,7 +214,6 @@ class TestSetParameterTask:
 
         task = SetRobotParameterTask(
             value=DEFAULT_PUBLISH_FREQUENCY,
-            validators=[set_param_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -246,7 +232,6 @@ class TestSetParameterTask:
 
         task = SetRobotParameterTask(
             value=DEFAULT_PUBLISH_FREQUENCY,
-            validators=[set_param_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -640,9 +625,9 @@ class TestGetSpecificParameterTask:
             },
         ]
 
+        # Test with refactored task (uses internal validators)
         task = GetSpecificParameterTask(
             parameter="publish_frequency",
-            validators=[get_parameters_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -665,7 +650,6 @@ class TestGetSpecificParameterTask:
 
         task = GetSpecificParameterTask(
             parameter="publish_frequency",
-            validators=[get_parameters_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -686,7 +670,6 @@ class TestGetSpecificParameterTask:
 
         task = GetSpecificParameterTask(
             parameter="publish_frequency",
-            validators=[get_parameters_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -783,9 +766,8 @@ class TestSpawnEntityTask:
             },
         ]
 
-        task = SpawnEntityTask(
-            entity=TOMATO_ENTITY, validators=[spawn_entity_val], task_args=task_args
-        )
+        # Test with refactored task (uses internal validators)
+        task = SpawnEntityTask(entity=TOMATO_ENTITY, task_args=task_args)
         score = task.validate(tool_calls)
         assert score == 1.0
 
@@ -805,9 +787,7 @@ class TestSpawnEntityTask:
             }
         ]
 
-        task = SpawnEntityTask(
-            entity=TOMATO_ENTITY, validators=[spawn_entity_val], task_args=task_args
-        )
+        task = SpawnEntityTask(entity=TOMATO_ENTITY, task_args=task_args)
         score = task.validate(tool_calls)
         assert score == 0.0
 
@@ -827,9 +807,7 @@ class TestSpawnEntityTask:
             }
         ]
 
-        task = SpawnEntityTask(
-            entity=TOMATO_ENTITY, validators=[spawn_entity_val], task_args=task_args
-        )
+        task = SpawnEntityTask(entity=TOMATO_ENTITY, task_args=task_args)
         score = task.validate(tool_calls)
         assert score == 0.0
 
@@ -846,9 +824,7 @@ class TestSpawnEntityTask:
             }
         ]
 
-        task = SpawnEntityTask(
-            entity=TOMATO_ENTITY, validators=[spawn_entity_val], task_args=task_args
-        )
+        task = SpawnEntityTask(entity=TOMATO_ENTITY, task_args=task_args)
         score = task.validate(tool_calls)
         assert score == 0.0
 
@@ -868,9 +844,7 @@ class TestSpawnEntityTask:
             }
         ]
 
-        task = SpawnEntityTask(
-            entity=TOMATO_ENTITY, validators=[spawn_entity_val], task_args=task_args
-        )
+        task = SpawnEntityTask(entity=TOMATO_ENTITY, task_args=task_args)
         score = task.validate(tool_calls)
         assert score == 0.0
 
@@ -941,15 +915,11 @@ class TestConfigureVisionPipelineTask:
             },
         ]
 
+        # Test with refactored task (uses internal validators)
         task = ConfigureVisionPipelineTask(
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[
-                set_grounded_sam_opt_val,
-                set_grounded_dino_opt_val,
-                set_o3de_fps_opt_val,
-            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1022,11 +992,6 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=SAM_CONFIDENCE_2,
             dino_confidence_threshold=DINO_CONFIDENCE_2,
             fps=FPS_2,
-            validators=[
-                set_grounded_sam_opt_val_2,
-                set_grounded_dino_opt_val_2,
-                set_o3de_fps_opt_val_2,
-            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1062,11 +1027,6 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[
-                set_grounded_sam_opt_val,
-                set_grounded_dino_opt_val,
-                set_o3de_fps_opt_val,
-            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1111,11 +1071,6 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[
-                set_grounded_sam_opt_val,
-                set_grounded_dino_opt_val,
-                set_o3de_fps_opt_val,
-            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1139,11 +1094,6 @@ class TestConfigureVisionPipelineTask:
             sam_confidence_threshold=DEFAULT_SAM_CONFIDENCE,
             dino_confidence_threshold=DEFAULT_DINO_CONFIDENCE,
             fps=DEFAULT_FPS,
-            validators=[
-                set_grounded_sam_opt_val,
-                set_grounded_dino_opt_val,
-                set_o3de_fps_opt_val,
-            ],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1220,10 +1170,10 @@ class TestRespawnEntitiesTask:
             },
         ]
 
+        # Test with refactored task (uses internal validators)
         task = RespawnEntitiesTask(
             names=[BOX1_ENTITY, BOX2_ENTITY],
             coords=[BOX1_POSITION, BOX2_POSITION],
-            validators=[delete_both_val, spawn_both_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
@@ -1281,11 +1231,10 @@ class TestRespawnEntitiesTask:
         task = RespawnEntitiesTask(
             names=[BOX1_ENTITY, BOX2_ENTITY],
             coords=[BOX1_POSITION, BOX2_POSITION],
-            validators=[delete_both_val, spawn_both_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
-        assert score == 0.0
+        assert score == 0.0  # first validator fail so second fail too
 
     def test_respawn_entities_task_missing_spawn(self, task_args: TaskArgs) -> None:
         """Test respawn entities task with missing spawn calls."""
@@ -1330,11 +1279,10 @@ class TestRespawnEntitiesTask:
         task = RespawnEntitiesTask(
             names=[BOX1_ENTITY, BOX2_ENTITY],
             coords=[BOX1_POSITION, BOX2_POSITION],
-            validators=[delete_both_val, spawn_both_val],
             task_args=task_args,
         )
         score = task.validate(tool_calls)
-        assert score == 0.5
+        assert score == 0.5  # Only delete validators pass, spawn validators fail
 
 
 class TestMultiValidatorScoring:
@@ -1354,7 +1302,6 @@ class TestMultiValidatorScoring:
         ]
 
         # Create multiple validators for testing
-
         val1 = topics_ord_val
         val2 = color_image_ord_val
         val3 = depth_image_ord_val

--- a/tests/rai_bench/tool_calling_agent/test_subtasks.py
+++ b/tests/rai_bench/tool_calling_agent/test_subtasks.py
@@ -26,41 +26,48 @@ from rai_bench.tool_calling_agent.subtasks import (
 )
 
 
+class ConcreteSubTask(SubTask):
+    def validate(self, tool_call: ToolCall) -> bool:
+        return True
+
+    def dump(self) -> Dict[str, Any]:
+        return {}
+
+    @property
+    def info(self) -> Dict[str, Any]:
+        return {"name": "blybly"}
+
+
+@pytest.fixture
+def mock_subtask() -> ConcreteSubTask:
+    """Create a concrete implementation of the abstract SubTask for testing"""
+    return ConcreteSubTask()
+
+
 class TestSubTaskHelpers:
     """Test the helper methods in the abstract SubTask class."""
 
-    @pytest.fixture
-    def mock_subtask(self):
-        """Create a concrete implementation of the abstract SubTask for testing"""
-
-        class ConcreteSubTask(SubTask):
-            def validate(self, tool_call: ToolCall) -> bool:
-                return True
-
-            def dump(self) -> Dict[str, Any]:
-                return {}
-
-            @property
-            def info(self) -> Dict[str, Any]:
-                return {"name": "blybly"}
-
-        return ConcreteSubTask()
-
-    def test_check_tool_call_valid(self, mock_subtask):
+    def test_check_tool_call_valid(self, mock_subtask: ConcreteSubTask) -> None:
         """Test _check_tool_call with valid inputs."""
-        tool_call = {"name": "test_tool", "args": {"arg1": "value1", "arg2": 42}}
+        tool_call: Dict[str, Any] = {
+            "name": "test_tool",
+            "args": {"arg1": "value1", "arg2": 42},
+        }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
         assert mock_subtask._check_tool_call(
             tool_call=tool_call, expected_name="test_tool", expected_args=expected_args
         )
 
-    def test_check_tool_call_wrong_name(self, mock_subtask):
+    def test_check_tool_call_wrong_name(self, mock_subtask: ConcreteSubTask) -> None:
         """Test _check_tool_call fails with wrong tool name."""
-        tool_call = {"name": "wrong_tool", "args": {"arg1": "value1", "arg2": 42}}
+        tool_call: Dict[str, Any] = {
+            "name": "wrong_tool",
+            "args": {"arg1": "value1", "arg2": 42},
+        }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
         with pytest.raises(
             SubTaskValidationError,
@@ -72,11 +79,11 @@ class TestSubTaskHelpers:
                 expected_args=expected_args,
             )
 
-    def test_check_tool_call_missing_arg(self, mock_subtask):
+    def test_check_tool_call_missing_arg(self, mock_subtask: ConcreteSubTask) -> None:
         """Test _check_tool_call fails with missing argument."""
-        tool_call = {"name": "test_tool", "args": {"arg1": "value1"}}
+        tool_call: Dict[str, Any] = {"name": "test_tool", "args": {"arg1": "value1"}}
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
         with pytest.raises(
             SubTaskValidationError, match="Required argument 'arg2' missing"
@@ -87,11 +94,16 @@ class TestSubTaskHelpers:
                 expected_args=expected_args,
             )
 
-    def test_check_tool_call_wrong_arg_value(self, mock_subtask):
+    def test_check_tool_call_wrong_arg_value(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_tool_call fails with wrong argument value."""
-        tool_call = {"name": "test_tool", "args": {"arg1": "wrong_value", "arg2": 42}}
+        tool_call: Dict[str, Any] = {
+            "name": "test_tool",
+            "args": {"arg1": "wrong_value", "arg2": 42},
+        }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
         with pytest.raises(
             SubTaskValidationError,
@@ -103,14 +115,16 @@ class TestSubTaskHelpers:
                 expected_args=expected_args,
             )
 
-    def test_check_tool_call_unexpected_arg(self, mock_subtask):
+    def test_check_tool_call_unexpected_arg(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_tool_call fails with unexpected argument."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "test_tool",
             "args": {"arg1": "value1", "arg2": 42, "unexpected": "surprise"},
         }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
         with pytest.raises(
             SubTaskValidationError, match="Unexpected argument 'unexpected' found"
@@ -121,9 +135,11 @@ class TestSubTaskHelpers:
                 expected_args=expected_args,
             )
 
-    def test_check_topic_tool_call_field_valid(self, mock_subtask):
+    def test_check_topic_tool_call_field_valid(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field with valid inputs."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -147,9 +163,11 @@ class TestSubTaskHelpers:
             expected_value="base_link",
         )
 
-    def test_check_topic_tool_call_field_wrong_name(self, mock_subtask):
+    def test_check_topic_tool_call_field_wrong_name(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with wrong tool name."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "wrong_name",
             "args": {
                 "topic": "/test_topic",
@@ -168,9 +186,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_topic_tool_call_field_wrong_topic(self, mock_subtask):
+    def test_check_topic_tool_call_field_wrong_topic(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with wrong topic."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/wrong_topic",
@@ -189,9 +209,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_topic_tool_call_field_wrong_message_type(self, mock_subtask):
+    def test_check_topic_tool_call_field_wrong_message_type(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with wrong message type."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -210,9 +232,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_topic_tool_call_field_missing_message(self, mock_subtask):
+    def test_check_topic_tool_call_field_missing_message(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with missing message."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -233,9 +257,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_topic_tool_call_field_invalid_path(self, mock_subtask):
+    def test_check_topic_tool_call_field_invalid_path(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with invalid field path."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -256,9 +282,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_topic_tool_call_field_wrong_value(self, mock_subtask):
+    def test_check_topic_tool_call_field_wrong_value(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_topic_tool_call_field fails with wrong field value."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -279,9 +307,11 @@ class TestSubTaskHelpers:
                 expected_value="test",
             )
 
-    def test_check_service_tool_call_field_valid(self, mock_subtask):
+    def test_check_service_tool_call_field_valid(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_service_tool_call_field with valid inputs."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -299,9 +329,11 @@ class TestSubTaskHelpers:
             expected_value=True,
         )
 
-    def test_check_service_tool_call_field_empty_args(self, mock_subtask):
+    def test_check_service_tool_call_field_empty_args(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_service_tool_call_field with empty service_args."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -319,9 +351,11 @@ class TestSubTaskHelpers:
             expected_value={},
         )
 
-    def test_check_service_tool_call_field_wrong_service_name(self, mock_subtask):
+    def test_check_service_tool_call_field_wrong_service_name(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_service_tool_call_field fails with wrong service name."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/wrong_service",
@@ -340,9 +374,11 @@ class TestSubTaskHelpers:
                 expected_value=True,
             )
 
-    def test_check_service_tool_call_field_missing_service_args(self, mock_subtask):
+    def test_check_service_tool_call_field_missing_service_args(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_service_tool_call_field fails with missing service_args."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -363,9 +399,11 @@ class TestSubTaskHelpers:
                 expected_value=True,
             )
 
-    def test_check_action_tool_call_field_valid(self, mock_subtask):
+    def test_check_action_tool_call_field_valid(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_action_tool_call_field with valid inputs."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/test_action",
@@ -388,9 +426,11 @@ class TestSubTaskHelpers:
             expected_value=["joint1", "joint2"],
         )
 
-    def test_check_action_tool_call_field_empty_args(self, mock_subtask):
+    def test_check_action_tool_call_field_empty_args(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_action_tool_call_field with empty action_args."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/test_action",
@@ -408,9 +448,11 @@ class TestSubTaskHelpers:
             expected_value={},
         )
 
-    def test_check_action_tool_call_field_wrong_action_name(self, mock_subtask):
+    def test_check_action_tool_call_field_wrong_action_name(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_action_tool_call_field fails with wrong action name."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/wrong_action",
@@ -429,9 +471,11 @@ class TestSubTaskHelpers:
                 expected_value=True,
             )
 
-    def test_check_tool_call_with_type_check_optional_args(self, mock_subtask):
+    def test_check_tool_call_with_type_check_optional_args(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_tool_call with type checking for optional arguments."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "test_tool",
             "args": {
                 "arg1": "value1",
@@ -443,9 +487,9 @@ class TestSubTaskHelpers:
             },
         }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
-        expected_optional_args = {
+        expected_optional_args: Dict[str, Any] = {
             "optional1": str,  # expect string type
             "optional2": int,  # expect int type
             "optional3": list,  # expect list type
@@ -460,9 +504,11 @@ class TestSubTaskHelpers:
             expected_optional_args=expected_optional_args,
         )
 
-    def test_check_tool_call_wrong_optional_arg_type(self, mock_subtask):
+    def test_check_tool_call_wrong_optional_arg_type(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_tool_call fails with wrong optional argument type."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "test_tool",
             "args": {
                 "arg1": "value1",
@@ -471,9 +517,11 @@ class TestSubTaskHelpers:
             },
         }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
-        expected_optional_args = {"optional1": str}  # expect string type
+        expected_optional_args: Dict[str, Any] = {
+            "optional1": str
+        }  # expect string type
 
         with pytest.raises(SubTaskValidationError, match="has incorrect type"):
             mock_subtask._check_tool_call(
@@ -483,16 +531,18 @@ class TestSubTaskHelpers:
                 expected_optional_args=expected_optional_args,
             )
 
-    def test_check_tool_call_multiple_types(self, mock_subtask):
+    def test_check_tool_call_multiple_types(
+        self, mock_subtask: ConcreteSubTask
+    ) -> None:
         """Test _check_tool_call with optional arguments accepting multiple types."""
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "test_tool",
             "args": {"arg1": "value1", "arg2": 42, "optional1": 123},  # int type
         }
 
-        expected_args = {"arg1": "value1", "arg2": 42}
+        expected_args: Dict[str, Any] = {"arg1": "value1", "arg2": 42}
 
-        expected_optional_args = {
+        expected_optional_args: Dict[str, Any] = {
             "optional1": (str, int)  # accept either string or int
         }
 
@@ -507,23 +557,29 @@ class TestSubTaskHelpers:
 class TestCheckArgsToolCallSubTask:
     """Test the CheckArgsToolCallSubTask implementation."""
 
-    def test_validate_valid_args(self):
+    def test_validate_valid_args(self) -> None:
         """Test validate with valid arguments."""
         subtask = CheckArgsToolCallSubTask(
             expected_tool_name="test_tool", expected_args={"arg1": "value1", "arg2": 42}
         )
 
-        tool_call = {"name": "test_tool", "args": {"arg1": "value1", "arg2": 42}}
+        tool_call: Dict[str, Any] = {
+            "name": "test_tool",
+            "args": {"arg1": "value1", "arg2": 42},
+        }
 
         assert subtask.validate(tool_call)
 
-    def test_validate_invalid_args(self):
+    def test_validate_invalid_args(self) -> None:
         """Test validate with invalid arguments."""
         subtask = CheckArgsToolCallSubTask(
             expected_tool_name="test_tool", expected_args={"arg1": "value1", "arg2": 42}
         )
 
-        tool_call = {"name": "test_tool", "args": {"arg1": "wrong_value", "arg2": 42}}
+        tool_call: Dict[str, Any] = {
+            "name": "test_tool",
+            "args": {"arg1": "wrong_value", "arg2": 42},
+        }
 
         with pytest.raises(SubTaskValidationError):
             subtask.validate(tool_call)
@@ -532,7 +588,7 @@ class TestCheckArgsToolCallSubTask:
 class TestCheckTopicFieldsToolCallSubTask:
     """Test the CheckTopicFieldsToolCallSubTask implementation."""
 
-    def test_validate_valid_fields(self):
+    def test_validate_valid_fields(self) -> None:
         """Test validate with valid fields."""
         subtask = CheckTopicFieldsToolCallSubTask(
             expected_tool_name="publish_ros2_message",
@@ -541,7 +597,7 @@ class TestCheckTopicFieldsToolCallSubTask:
             expected_fields={"data": "test message"},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -552,7 +608,7 @@ class TestCheckTopicFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_multiple_fields(self):
+    def test_validate_multiple_fields(self) -> None:
         """Test validate with multiple fields."""
         subtask = CheckTopicFieldsToolCallSubTask(
             expected_tool_name="publish_ros2_message",
@@ -565,7 +621,7 @@ class TestCheckTopicFieldsToolCallSubTask:
             },
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -579,7 +635,7 @@ class TestCheckTopicFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_invalid_field(self):
+    def test_validate_invalid_field(self) -> None:
         """Test validate with invalid field value."""
         subtask = CheckTopicFieldsToolCallSubTask(
             expected_tool_name="publish_ros2_message",
@@ -588,7 +644,7 @@ class TestCheckTopicFieldsToolCallSubTask:
             expected_fields={"data": "expected message"},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "publish_ros2_message",
             "args": {
                 "topic": "/test_topic",
@@ -604,7 +660,7 @@ class TestCheckTopicFieldsToolCallSubTask:
 class TestCheckServiceFieldsToolCallSubTask:
     """Test the CheckServiceFieldsToolCallSubTask implementation."""
 
-    def test_validate_valid_fields(self):
+    def test_validate_valid_fields(self) -> None:
         """Test validate with valid fields."""
         subtask = CheckServiceFieldsToolCallSubTask(
             expected_tool_name="call_ros2_service",
@@ -613,7 +669,7 @@ class TestCheckServiceFieldsToolCallSubTask:
             expected_fields={"data": True},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -624,7 +680,7 @@ class TestCheckServiceFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_multiple_fields(self):
+    def test_validate_multiple_fields(self) -> None:
         """Test validate with multiple fields."""
         subtask = CheckServiceFieldsToolCallSubTask(
             expected_tool_name="call_ros2_service",
@@ -633,7 +689,7 @@ class TestCheckServiceFieldsToolCallSubTask:
             expected_fields={"request_field.subfield": "value", "flag": True},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -644,7 +700,27 @@ class TestCheckServiceFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_empty_args(self):
+    def test_validate_empty_args(self) -> None:
+        """Test validate with empty service args."""
+        subtask = CheckServiceFieldsToolCallSubTask(
+            expected_tool_name="call_ros2_service",
+            expected_service="/test_service",
+            expected_service_type="std_srvs/srv/SetParam",
+            expected_fields={"value.0.any": 30},
+        )
+
+        tool_call: Dict[str, Any] = {
+            "name": "call_ros2_service",
+            "args": {
+                "service_name": "/test_service",
+                "service_type": "std_srvs/srv/SetParam",
+                "service_args": {"value": [{"any": 30}]},
+            },
+        }
+
+        assert subtask.validate(tool_call)
+
+    def test_validate_list_in_params(self) -> None:
         """Test validate with empty service args."""
         subtask = CheckServiceFieldsToolCallSubTask(
             expected_tool_name="call_ros2_service",
@@ -653,7 +729,7 @@ class TestCheckServiceFieldsToolCallSubTask:
             expected_fields={"": {}},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_service",
             "args": {
                 "service_name": "/test_service",
@@ -668,7 +744,7 @@ class TestCheckServiceFieldsToolCallSubTask:
 class TestCheckActionFieldsToolCallSubTask:
     """Test the CheckActionFieldsToolCallSubTask implementation."""
 
-    def test_validate_valid_fields(self):
+    def test_validate_valid_fields(self) -> None:
         """Test validate with valid fields."""
         subtask = CheckActionFieldsToolCallSubTask(
             expected_tool_name="call_ros2_action",
@@ -677,7 +753,7 @@ class TestCheckActionFieldsToolCallSubTask:
             expected_fields={"command.position": 0.5},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/test_action",
@@ -688,7 +764,7 @@ class TestCheckActionFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_multiple_fields(self):
+    def test_validate_multiple_fields(self) -> None:
         """Test validate with multiple fields."""
         subtask = CheckActionFieldsToolCallSubTask(
             expected_tool_name="call_ros2_action",
@@ -697,7 +773,7 @@ class TestCheckActionFieldsToolCallSubTask:
             expected_fields={"goal.x": 1.0, "goal.y": 2.0, "speed": 0.5},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/test_action",
@@ -708,7 +784,7 @@ class TestCheckActionFieldsToolCallSubTask:
 
         assert subtask.validate(tool_call)
 
-    def test_validate_empty_args(self):
+    def test_validate_empty_args(self) -> None:
         """Test validate with empty action args."""
         subtask = CheckActionFieldsToolCallSubTask(
             expected_tool_name="call_ros2_action",
@@ -717,7 +793,7 @@ class TestCheckActionFieldsToolCallSubTask:
             expected_fields={"": {}},
         )
 
-        tool_call = {
+        tool_call: Dict[str, Any] = {
             "name": "call_ros2_action",
             "args": {
                 "action_name": "/test_action",

--- a/tests/rai_bench/tool_calling_agent/test_validators.py
+++ b/tests/rai_bench/tool_calling_agent/test_validators.py
@@ -20,7 +20,7 @@ import pytest
 from rai_bench.tool_calling_agent.interfaces import SubTaskValidationError, Validator
 from rai_bench.tool_calling_agent.validators import (
     NotOrderedCallsValidator,
-    OptionalValidator,
+    OneFromManyValidator,
     OrderedCallsValidator,
 )
 
@@ -680,11 +680,11 @@ class TestNotOrderedCallsValidator:
 class TestOptionalValidator:
     def test_init_with_empty_subtasks(self):
         with pytest.raises(ValueError, match="Validator must have at least 1 subtask"):
-            OptionalValidator(subtasks=[])
+            OneFromManyValidator(subtasks=[])
 
     def test_validate_empty_tool_calls(self):
         subtasks = [DummySubTask("task1")]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
 
         success, remaining = validator.validate(tool_calls=[])
 
@@ -709,7 +709,7 @@ class TestOptionalValidator:
             DummySubTask("task1", specific_tool="tool1"),
             DummySubTask("task2", specific_tool="tool2"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall(name="tool1")]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -737,7 +737,7 @@ class TestOptionalValidator:
             DummySubTask("task1", specific_tool="tool1"),
             DummySubTask("task2", specific_tool="tool2"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall(name="tool2")]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -765,7 +765,7 @@ class TestOptionalValidator:
             DummySubTask("task1", specific_tool="tool1"),
             DummySubTask("task2", specific_tool="tool2"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [
             ToolCall(name="tool1"),
             ToolCall(name="extra_tool"),
@@ -799,7 +799,7 @@ class TestOptionalValidator:
             DummySubTask("task1", specific_tool="tool1"),
             DummySubTask("task2", specific_tool="tool2"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [
             ToolCall(name="wrong_tool"),
             ToolCall(name="another_wrong"),
@@ -835,7 +835,7 @@ class TestOptionalValidator:
             DummySubTask("task1", specific_tool="tool1"),
             DummySubTask("task2", specific_tool="tool2"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [
             ToolCall(name="wrong_tool"),
             ToolCall(name="another_wrong"),
@@ -868,7 +868,7 @@ class TestOptionalValidator:
             DummySubTask("task1", outcomes=[False]),
             DummySubTask("task2", outcomes=[False]),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall()]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -895,7 +895,7 @@ class TestOptionalValidator:
 
     def test_validate_single_subtask_success(self):
         subtasks = [DummySubTask("task1")]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall()]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -918,7 +918,7 @@ class TestOptionalValidator:
 
     def test_validate_single_subtask_failure(self):
         subtasks = [DummySubTask("task1", outcomes=[False])]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall()]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -947,7 +947,7 @@ class TestOptionalValidator:
             DummySubTask("task3", specific_tool="tool3"),
             DummySubTask("task4", specific_tool="tool4"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall(name="tool4")]
 
         success, remaining = validator.validate(tool_calls=tool_calls)
@@ -979,7 +979,7 @@ class TestOptionalValidator:
             DummySubTask("task1", outcomes=4 * [False]),
             DummySubTask("task2", outcomes=4 * [False]),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
         tool_calls = [ToolCall(), ToolCall()]
 
         # First validation call
@@ -1013,7 +1013,7 @@ class TestOptionalValidator:
             DummySubTask("task2"),
             DummySubTask("task3"),
         ]
-        validator = OptionalValidator(subtasks=subtasks)
+        validator = OneFromManyValidator(subtasks=subtasks)
 
         # OptionalValidator should only require 1 call
         assert validator.required_calls == 1


### PR DESCRIPTION
## Purpose
Make new basic tasks for tool calling benchmark, test and adjust task prompts and system prompt
For now basic tasks revolve around receiving messages from topics, which is quite easy. we need more medium and hard tasks.

## Proposed Changes
- To make some harder tasks i included service calls. To validate these calls we nned to check is provided service type exists and if args match this type.To do this I implemented `ServiceValidator`. It combines the validation of custom interfaces, that was already present and  done with pydantic models, with validation of ROS2 services present in installed packages.

- Introduced `_check_nested_fields` which resolved issue with checking nested fields that did not work when  field was list.
Now you can use int as idx when passing path:
```python
set_robot_state_params_subtask = CheckServiceFieldsToolCallSubTask(
    expected_tool_name="call_ros2_service",
    expected_service="/robot_state_publisher/set_parameters",
    expected_service_type="rcl_interfaces/srv/SetParameters",
    expected_fields={
        "parameters.0.name": "publish_frequency",
        "parameters.0.value.type": "3",
        "parameters.0.value.double_value": 30.0,
    },
)
``` 
- Added new type of validator - Optional Validator - it passes when 1 of given subtasks passes. Useful when same thing can be accomplished in 2 different tool calls.  
- Recurssion limit calculated differently so it scales better with number of extra and optional tool calls 
- Added a bunch of mocked interfaces to match all types written in available topics
- Added 7 new tasks of medium and hard complexity, that makes total of 14 tasks.
- Some of new tasks are parametrizable so they can be created with different items and values in prompts.
- Currently there are 16 predefined, importable basic tasks

- Added tests for predefined tasks to make sure they pass and fail under certain tool calls. 
- Added tests for ServiceValidator
- Added tests with nested lists to subtask tests and adjusted typing
## Issues
partially https://github.com/RobotecAI/rai/issues/576
https://github.com/RobotecAI/rai/issues/623
https://github.com/RobotecAI/rai/issues/622

## Testing
1. Mark only basic tasks, then run;
```bash
python src/rai_bench/rai_bench/examples/benchmarking_models.py 
```
2. View results, check if everything works 
3. Run tests
```bash
pytest tests/rai_bench/tool_calling_agent
```
4. Check the task prompts in `rai_bench/tool_calling_agent/tasks/basic.py` if they make sense to you
5. Check the subtasks in `rai_bench/tool_calling_agent/predefined/tasks_tasks.py` if they make sense to you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added advanced support for ROS2 service discovery, parameter management, entity spawning, and AI vision pipeline configuration in predefined tasks.
  - Introduced new validators, including an optional validator, enhancing task validation flexibility.
  - Expanded the set of available ROS2 interface definitions for more comprehensive simulation and testing.

- **Refactor**
  - Streamlined and centralized nested field validation logic for subtasks, reducing code duplication.
  - Reorganized and extended predefined tasks to focus more on service-based and parameter-centric operations.

- **Bug Fixes**
  - Improved error handling and validation for ROS2 service calls and argument checking.

- **Tests**
  - Added extensive new test suites covering service validation, predefined tasks, subtasks, and validator logic to ensure robustness and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
