### PR TITLE
fix: manipulaiton bench fixes

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -308,8 +308,7 @@ class ManipulationO3DEBenchmark(BaseBenchmark):
                 self.logger.error(msg=f"Task timeout: {e}")
             except GraphRecursionError as e:
                 self.logger.error(msg=f"Reached recursion limit {e}")
-            except Exception as e:
-                self.logger.error(msg=f"Unexpected errot occured: {e}")
+
             te = time.perf_counter()
             try:
                 score = scenario.task.calculate_score(self.simulation_bridge)

--- a/src/rai_bench/rai_bench/test_models.py
+++ b/src/rai_bench/rai_bench/test_models.py
@@ -250,7 +250,12 @@ def test_models(
                                 bench_logger=bench_logger,
                             )
                     except Exception as e:
-                        bench_logger.critical(f"BENCHMARK RUN FAILED: {e}")
+                        import traceback
+
                         bench_logger.critical(
-                            f"{bench_conf.name} benchmark for {model_name}, vendor: {vendors[i]}, execution number: {u + 1}"
+                            f"{bench_conf.name} benchmark for {model_name}, vendor: {vendors[i]}, repeat number: {u + 1}"
                         )
+                        bench_logger.critical(f"BENCHMARK RUN FAILED: {e}")
+                        error_msg = traceback.format_exc()
+                        bench_logger.critical(error_msg)
+                        print(error_msg)

--- a/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
+++ b/src/rai_bench/rai_bench/tool_calling_agent/benchmark.py
@@ -148,8 +148,7 @@ class ToolCallingAgentBenchmark(BaseBenchmark):
             self.logger.error(msg=f"Task timeout: {e}")
         except GraphRecursionError as e:
             self.logger.error(msg=f"Reached recursion limit {e}")
-        except Exception as e:
-            self.logger.error(msg=f"Unexpected error occured: {e}")
+
         tool_calls = task.get_tool_calls_from_messages(messages=messages)
         score = task.validate(tool_calls=tool_calls)
         te = time.perf_counter()

--- a/src/rai_core/rai/tools/ros2/manipulation/custom.py
+++ b/src/rai_core/rai/tools/ros2/manipulation/custom.py
@@ -245,12 +245,12 @@ class MoveObjectFromToTool(BaseROS2Tool):
         response = get_future_result(future, timeout_sec=20.0)
 
         if response is None:
-            return f"Service call failed for point ({x:.2f}, {y:.2f}, {z:.2f})."
+            return f"Service call failed for point ({x1:.2f}, {y1:.2f}, {z1:.2f})."
 
         if response.success:
-            return f"End effector successfully positioned at coordinates ({x:.2f}, {y:.2f}, {z:.2f}). Note: The status of object interaction (grab/drop) is not confirmed by this movement."
+            return f"End effector successfully positioned at coordinates ({x1:.2f}, {y1:.2f}, {z1:.2f}). Note: The status of object interaction (grab/drop) is not confirmed by this movement."
         else:
-            return f"Failed to position end effector at coordinates ({x:.2f}, {y:.2f}, {z:.2f})."
+            return f"Failed to position end effector at coordinates ({x1:.2f}, {y1:.2f}, {z1:.2f})."
 
 
 class GetObjectPositionsToolInput(BaseModel):


### PR DESCRIPTION
## Purpose
Fixing couple small issues that were occuring during execution:
- Some scenarios didn't have proper level assigned 
- Errors were catched in a manner that was not informative and lead to further execution
- Fixed response returned by MoveObjectFromToTool 

## Proposed Changes
- Now all scenarios have proper level assignment in predefined scenarios
- Errors are now catched in `test_models` function instead of in `run_next`. Before that when an unexpected exception occured, it would affect the single scenario execution. After that the next scenario would execute as planned, but that was the problem, because usually the problem was outside of scenario scope and would reoccur in every scenario till the end - for example cuda OOM. In such case it was a wasted time and the avg scores were impared by the 0.0 scores that were result of error.
Now when unexpected error occurs the whole benchmark will stop, preserving the scores that were achieved till this moment. 

## Issues


## Testing
Just run manipulation benchmark
```python 
python src/rai_bench/rai_bench/examples/benchmarking_models.py
```

you can check out the logs to see that levels are assigned properly
