### PR TITLE
refactor(`nav2_toolkit`): remove unused `action_client`

### DIFF
--- a/src/rai_core/rai/tools/ros2/navigation/nav2.py
+++ b/src/rai_core/rai/tools/ros2/navigation/nav2.py
@@ -31,7 +31,6 @@ from rai.communication.ros2.connectors import ROS2Connector
 from rai.messages import MultimodalArtifact
 from rai.tools.ros2.base import BaseROS2Tool, BaseROS2Toolkit
 
-action_client: Optional[ActionClient] = None
 current_action_id: Optional[str] = None
 current_feedback: Optional[NavigateToPose.Feedback] = None
 current_result: Optional[NavigateToPose.Result] = None
@@ -88,12 +87,6 @@ class NavigateToPoseTool(BaseROS2Tool):
         current_result = result
 
     def _run(self, x: float, y: float, z: float, yaw: float) -> str:
-        global action_client
-        if action_client is None:
-            action_client = ActionClient(
-                self.connector.node, NavigateToPose, self.action_name
-            )
-
         pose = PoseStamped()
         pose.header.frame_id = self.frame_id
         pose.header.stamp = self.connector.node.get_clock().now().to_msg()

--- a/src/rai_core/rai/tools/ros2/navigation/nav2.py
+++ b/src/rai_core/rai/tools/ros2/navigation/nav2.py
@@ -23,7 +23,6 @@ from langchain_core.tools import BaseTool
 from nav2_msgs.action import NavigateToPose
 from nav_msgs.msg import OccupancyGrid
 from pydantic import BaseModel, Field
-from rclpy.action import ActionClient
 from tf_transformations import euler_from_quaternion, quaternion_from_euler
 
 from rai.communication.ros2 import ROS2Message


### PR DESCRIPTION
## Purpose

- `action_client` is not used in `Nav2Toolkit` and should be removed
 
## Proposed Changes

-  Remove unused global variable. 

## Issues

## Testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Nav2 navigation action handling by using a single startup path via the connector and removing redundant internal initialization.
  * Existing feedback and result behavior remains unchanged during Navigate-to-Pose actions.
  * No changes to user workflows or visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->