### PR TITLE
fix: Transform obtained from GetROS2TransformTool can be old

### DIFF
--- a/examples/rosbot-xl-demo.py
+++ b/examples/rosbot-xl-demo.py
@@ -50,7 +50,7 @@ def initialize_agent() -> Runnable[ReActAgentState, ReActAgentState]:
         "examples/embodiments/rosbotxl_embodiment.json"
     )
 
-    connector = ROS2Connector(executor_type="multi_threaded")
+    connector = ROS2Connector(executor_type="multi_threaded", use_sim_time=True)
     tools: List[BaseTool] = [
         GetROS2TransformConfiguredTool(
             connector=connector,

--- a/src/rai_core/rai/communication/ros2/connectors/base.py
+++ b/src/rai_core/rai/communication/ros2/connectors/base.py
@@ -25,6 +25,7 @@ import rclpy.time
 from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.qos import QoSProfile
 from tf2_ros import Buffer, LookupException, TransformListener, TransformStamped
 
@@ -55,6 +56,8 @@ class ROS2BaseConnector(ROS2ActionMixin, ROS2ServiceMixin, BaseConnector[T]):
         Whether to destroy subscribers after receiving a message, by default False.
     executor_type : Literal["single_threaded", "multi_threaded"], optional
         Type of executor to use for processing ROS2 callbacks, by default "multi_threaded".
+    use_sim_time : bool, optional
+        Whether to use simulation time or system time, by default False.
 
     Methods
     -------
@@ -100,6 +103,7 @@ class ROS2BaseConnector(ROS2ActionMixin, ROS2ServiceMixin, BaseConnector[T]):
         node_name: str = f"rai_ros2_connector_{str(uuid.uuid4())[-12:]}",
         destroy_subscribers: bool = False,
         executor_type: Literal["single_threaded", "multi_threaded"] = "multi_threaded",
+        use_sim_time: bool = False,
     ):
         """Initialize the ROS2BaseConnector.
 
@@ -127,6 +131,10 @@ class ROS2BaseConnector(ROS2ActionMixin, ROS2ServiceMixin, BaseConnector[T]):
             )
         self._executor_type = executor_type
         self._node = Node(node_name)
+        if use_sim_time:
+            self._node.set_parameters(
+                [Parameter("use_sim_time", Parameter.Type.BOOL, True)]
+            )
         self._topic_api = ROS2TopicAPI(self._node, destroy_subscribers)
         self._service_api = ROS2ServiceAPI(self._node)
         self._actions_api = ROS2ActionAPI(self._node)


### PR DESCRIPTION
This detects stale TF transform data and return warnings. 

## Purpose
This PR implements stale transform detection in the `GetROS2TransformTool` and adds proper time handling for both real-world and simulation environments.

## Proposed Changes
- Added logic in `GetROS2TransformTool` to detect stale TF transform data and include warnings in the response
- Added optional `use_sim_time` parameter to ROS2 connector initialization for proper time comparison in both real-world and simulation environments

### Additional Updates
- Updated `rosbot-xl-demo.py` to initialize connector with `use_sim_time=True`
- Added two unit tests to validate the stale transform detection functionality
- Made changes in helper.py for test cleanup. 

## Issues Addressed
- Fixes [#506](https://github.com/RobotecAI/rai/issues/506)

## Testing
- New Unit tests pass with new test coverage, no regression in existing test suite
- Validated with rosbot-xl demo execution

@maciejmajek - This is to address https://github.com/RobotecAI/rai/issues/506, your feedback on this implementation would be greatly appreciated.  To validate the changes, the original repro from the issue may not be ideal since it also stops the `/clock`.   I've added a test case to cover the simulation scenario. 