### PR TITLE
feat: service client cache

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.2.1"
+version = "2.3.0"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_core/rai/communication/ros2/api/service.py
+++ b/src/rai_core/rai/communication/ros2/api/service.py
@@ -74,17 +74,15 @@ class ROS2ServiceAPI(BaseROS2API):
         Returns:
             The response message
         """
-        request_message, service_type_class = self.build_ros2_service_request(
-            service_type, request
-        )
+        srv_msg, srv_cls = self.build_ros2_service_request(service_type, request)
         if reuse_client:
             with self._persistent_clients_lock:
                 client = self._persistent_clients.get(service_name, None)
                 if client is None:
-                    client = self.node.create_client(service_type_class, service_name)  # type: ignore
+                    client = self.node.create_client(srv_cls, service_name)  # type: ignore
                     self._persistent_clients[service_name] = client
         else:
-            client = self.node.create_client(service_type_class, service_name)  # type: ignore
+            client = self.node.create_client(srv_cls, service_name)  # type: ignore
         is_service_available = client.wait_for_service(timeout_sec=timeout_sec)
         if not is_service_available:
             raise ValueError(
@@ -92,9 +90,9 @@ class ROS2ServiceAPI(BaseROS2API):
                 "Try increasing the timeout or check if the service is running."
             )
         if os.getenv("ROS_DISTRO") == "humble":
-            return client.call(request_message)
+            return client.call(srv_msg)
         else:
-            return client.call(request_message, timeout_sec=timeout_sec)
+            return client.call(srv_msg, timeout_sec=timeout_sec)
 
     def get_service_names_and_types(self) -> List[Tuple[str, List[str]]]:
         return self.node.get_service_names_and_types()

--- a/src/rai_core/rai/communication/ros2/api/service.py
+++ b/src/rai_core/rai/communication/ros2/api/service.py
@@ -60,7 +60,7 @@ class ROS2ServiceAPI(BaseROS2API):
         service_type: str,
         request: Any,
         timeout_sec: float = 5.0,
-        /,
+        *,
         reuse_client: bool = True,
     ) -> Any:
         """

--- a/src/rai_core/rai/communication/ros2/connectors/service_mixin.py
+++ b/src/rai_core/rai/communication/ros2/connectors/service_mixin.py
@@ -30,6 +30,9 @@ class ROS2ServiceMixin:
                 f"{self.__class__.__name__} instance must have an attribute '_service_api' of type ROS2ServiceAPI"
             )
 
+    def release_client(self, service_name: str) -> bool:
+        return self._service_api.release_client(service_name)
+
     def service_call(
         self,
         message: ROS2Message,
@@ -37,6 +40,7 @@ class ROS2ServiceMixin:
         timeout_sec: float = 5.0,
         *,
         msg_type: str,
+        reuse_client: bool = True,
         **kwargs: Any,
     ) -> ROS2Message:
         msg = self._service_api.call_service(
@@ -44,6 +48,7 @@ class ROS2ServiceMixin:
             service_type=msg_type,
             request=message.payload,
             timeout_sec=timeout_sec,
+            reuse_client=reuse_client,
         )
         return ROS2Message(
             payload=msg, metadata={"msg_type": str(type(msg)), "service": target}

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -212,7 +212,7 @@ def test_ros2_service_multiple_calls_with_reused_client(
         service_api = ROS2ServiceAPI(node)
         for _ in range(3):
             invoke_set_bool_service(service_name, service_api, reuse_client=True)
-            assert service_api.release_client(service_name), "Client not released"
+        assert service_api.release_client(service_name), "Client not released"
     finally:
         shutdown_executors_and_threads(executors, threads)
 

--- a/tests/communication/ros2/test_api.py
+++ b/tests/communication/ros2/test_api.py
@@ -138,11 +138,14 @@ def test_ros2_single_message_publish_wrong_qos_setup(
         shutdown_executors_and_threads(executors, threads)
 
 
-def service_call_helper(service_name: str, service_api: ROS2ServiceAPI):
+def invoke_set_bool_service(
+    service_name: str, service_api: ROS2ServiceAPI, reuse_client: bool = True
+):
     response = service_api.call_service(
         service_name,
         service_type="std_srvs/srv/SetBool",
         request={"data": True},
+        reuse_client=reuse_client,
     )
     assert response.success
     assert response.message == "Test service called"
@@ -164,7 +167,7 @@ def test_ros2_service_single_call(
 
     try:
         service_api = ROS2ServiceAPI(node)
-        service_call_helper(service_name, service_api)
+        invoke_set_bool_service(service_name, service_api)
     finally:
         shutdown_executors_and_threads(executors, threads)
 
@@ -186,7 +189,30 @@ def test_ros2_service_multiple_calls(
     try:
         service_api = ROS2ServiceAPI(node)
         for _ in range(3):
-            service_call_helper(service_name, service_api)
+            invoke_set_bool_service(service_name, service_api, reuse_client=False)
+    finally:
+        shutdown_executors_and_threads(executors, threads)
+
+
+@pytest.mark.parametrize(
+    "callback_group",
+    [MutuallyExclusiveCallbackGroup(), ReentrantCallbackGroup()],
+    ids=["MutuallyExclusiveCallbackGroup", "ReentrantCallbackGroup"],
+)
+def test_ros2_service_multiple_calls_with_reused_client(
+    ros_setup: None, request: pytest.FixtureRequest, callback_group: CallbackGroup
+) -> None:
+    service_name = f"{request.node.originalname}_service"  # type: ignore
+    node_name = f"{request.node.originalname}_node"  # type: ignore
+    service_server = ServiceServer(service_name, callback_group)
+    node = Node(node_name)
+    executors, threads = multi_threaded_spinner([service_server, node])
+
+    try:
+        service_api = ROS2ServiceAPI(node)
+        for _ in range(3):
+            invoke_set_bool_service(service_name, service_api, reuse_client=True)
+            assert service_api.release_client(service_name), "Client not released"
     finally:
         shutdown_executors_and_threads(executors, threads)
 
@@ -210,7 +236,7 @@ def test_ros2_service_multiple_calls_at_the_same_time_threading(
         service_threads: List[threading.Thread] = []
         for _ in range(10):
             thread = threading.Thread(
-                target=service_call_helper, args=(service_name, service_api)
+                target=invoke_set_bool_service, args=(service_name, service_api)
             )
             service_threads.append(thread)
             thread.start()
@@ -241,7 +267,7 @@ def test_ros2_service_multiple_calls_at_the_same_time_multiprocessing(
         service_api = ROS2ServiceAPI(node)
         with Pool(10) as pool:
             pool.map(
-                lambda _: service_call_helper(service_name, service_api), range(10)
+                lambda _: invoke_set_bool_service(service_name, service_api), range(10)
             )
     finally:
         shutdown_executors_and_threads(executors, threads)


### PR DESCRIPTION
## Purpose

Resolves #684 

## Proposed Changes

Dict caching of created clients

## Issues

#684 

## Testing

New test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added thread-safe caching and reuse of ROS 2 service clients, improving performance for repeated calls.
  - Introduced an option to toggle client reuse per call.
  - Added the ability to release a cached client when no longer needed.

- Tests
  - Expanded coverage for client reuse, concurrent calls, and client release scenarios.
  - Updated test helpers to support the reuse option.

- Chores
  - Bumped package version to 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->