### PR TITLE
fix: create missing vision subdirectory for weights download path

### DIFF
--- a/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
+++ b/src/rai_extensions/rai_open_set_vision/rai_open_set_vision/agents/base_vision_agent.py
@@ -36,10 +36,11 @@ class BaseVisionAgent(BaseAgent):
             raise ValueError("WEIGHTS_FILENAME is not set")
         super().__init__()
         self.weights_root_path = Path(weights_root_path)
-        self.weights_root_path.mkdir(parents=True, exist_ok=True)
         self.weights_path = (
             self.weights_root_path / self.WEIGHTS_DIR_PATH_PART / self.WEIGHTS_FILENAME
         )
+        # create the directory structure
+        self.weights_path.parent.mkdir(parents=True, exist_ok=True)
         if not self.weights_path.exists():
             self._download_weights()
         self.ros2_connector = ROS2Connector(ros2_name, executor_type="single_threaded")

--- a/tests/rai_open_set_vision/test_base_vision_agent.py
+++ b/tests/rai_open_set_vision/test_base_vision_agent.py
@@ -16,6 +16,7 @@ import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rclpy
 from rai_open_set_vision.agents.base_vision_agent import BaseVisionAgent
 
 
@@ -66,8 +67,10 @@ class TestVisionWeightsDownload:
             # Verify file exists after download
             assert weights_path.exists()
 
-            # Clean up ROS2 node
+            # Clean up ROS2 node and context
             agent.stop()
+            if rclpy.ok():
+                rclpy.shutdown()
 
     def test_download_weights_failure(self, tmp_path):
         """Test weight download failure raises exception."""
@@ -88,5 +91,7 @@ class TestVisionWeightsDownload:
             with pytest.raises(Exception, match="Could not download weights"):
                 agent._download_weights()
 
-            # Clean up ROS2 node
+            # Clean up ROS2 node and context
             agent.stop()
+            if rclpy.ok():
+                rclpy.shutdown()

--- a/tests/rai_open_set_vision/test_base_vision_agent.py
+++ b/tests/rai_open_set_vision/test_base_vision_agent.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from rai_open_set_vision.agents.base_vision_agent import BaseVisionAgent
+
+
+class MockBaseVisionAgent(BaseVisionAgent):
+    """Mock implementation of BaseVisionAgent with required attributes."""
+    WEIGHTS_URL = "https://example.com/test_weights.pth"
+    WEIGHTS_FILENAME = "test_weights.pth"
+    
+    def run(self):
+        """Dummy implementation of abstract run method for testing."""
+        pass
+
+
+class TestVisionWeightsDownload:
+    """Test cases for BaseVisionAgent._download_weights method."""
+
+    def test_download_weights_success(self, tmp_path):
+        """Test successful weight download."""
+        # make sure we have multiple levels of directories
+        weights_path = tmp_path / "vision" / "weights" / "test_weights.pth"
+        
+        # check whether file doesn't exist before download
+        assert not weights_path.exists()
+        
+        def mock_wget(*args, **kwargs):
+            # Simulate wget creating the file
+            output_path = args[0][3]  # -O argument is at index 3
+            output_path.write_text("downloaded weights content")
+            return MagicMock(returncode=0)
+        
+        with patch('subprocess.run', side_effect=mock_wget) as mock_run:
+            agent = MockBaseVisionAgent(weights_root_path=str(tmp_path), ros2_name="test_agent")
+            agent.weights_path = weights_path
+            
+            mock_run.assert_called_once_with([
+                "wget",
+                "https://example.com/test_weights.pth",
+                "-O",
+                weights_path,  
+                "--progress=dot:giga",
+            ])
+            
+            # Verify file exists after download
+            assert weights_path.exists()
+            
+            # Clean up ROS2 node
+            agent.stop()
+            
+            
+    def test_download_weights_failure(self, tmp_path):
+        """Test weight download failure raises exception."""
+        weights_path = tmp_path / "vision" / "weights" / "test_weights.pth"
+        
+        with patch('subprocess.run') as mock_run:
+            # First call succeeds (during initialization), second call fails
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # Initial download succeeds
+                subprocess.CalledProcessError(1, "wget")  # Explicit call fails
+            ]
+            
+            agent = MockBaseVisionAgent(weights_root_path=str(tmp_path), ros2_name="test_agent")
+            agent.weights_path = weights_path
+            
+            with pytest.raises(Exception, match="Could not download weights"):
+                agent._download_weights()
+            
+            # Clean up ROS2 node
+            agent.stop()
+

--- a/tests/rai_open_set_vision/test_base_vision_agent.py
+++ b/tests/rai_open_set_vision/test_base_vision_agent.py
@@ -12,21 +12,19 @@
 # See the specific language governing permissions and
 # limitations under the License.
 
-import os
 import subprocess
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
-
 from rai_open_set_vision.agents.base_vision_agent import BaseVisionAgent
 
 
 class MockBaseVisionAgent(BaseVisionAgent):
     """Mock implementation of BaseVisionAgent with required attributes."""
+
     WEIGHTS_URL = "https://example.com/test_weights.pth"
     WEIGHTS_FILENAME = "test_weights.pth"
-    
+
     def run(self):
         """Dummy implementation of abstract run method for testing."""
         pass
@@ -39,52 +37,56 @@ class TestVisionWeightsDownload:
         """Test successful weight download."""
         # make sure we have multiple levels of directories
         weights_path = tmp_path / "vision" / "weights" / "test_weights.pth"
-        
+
         # check whether file doesn't exist before download
         assert not weights_path.exists()
-        
+
         def mock_wget(*args, **kwargs):
             # Simulate wget creating the file
             output_path = args[0][3]  # -O argument is at index 3
             output_path.write_text("downloaded weights content")
             return MagicMock(returncode=0)
-        
-        with patch('subprocess.run', side_effect=mock_wget) as mock_run:
-            agent = MockBaseVisionAgent(weights_root_path=str(tmp_path), ros2_name="test_agent")
+
+        with patch("subprocess.run", side_effect=mock_wget) as mock_run:
+            agent = MockBaseVisionAgent(
+                weights_root_path=str(tmp_path), ros2_name="test_agent"
+            )
             agent.weights_path = weights_path
-            
-            mock_run.assert_called_once_with([
-                "wget",
-                "https://example.com/test_weights.pth",
-                "-O",
-                weights_path,  
-                "--progress=dot:giga",
-            ])
-            
+
+            mock_run.assert_called_once_with(
+                [
+                    "wget",
+                    "https://example.com/test_weights.pth",
+                    "-O",
+                    weights_path,
+                    "--progress=dot:giga",
+                ]
+            )
+
             # Verify file exists after download
             assert weights_path.exists()
-            
-            # Clean up ROS2 node
-            agent.stop()
-            
-            
-    def test_download_weights_failure(self, tmp_path):
-        """Test weight download failure raises exception."""
-        weights_path = tmp_path / "vision" / "weights" / "test_weights.pth"
-        
-        with patch('subprocess.run') as mock_run:
-            # First call succeeds (during initialization), second call fails
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # Initial download succeeds
-                subprocess.CalledProcessError(1, "wget")  # Explicit call fails
-            ]
-            
-            agent = MockBaseVisionAgent(weights_root_path=str(tmp_path), ros2_name="test_agent")
-            agent.weights_path = weights_path
-            
-            with pytest.raises(Exception, match="Could not download weights"):
-                agent._download_weights()
-            
+
             # Clean up ROS2 node
             agent.stop()
 
+    def test_download_weights_failure(self, tmp_path):
+        """Test weight download failure raises exception."""
+        weights_path = tmp_path / "vision" / "weights" / "test_weights.pth"
+
+        with patch("subprocess.run") as mock_run:
+            # First call succeeds (during initialization), second call fails
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # Initial download succeeds
+                subprocess.CalledProcessError(1, "wget"),  # Explicit call fails
+            ]
+
+            agent = MockBaseVisionAgent(
+                weights_root_path=str(tmp_path), ros2_name="test_agent"
+            )
+            agent.weights_path = weights_path
+
+            with pytest.raises(Exception, match="Could not download weights"):
+                agent._download_weights()
+
+            # Clean up ROS2 node
+            agent.stop()


### PR DESCRIPTION
## Purpose

A regression was introduced in https://github.com/RobotecAI/rai/pull/686 which causes the following error when starting `rai_open_set_vision` agents.  

```
[python-2] FileNotFoundError: [Errno 2] No such file or directory: '/home/mmajek/.cache/rai/vision/weights/groundingdino_swint_ogc.pth'
```
The bug was missed because it only manifests when the `vision` folder doesn't exist under `.cache/rai/`.

## Proposed Changes

The `BaseVisionAgent` constructor creates `weights_root_path` however fails to create the intermediate `vision` subdirectory (WEIGHTS_DIR_PATH_PART). This causes the `wget` command to fail when attempting to download weights to a non-existent directory path.

This PR handles the directory structure creation and adds unit tests to cover the weights download. 

## Issues

-   None,

## Testing

-  New unit tests pass.
-  Remove  `rai/vision` from `.cache` and run following 
```
python src/rai_extensions/rai_open_set_vision/scripts/run_vision_agents.py
``` 
