### PR TITLE
feat: timeout in ros2 waiters

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.5.10"
+version = "2.6.0"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_core/rai/communication/ros2/waiters.py
+++ b/src/rai_core/rai/communication/ros2/waiters.py
@@ -15,7 +15,7 @@
 
 import logging
 import time
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -23,86 +23,157 @@ if TYPE_CHECKING:
     from rai.communication.ros2.connectors.base import ROS2BaseConnector
 
 
+def get_missing_entities(
+    callable_get_entities: Callable[[], List[Tuple[str, Any]]],
+    requested_entities: List[str],
+) -> set[str]:
+    available_entities = callable_get_entities()
+    available_entity_names = [entity[0] for entity in available_entities]
+    return set(requested_entities) - set(available_entity_names)
+
+
 def wait_for_ros2_services(
     connector: "ROS2BaseConnector[Any]",
     requested_services: List[str],
     time_interval: float = 1.0,
-    timeout: float = 60.0,
+    timeout: float = -1.0,
 ) -> None:
-    # make sure the requested services start with '/'
+    """
+    Wait until all requested ROS2 services are available.
+
+    Args:
+        connector: Connector providing service information.
+        requested_services: List of service names to wait for.
+        time_interval: Time interval (in seconds) to check for the services.
+        timeout: Timeout in seconds. If set to -1 (default), there is no timeout.
+
+    Raises:
+        TimeoutError: If the services are not available within the timeout.
+    """
     requested_services = [
         f"/{service}" if not service.startswith("/") else service
         for service in requested_services
     ]
 
-    service_names: List[str] = []
     start_time = time.time()
-    while time.time() - start_time < timeout:
-        available_services = connector.get_services_names_and_types()
-        service_names = [service[0] for service in available_services]
-        if set(requested_services).issubset(set(service_names)):
-            break
-        logger.info(
-            f"Waiting for services {set(requested_services) - set(service_names)}..."
-        )
-        time.sleep(time_interval)
+    get_services = connector.get_services_names_and_types
+
+    if timeout == -1:
+        while True:
+            missing = get_missing_entities(get_services, requested_services)
+            if not missing:
+                break
+            logger.info(f"Waiting for services {missing}...")
+            time.sleep(time_interval)
     else:
-        raise TimeoutError(
-            f"Services {set(requested_services) - set(service_names)} not available within {timeout} seconds"
-        )
+        while time.time() - start_time < timeout:
+            missing = get_missing_entities(get_services, requested_services)
+            if not missing:
+                break
+            logger.info(f"Waiting for services {missing}...")
+            time.sleep(time_interval)
+        else:
+            available_services = get_services()
+            service_names = [service[0] for service in available_services]
+            missing = set(requested_services) - set(service_names)
+            raise TimeoutError(
+                f"Services {missing} not available within {timeout} seconds"
+            )
 
 
 def wait_for_ros2_topics(
     connector: "ROS2BaseConnector[Any]",
     requested_topics: List[str],
     time_interval: float = 1.0,
-    timeout: float = 60.0,
+    timeout: float = -1.0,
 ) -> None:
-    # make sure the requested topics start with '/'
+    """
+    Wait until all requested ROS2 topics are available.
+
+    Args:
+        connector: Connector providing topic information.
+        requested_topics: List of topic names to wait for.
+        time_interval: Time interval (in seconds) to check for the topics.
+        timeout: Timeout in seconds. If set to -1 (default), there is no timeout.
+
+    Raises:
+        TimeoutError: If the topics are not available within the timeout.
+    """
     requested_topics = [
         f"/{topic}" if not topic.startswith("/") else topic
         for topic in requested_topics
     ]
 
-    topic_names: List[str] = []
     start_time = time.time()
-    while time.time() - start_time < timeout:
-        available_topics = connector.get_topics_names_and_types()
-        topic_names = [topic[0] for topic in available_topics]
-        if set(requested_topics).issubset(set(topic_names)):
-            break
-        logger.info(f"Waiting for topics {set(requested_topics) - set(topic_names)}...")
-        time.sleep(time_interval)
+    get_topics = connector.get_topics_names_and_types
+
+    if timeout == -1:
+        while True:
+            missing = get_missing_entities(get_topics, requested_topics)
+            if not missing:
+                break
+            logger.info(f"Waiting for topics {missing}...")
+            time.sleep(time_interval)
     else:
-        raise TimeoutError(
-            f"Topics {set(requested_topics) - set(topic_names)} not available within {timeout} seconds. Available topics: {topic_names}"
-        )
+        while time.time() - start_time < timeout:
+            missing = get_missing_entities(get_topics, requested_topics)
+            if not missing:
+                break
+            logger.info(f"Waiting for topics {missing}...")
+            time.sleep(time_interval)
+        else:
+            available_topics = get_topics()
+            topic_names = [topic[0] for topic in available_topics]
+            missing = set(requested_topics) - set(topic_names)
+            raise TimeoutError(
+                f"Topics {missing} not available within {timeout} seconds. Available topics: {topic_names}"
+            )
 
 
 def wait_for_ros2_actions(
     connector: "ROS2BaseConnector[Any]",
     requested_actions: List[str],
     time_interval: float = 1.0,
-    timeout: float = 60.0,
+    timeout: float = -1.0,
 ) -> None:
-    # make sure the requested actions start with '/'
+    """
+    Wait until all requested ROS2 actions are available.
+
+    Args:
+        connector: Connector providing action information.
+        requested_actions: List of action names to wait for.
+        time_interval: Time interval (in seconds) to check for the actions.
+        timeout: Timeout in seconds. If set to -1 (default), there is no timeout.
+
+    Raises:
+        TimeoutError: If the actions are not available within the timeout.
+    """
     requested_actions = [
         f"/{action}" if not action.startswith("/") else action
         for action in requested_actions
     ]
 
-    action_names: List[str] = []
     start_time = time.time()
-    while time.time() - start_time < timeout:
-        available_actions = connector.get_actions_names_and_types()
-        action_names = [action[0] for action in available_actions]
-        if set(requested_actions).issubset(set(action_names)):
-            break
-        logger.info(
-            f"Waiting for actions {set(requested_actions) - set(action_names)}..."
-        )
-        time.sleep(time_interval)
+    get_actions = connector.get_actions_names_and_types
+
+    if timeout == -1:
+        while True:
+            missing = get_missing_entities(get_actions, requested_actions)
+            if not missing:
+                break
+            logger.info(f"Waiting for actions {missing}...")
+            time.sleep(time_interval)
     else:
-        raise TimeoutError(
-            f"Actions {set(requested_actions) - set(action_names)} not available within {timeout} seconds. Available actions: {action_names}"
-        )
+        while time.time() - start_time < timeout:
+            missing = get_missing_entities(get_actions, requested_actions)
+            if not missing:
+                break
+            logger.info(f"Waiting for actions {missing}...")
+            time.sleep(time_interval)
+        else:
+            available_actions = get_actions()
+            action_names = [action[0] for action in available_actions]
+            missing = set(requested_actions) - set(action_names)
+            raise TimeoutError(
+                f"Actions {missing} not available within {timeout} seconds. Available actions: {action_names}"
+            )

--- a/src/rai_core/rai/communication/ros2/waiters.py
+++ b/src/rai_core/rai/communication/ros2/waiters.py
@@ -27,6 +27,7 @@ def wait_for_ros2_services(
     connector: "ROS2BaseConnector[Any]",
     requested_services: List[str],
     time_interval: float = 1.0,
+    timeout: float = 60.0,
 ) -> None:
     # make sure the requested services start with '/'
     requested_services = [
@@ -34,7 +35,9 @@ def wait_for_ros2_services(
         for service in requested_services
     ]
 
-    while True:
+    service_names: List[str] = []
+    start_time = time.time()
+    while time.time() - start_time < timeout:
         available_services = connector.get_services_names_and_types()
         service_names = [service[0] for service in available_services]
         if set(requested_services).issubset(set(service_names)):
@@ -43,12 +46,17 @@ def wait_for_ros2_services(
             f"Waiting for services {set(requested_services) - set(service_names)}..."
         )
         time.sleep(time_interval)
+    else:
+        raise TimeoutError(
+            f"Services {set(requested_services) - set(service_names)} not available within {timeout} seconds"
+        )
 
 
 def wait_for_ros2_topics(
     connector: "ROS2BaseConnector[Any]",
     requested_topics: List[str],
     time_interval: float = 1.0,
+    timeout: float = 60.0,
 ) -> None:
     # make sure the requested topics start with '/'
     requested_topics = [
@@ -56,19 +64,26 @@ def wait_for_ros2_topics(
         for topic in requested_topics
     ]
 
-    while True:
+    topic_names: List[str] = []
+    start_time = time.time()
+    while time.time() - start_time < timeout:
         available_topics = connector.get_topics_names_and_types()
         topic_names = [topic[0] for topic in available_topics]
         if set(requested_topics).issubset(set(topic_names)):
             break
         logger.info(f"Waiting for topics {set(requested_topics) - set(topic_names)}...")
         time.sleep(time_interval)
+    else:
+        raise TimeoutError(
+            f"Topics {set(requested_topics) - set(topic_names)} not available within {timeout} seconds. Available topics: {topic_names}"
+        )
 
 
 def wait_for_ros2_actions(
     connector: "ROS2BaseConnector[Any]",
     requested_actions: List[str],
     time_interval: float = 1.0,
+    timeout: float = 60.0,
 ) -> None:
     # make sure the requested actions start with '/'
     requested_actions = [
@@ -76,7 +91,9 @@ def wait_for_ros2_actions(
         for action in requested_actions
     ]
 
-    while True:
+    action_names: List[str] = []
+    start_time = time.time()
+    while time.time() - start_time < timeout:
         available_actions = connector.get_actions_names_and_types()
         action_names = [action[0] for action in available_actions]
         if set(requested_actions).issubset(set(action_names)):
@@ -85,3 +102,7 @@ def wait_for_ros2_actions(
             f"Waiting for actions {set(requested_actions) - set(action_names)}..."
         )
         time.sleep(time_interval)
+    else:
+        raise TimeoutError(
+            f"Actions {set(requested_actions) - set(action_names)} not available within {timeout} seconds. Available actions: {action_names}"
+        )

--- a/tests/communication/ros2/test_waiters.py
+++ b/tests/communication/ros2/test_waiters.py
@@ -14,6 +14,7 @@
 
 from collections import deque
 
+import pytest
 from rai.communication.ros2 import waiters
 
 
@@ -77,3 +78,33 @@ def test_wait_for_ros2_actions(monkeypatch):
     monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
 
     waiters.wait_for_ros2_actions(connector, ["action_a"], time_interval=0)
+
+
+def test_wait_for_ros2_services_timeout(monkeypatch):
+    connector = DummyConnector(services_seq=[[]])
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+
+    with pytest.raises(TimeoutError):
+        waiters.wait_for_ros2_services(
+            connector, ["target_service"], time_interval=0.001, timeout=0.01
+        )
+
+
+def test_wait_for_ros2_topics_timeout(monkeypatch):
+    connector = DummyConnector(topics_seq=[[]])
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+
+    with pytest.raises(TimeoutError):
+        waiters.wait_for_ros2_topics(
+            connector, ["target_topic"], time_interval=0.001, timeout=0.01
+        )
+
+
+def test_wait_for_ros2_actions_timeout(monkeypatch):
+    connector = DummyConnector(actions_seq=[[]])
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+
+    with pytest.raises(TimeoutError):
+        waiters.wait_for_ros2_actions(
+            connector, ["target_action"], time_interval=0.001, timeout=0.01
+        )

--- a/tests/communication/ros2/test_waiters.py
+++ b/tests/communication/ros2/test_waiters.py
@@ -108,3 +108,21 @@ def test_wait_for_ros2_actions_timeout(monkeypatch):
         waiters.wait_for_ros2_actions(
             connector, ["target_action"], time_interval=0.001, timeout=0.01
         )
+
+
+@pytest.mark.parametrize(
+    "seq_type, seq_arg, wait_func, name",
+    [
+        ("topics_seq", [[]], waiters.wait_for_ros2_topics, "target_topic"),
+        ("actions_seq", [[]], waiters.wait_for_ros2_actions, "target_action"),
+        ("services_seq", [[]], waiters.wait_for_ros2_services, "target_service"),
+    ],
+)
+def test_wait_for_ros2_negative_timeout(
+    monkeypatch, seq_type, seq_arg, wait_func, name
+):
+    connector = DummyConnector(**{seq_type: seq_arg})
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+
+    with pytest.raises(ValueError):
+        wait_func(connector, [name], time_interval=0.001, timeout=-0.01)


### PR DESCRIPTION
## Purpose

Enables the use of ros2_waiters in scenarios where the absence of certain topics, services, or actions should prevent the application from starting.

## Issues

Closes #728 

## Testing

New tests