### PR TITLE
fix: add on chat start callback impl

### DIFF
--- a/src/rai_core/rai/agents/integrations/streamlit.py
+++ b/src/rai_core/rai/agents/integrations/streamlit.py
@@ -74,6 +74,18 @@ def get_streamlit_cb(parent_container: DeltaGenerator) -> BaseCallbackHandler:
             self.text += token  # Append the new token to the existing text
             self.token_placeholder.write(self.text)
 
+        def on_chat_model_start(
+            self, serialized: Dict[str, Any], messages: List[List[BaseMessage]], **kwargs: Any
+        ) -> None:
+            """
+            Run when the chat model starts.
+            Args:
+                serialized (Dict[str, Any]): The serialized model.
+                messages (List[List[BaseMessage]]): The messages.
+                **kwargs: Additional keyword arguments.
+            """
+            pass  # No specific action needed for chat model start
+
         def on_tool_start(
             self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
         ) -> None:

--- a/src/rai_core/rai/agents/integrations/streamlit.py
+++ b/src/rai_core/rai/agents/integrations/streamlit.py
@@ -75,7 +75,10 @@ def get_streamlit_cb(parent_container: DeltaGenerator) -> BaseCallbackHandler:
             self.token_placeholder.write(self.text)
 
         def on_chat_model_start(
-            self, serialized: Dict[str, Any], messages: List[List[BaseMessage]], **kwargs: Any
+            self,
+            serialized: Dict[str, Any],
+            messages: List[List[BaseMessage]],
+            **kwargs: Any,
         ) -> None:
             """
             Run when the chat model starts.


### PR DESCRIPTION
Without this the streamlit demos throw an exception after entering a message:

`File "/home/pkotowski/AMD-RosCon2025-Demo/rai/examples/rosbot-xl-demo.py", line 100, in <module>
    main()
File "/home/pkotowski/AMD-RosCon2025-Demo/rai/examples/rosbot-xl-demo.py", line 92, in main
    run_streamlit_app(
File "/home/pkotowski/AMD-RosCon2025-Demo/rai/src/rai_core/rai/frontend/streamlit.py", line 55, in run_streamlit_app
    streamlit_invoke(
File "/home/pkotowski/AMD-RosCon2025-Demo/rai/src/rai_core/rai/agents/integrations/streamlit.py", line 192, in streamlit_invoke
    return graph.invoke(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/pregel/__init__.py", line 2844, in invoke
    for chunk in self.stream(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/pregel/__init__.py", line 2534, in stream
    for _ in runner.tick(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/pregel/runner.py", line 162, in tick
    run_with_retry(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/pregel/retry.py", line 42, in run_with_retry
    return task.proc.invoke(task.input, config)
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/utils/runnable.py", line 623, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langgraph/utils/runnable.py", line 377, in invoke
    ret = self.func(*args, **kwargs)
File "/home/pkotowski/AMD-RosCon2025-Demo/rai/src/rai_core/rai/agents/langchain/core/react_agent.py", line 78, in llm_node
    ai_msg = llm.invoke(state["messages"])
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/runnables/base.py", line 5434, in invoke
    return self.bound.invoke(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 378, in invoke
    self.generate_prompt(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 963, in generate_prompt
    return self.generate(prompt_messages, stop=stop, callbacks=callbacks, **kwargs)
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 766, in generate
    run_managers = callback_manager.on_chat_model_start(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/callbacks/manager.py", line 1378, in on_chat_model_start
    handle_event(
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/callbacks/manager.py", line 278, in handle_event
    message_strings = [get_buffer_string(m) for m in args[1]]
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/callbacks/manager.py", line 278, in <listcomp>
    message_strings = [get_buffer_string(m) for m in args[1]]
File "/home/pkotowski/.cache/pypoetry/virtualenvs/rai-framework-ASoQ0CNz-py3.10/lib/python3.10/site-packages/langchain_core/messages/utils.py", line 132, in get_buffer_string
    message = f"{role}: {m.text()}"`
