### PR TITLE
fix: invoke_with_tracing breaks rai used outside of developer space

### DIFF
--- a/src/rai_core/rai/agents/langchain/__init__.py
+++ b/src/rai_core/rai/agents/langchain/__init__.py
@@ -19,6 +19,7 @@ from .core import (
     create_react_runnable,
     create_state_based_runnable,
 )
+from .invocation_helpers import invoke_llm_with_tracing
 from .react_agent import ReActAgent
 from .state_based_agent import BaseStateBasedAgent, StateBasedConfig
 
@@ -32,5 +33,6 @@ __all__ = [
     "StateBasedConfig",
     "create_react_runnable",
     "create_state_based_runnable",
+    "invoke_llm_with_tracing",
     "newMessageBehaviorType",
 ]

--- a/src/rai_core/rai/agents/langchain/invocation_helpers.py
+++ b/src/rai_core/rai/agents/langchain/invocation_helpers.py
@@ -35,6 +35,8 @@ def invoke_llm_with_tracing(
     This function automatically adds tracing callbacks (like Langfuse) to LLM calls
     within LangGraph nodes, solving the callback propagation issue.
 
+    Tracing is controlled by config.toml. If the file is missing, no tracing is applied.
+
     Parameters
     ----------
     llm : BaseChatModel

--- a/src/rai_core/rai/initialization/model_initialization.py
+++ b/src/rai_core/rai/initialization/model_initialization.py
@@ -273,11 +273,16 @@ def get_embeddings_model(
 
 
 def get_tracing_callbacks(
-    override_use_langfuse: bool = False, override_use_langsmith: bool = False
+    config_path: Optional[str] = None,
 ) -> List[BaseCallbackHandler]:
-    config = load_config()
+    try:
+        config = load_config(config_path)
+    except Exception as e:
+        logger.warning(f"Failed to load config for tracing: {e}, tracing disabled")
+        return []
+
     callbacks: List[BaseCallbackHandler] = []
-    if config.tracing.langfuse.use_langfuse or override_use_langfuse:
+    if config.tracing.langfuse.use_langfuse:
         from langfuse.callback import CallbackHandler  # type: ignore
 
         public_key = os.getenv("LANGFUSE_PUBLIC_KEY", None)
@@ -292,7 +297,7 @@ def get_tracing_callbacks(
         )
         callbacks.append(callback)
 
-    if config.tracing.langsmith.use_langsmith or override_use_langsmith:
+    if config.tracing.langsmith.use_langsmith:
         os.environ["LANGCHAIN_TRACING_V2"] = "true"
         os.environ["LANGCHAIN_PROJECT"] = config.tracing.project
         api_key = os.getenv("LANGCHAIN_API_KEY", None)

--- a/tests/agents/langchain/test_langchain_agent.py
+++ b/tests/agents/langchain/test_langchain_agent.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import deque
 from typing import List
+from unittest.mock import MagicMock, patch
 
 import pytest
+from rai.agents.langchain import invoke_llm_with_tracing
 from rai.agents.langchain.agent import LangChainAgent, newMessageBehaviorType
+from rai.initialization import get_tracing_callbacks
 
 
 @pytest.mark.parametrize(
@@ -39,3 +43,110 @@ def test_reduce_messages(
     output_ = LangChainAgent._apply_reduction_behavior(new_message_behavior, buffer)
     assert output == output_
     assert buffer == deque(out_buffer)
+
+
+class TestTracingConfiguration:
+    """Test tracing configuration integration with langchain agents."""
+
+    def test_tracing_with_missing_config_file(self):
+        """Test that tracing gracefully handles missing config.toml file in langchain context."""
+        # This should not crash even without config.toml
+        callbacks = get_tracing_callbacks()
+        assert len(callbacks) == 0
+
+    def test_tracing_with_config_file_present(self, test_config_toml):
+        """Test that tracing works when config.toml is present in langchain context."""
+        config_path, cleanup = test_config_toml(
+            langfuse_enabled=True, langsmith_enabled=False
+        )
+
+        try:
+            # Mock environment variables to avoid actual API calls
+            with patch.dict(
+                os.environ,
+                {
+                    "LANGFUSE_PUBLIC_KEY": "test_key",
+                    "LANGFUSE_SECRET_KEY": "test_secret",
+                },
+            ):
+                callbacks = get_tracing_callbacks(config_path=config_path)
+                # Should return 1 callback for langfuse
+                assert len(callbacks) == 1
+        finally:
+            cleanup()
+
+
+class TestInvokeLLMWithTracing:
+    """Test the invoke_llm_with_tracing function."""
+
+    def test_invoke_llm_without_tracing(self):
+        """Test that invoke_llm_with_tracing works when no tracing callbacks are available."""
+        # Mock LLM
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = "test response"
+
+        # Mock messages
+        mock_messages = ["test message"]
+
+        # Mock get_tracing_callbacks to return empty list (no config.toml)
+        with patch(
+            "rai.agents.langchain.invocation_helpers.get_tracing_callbacks"
+        ) as mock_get_callbacks:
+            mock_get_callbacks.return_value = []
+
+            result = invoke_llm_with_tracing(mock_llm, mock_messages)
+
+            mock_llm.invoke.assert_called_once_with(mock_messages, config=None)
+            assert result == "test response"
+
+    def test_invoke_llm_with_tracing(self):
+        """Test that invoke_llm_with_tracing works when tracing callbacks are available."""
+        # Mock LLM
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = "test response"
+
+        # Mock messages
+        mock_messages = ["test message"]
+
+        # Mock get_tracing_callbacks to return some callbacks
+        with patch(
+            "rai.agents.langchain.invocation_helpers.get_tracing_callbacks"
+        ) as mock_get_callbacks:
+            mock_get_callbacks.return_value = ["tracing_callback"]
+
+            _ = invoke_llm_with_tracing(mock_llm, mock_messages)
+
+            # Verify that the LLM was called with enhanced config
+            mock_llm.invoke.assert_called_once()
+            call_args = mock_llm.invoke.call_args
+            assert call_args[0][0] == mock_messages
+            assert "callbacks" in call_args[1]["config"]
+            assert "tracing_callback" in call_args[1]["config"]["callbacks"]
+
+    def test_invoke_llm_with_existing_config(self):
+        """Test that invoke_llm_with_tracing preserves existing config."""
+        # Mock LLM
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = "test response"
+
+        # Mock messages
+        mock_messages = ["test message"]
+
+        # Mock existing config
+        existing_config = {"callbacks": ["existing_callback"]}
+
+        # Mock get_tracing_callbacks to return some callbacks
+        with patch(
+            "rai.agents.langchain.invocation_helpers.get_tracing_callbacks"
+        ) as mock_get_callbacks:
+            mock_get_callbacks.return_value = ["tracing_callback"]
+
+            _ = invoke_llm_with_tracing(mock_llm, mock_messages, existing_config)
+
+            # Verify that the LLM was called with enhanced config
+            mock_llm.invoke.assert_called_once()
+            call_args = mock_llm.invoke.call_args
+            assert call_args[0][0] == mock_messages
+            assert "callbacks" in call_args[1]["config"]
+            assert "existing_callback" in call_args[1]["config"]["callbacks"]
+            assert "tracing_callback" in call_args[1]["config"]["callbacks"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,132 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def test_config_toml():
+    """
+    Fixture to create a temporary test config.toml file with tracing enabled.
+
+    Returns
+    -------
+    tuple
+        (config_path, cleanup_function) - The path to the config file and a function to clean it up
+    """
+
+    def _create_config(langfuse_enabled=False, langsmith_enabled=False):
+        # Create a temporary config.toml file
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False)
+
+        # Base config sections (always required)
+        config_content = """[vendor]
+simple_model = "openai"
+complex_model = "openai"
+embeddings_model = "text-embedding-ada-002"
+
+[aws]
+simple_model = "anthropic.claude-instant-v1"
+complex_model = "anthropic.claude-v2"
+embeddings_model = "amazon.titan-embed-text-v1"
+region_name = "us-east-1"
+
+[openai]
+simple_model = "gpt-3.5-turbo"
+complex_model = "gpt-4"
+embeddings_model = "text-embedding-ada-002"
+base_url = "https://api.openai.com/v1"
+
+[ollama]
+simple_model = "llama2"
+complex_model = "llama2"
+embeddings_model = "llama2"
+base_url = "http://localhost:11434"
+
+[tracing]
+project = "test-project"
+
+[tracing.langfuse]
+use_langfuse = {langfuse_enabled}
+host = "http://localhost:3000"
+
+[tracing.langsmith]
+use_langsmith = {langsmith_enabled}
+host = "https://api.smith.langchain.com"
+""".format(
+            langfuse_enabled=str(langfuse_enabled).lower(),
+            langsmith_enabled=str(langsmith_enabled).lower(),
+        )
+
+        f.write(config_content)
+        f.close()
+
+        def cleanup():
+            try:
+                f.close()  # Ensure file is properly closed
+                os.unlink(f.name)
+            except (OSError, PermissionError):
+                pass  # File might already be deleted or have permission issues
+
+        return f.name, cleanup
+
+    return _create_config
+
+
+@pytest.fixture
+def test_config_no_tracing():
+    """
+    Fixture to create a temporary test config.toml file with no tracing section.
+
+    Returns
+    -------
+    tuple
+        (config_path, cleanup_function) - The path to the config file and a function to clean it up
+    """
+
+    def _create_config():
+        # Create a temporary config.toml file
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False)
+
+        # Base config sections (always required)
+        config_content = """[vendor]
+simple_model = "openai"
+complex_model = "openai"
+embeddings_model = "text-embedding-ada-002"
+
+[aws]
+simple_model = "anthropic.claude-instant-v1"
+complex_model = "anthropic.claude-v2"
+embeddings_model = "amazon.titan-embed-text-v1"
+region_name = "us-east-1"
+
+[openai]
+simple_model = "gpt-3.5-turbo"
+complex_model = "gpt-4"
+embeddings_model = "text-embedding-ada-002"
+base_url = "https://api.openai.com/v1"
+
+[ollama]
+simple_model = "llama2"
+complex_model = "llama2"
+embeddings_model = "llama2"
+base_url = "http://localhost:11434"
+"""
+
+        f.write(config_content)
+        f.close()
+
+        def cleanup():
+            try:
+                f.close()  # Ensure file is properly closed
+                os.unlink(f.name)
+            except (OSError, PermissionError):
+                pass  # File might already be deleted or have permission issues
+
+        return f.name, cleanup
+
+    return _create_config

--- a/tests/initialization/test_tracing.py
+++ b/tests/initialization/test_tracing.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+from rai.initialization import get_tracing_callbacks
+
+
+class TestInitializationTracing:
+    """Test the initialization module's tracing functionality."""
+
+    def test_tracing_with_missing_config_file(self):
+        """Test that tracing gracefully handles missing config.toml file."""
+        # This should not crash even without config.toml
+        callbacks = get_tracing_callbacks()
+        assert len(callbacks) == 0
+
+    def test_tracing_with_config_file_present_tracing_disabled(self, test_config_toml):
+        """Test that tracing works when config.toml is present but tracing is disabled."""
+        config_path, cleanup = test_config_toml(
+            langfuse_enabled=False, langsmith_enabled=False
+        )
+
+        try:
+            callbacks = get_tracing_callbacks(config_path=config_path)
+            # Should return 0 callbacks since both langfuse and langsmith are disabled
+            assert len(callbacks) == 0
+        finally:
+            cleanup()
+
+    def test_tracing_with_config_file_present_tracing_enabled(self, test_config_toml):
+        """Test that tracing works when config.toml is present and tracing is enabled."""
+        config_path, cleanup = test_config_toml(
+            langfuse_enabled=True, langsmith_enabled=False
+        )
+
+        try:
+            # Mock environment variables to avoid actual API calls
+            with patch.dict(
+                os.environ,
+                {
+                    "LANGFUSE_PUBLIC_KEY": "test_key",
+                    "LANGFUSE_SECRET_KEY": "test_secret",
+                },
+            ):
+                callbacks = get_tracing_callbacks(config_path=config_path)
+                # Should return 1 callback for langfuse
+                assert len(callbacks) == 1
+        finally:
+            cleanup()
+
+    def test_tracing_with_valid_config_file_no_tracing(self, test_config_no_tracing):
+        """Test that tracing works when config.toml is valid but has no tracing sections."""
+        config_path, cleanup = test_config_no_tracing()
+
+        try:
+            # This should not crash, should return empty callbacks
+            callbacks = get_tracing_callbacks(config_path=config_path)
+            assert len(callbacks) == 0
+        finally:
+            cleanup()


### PR DESCRIPTION
## Purpose

Fix issue #675 by making tracing gracefully handle missing `config.toml` file, ensuring RAI works outside of developer space.

## Proposed Changes

-  Use `config.toml` as a source of truth for tracing configuration. If it is missing, tracing is disabled.
-  Added optional `config_path` parameter to `get_tracing_callbacks()` for better unit testing.
- Added unit tests for tracing scenarios and langchain integration.
-  Added test fixture in conftest.py to mock tracing config.

## Issues

- Fixes [Issue #675](https://github.com/RobotecAI/rai/issues/675) - `invoke_with_tracing` breaks RAI when used outside developer workspace

## Testing

- [x] Verified RAI works without `config.toml` (tracing disabled) outside developer space. A Python virual env was created with Python 3.12 and `pip install rai-core`, the repro code from issue 675 was run and verified the warning of missing config.toml was logged. @maciejmajek, could you also give this a try ?
- [x] Confirmed manipulation-demo works with new changes.
- [x] All existing tests pass, new tests cover tracing scenarios
