### PR TITLE
fix: rai-interfaces-in-dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN apt update && apt install -y \
     python3-pip \
     git \
     wget \
-    zip
+    zip \
+    ros-${ROS_DISTRO}-rai-interfaces
 
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.3
@@ -73,5 +74,6 @@ RUN apt install -y \
     libxcb-xinput0 \
     libpcre2-16-0 \
     libunwind-dev
+
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,9 +32,7 @@ RUN apt update && apt install -y \
     python3-pip \
     git \
     wget \
-    zip \
-    ros-${ROS_DISTRO}-rai-interfaces
-
+    zip
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.3
 ENV PATH="/root/.local/bin:$PATH"

--- a/src/rai_bringup/package.xml
+++ b/src/rai_bringup/package.xml
@@ -6,6 +6,8 @@
   <maintainer email="maciej.majek@robotec.ai">Maciej Majek</maintainer>
   <license>Apache-2.0</license>
 
+  <exec_depend>rai_interfaces</exec_depend>
+
   <test_depend>python3-pytest</test_depend>
 
   <export>


### PR DESCRIPTION
## Purpose
rai interfaces were missing in dockerfile which resulted in some ros packages being not installed

## Proposed Changes

What does this PR add, remove or fix?

## Issues

-   Links to relevant issues

## Testing
Follow the docker setup in README. All tests should pass inside container
