### PR TITLE
feat: megamind context providers

### DIFF
--- a/src/rai_core/rai/agents/langchain/core/__init__.py
+++ b/src/rai_core/rai/agents/langchain/core/__init__.py
@@ -14,7 +14,12 @@
 
 from .conversational_agent import State as ConversationalAgentState
 from .conversational_agent import create_conversational_agent
-from .megamind import Executor, create_megamind, get_initial_megamind_state
+from .megamind import (
+    ContextProvider,
+    Executor,
+    create_megamind,
+    get_initial_megamind_state,
+)
 from .react_agent import (
     ReActAgentState,
     create_react_runnable,
@@ -23,6 +28,7 @@ from .state_based_agent import create_state_based_runnable
 from .tool_runner import SubAgentToolRunner, ToolRunner
 
 __all__ = [
+    "ContextProvider",
     "ConversationalAgentState",
     "Executor",
     "ReActAgentState",

--- a/src/rai_core/rai/agents/langchain/core/megamind.py
+++ b/src/rai_core/rai/agents/langchain/core/megamind.py
@@ -260,8 +260,8 @@ def plan_step(
 
 def create_megamind(
     megamind_llm: BaseChatModel,
-    megamind_system_prompt: str,
     executors: List[Executor],
+    megamind_system_prompt: Optional[str] = None,
     task_planning_prompt: Optional[str] = None,
     context_providers: List[ContextProvider] = [],
 ) -> CompiledStateGraph:
@@ -270,8 +270,17 @@ def create_megamind(
     Args:
         executors (List[Executor]): Subagents for megamind, each can be a specialist with
         its own tools llm and system prompt
+
+        megamind_system_prompt (Optional[str]): Prompt for megamind node. If not provided
+        it will default to informing agent of the avaialble executors and listing their tools.
+
         task_planning_prompt (Optional[str]): Prompt that helps summarize the step in a way
         that helps planning task
+
+        context_providers (List[ContextProvider]): Each ContextProvider can inject external info
+        to prompt during planning phase
+
+
     """
     executor_agents = {}
     handoff_tools = []

--- a/src/rai_core/rai/agents/langchain/core/megamind.py
+++ b/src/rai_core/rai/agents/langchain/core/megamind.py
@@ -209,8 +209,8 @@ def get_initial_megamind_state(task: str):
 
 def plan_step(
     megamind_agent: BaseChatModel,
-    context_providers: Optional[List[ContextProvider]],
     state: MegamindState,
+    context_providers: Optional[List[ContextProvider]] = None,
 ) -> MegamindState:
     """Initial planning step."""
     if "original_task" not in state:
@@ -321,7 +321,8 @@ The single task should be delegated to only 1 agent and should be doable by only
     )
 
     graph = StateGraph(MegamindState).add_node(
-        "megamind", partial(plan_step, megamind_agent, context_providers)
+        "megamind",
+        partial(plan_step, megamind_agent, context_providers=context_providers),
     )
     for agent_name, agent in executor_agents.items():
         graph.add_node(agent_name, agent)


### PR DESCRIPTION
## Purpose
Injecting external info to megamind prompt

## Proposed Changes

ContextProvider abstract class which has just one method get_context() which later provides an additional info during plan step

## Issues


## Testing
1. import and define some context provider, like:
```python
class UsefulContext:
        def get_context(self) -> str:
            return "\nVery useful context!\n"

    useful_context = UsefulContext()
    agent = create_megamind(
        megamind_llm=supervisor_llm,
        megamind_system_prompt=task.get_system_prompt(),
        executors=executors,
        task_planning_prompt=task.get_planning_prompt(),
        context_providers=[useful_context],
    )

```
2. Run and check the prompt (easiest via Langfuse)
```bash
python3 src/rai_bench/rai_bench/examples/tool_calling_custom_agent.py 
```
