### PR TITLE
fix(react-agent-ros2): replace non-blocking run with blocking to avoid severe ROS 2 degradation

### DIFF
--- a/examples/agents/react_ros2.py
+++ b/examples/agents/react_ros2.py
@@ -34,7 +34,7 @@ def main():
     # Agent will wait for messages published to /from_human ros2 topic
     agent.subscribe_source("/from_human", hri_connector)
     runner = AgentRunner([agent])
-    runner.run()
+    runner.run_and_wait_for_shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

bugfix

- issue: `ReActAgent` example is unable to receive messages on `/from_human` topic

## Proposed Changes

run -> run_and_wait_for_shutdown()

## Issues

-   Links to relevant issues

## Testing

-   How was it tested, what were the results?
