### PR TITLE
fix: ROS 2 color space

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.5.3"
+version = "2.5.4"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_core/rai/messages/conversion.py
+++ b/src/rai_core/rai/messages/conversion.py
@@ -68,6 +68,7 @@ def preprocess_image(
     - All inputs are decoded and re-encoded to PNG to guarantee consistent output.
     - Float arrays are assumed to be in [0, 1] and are scaled to ``uint8``.
     - Network requests use a timeout of ``(5, 15)`` seconds (connect, read).
+    - Supported color space: rgb
 
     Examples
     --------

--- a/src/rai_core/rai/tools/ros2/generic/topics.py
+++ b/src/rai_core/rai/tools/ros2/generic/topics.py
@@ -137,11 +137,11 @@ class GetROS2ImageTool(BaseROS2Tool):
         msg_type = type(message.payload)
         if msg_type == Image:
             image = CvBridge().imgmsg_to_cv2(  # type: ignore
-                message.payload, desired_encoding="bgr8"
+                message.payload, desired_encoding="rgb8"
             )
         elif msg_type == CompressedImage:
             image = CvBridge().compressed_imgmsg_to_cv2(  # type: ignore
-                message.payload, desired_encoding="bgr8"
+                message.payload, desired_encoding="rgb8"
             )
         else:
             raise ValueError(


### PR DESCRIPTION
## Purpose

Fix wrong color space. preprocess_message expects rgb image instead of bgr8.

## Proposed Changes

desired_encoding: bgr8 -> rgb8

## Issues

-   Links to relevant issues

## Testing

-   How was it tested, what were the results?
