### PR TITLE
fix: manipulation demo

### DIFF
--- a/examples/manipulation-demo.py
+++ b/examples/manipulation-demo.py
@@ -16,8 +16,6 @@
 import logging
 from typing import List
 
-import rclpy
-import rclpy.qos
 from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from rai import get_llm_model
@@ -38,8 +36,6 @@ logger = logging.getLogger(__name__)
 
 
 def create_agent():
-    if not rclpy.ok():
-        rclpy.init()
     connector = ROS2Connector(executor_type="single_threaded")
 
     required_services = ["/grounded_sam_segment", "/grounding_dino_classify"]

--- a/examples/manipulation-demo.py
+++ b/examples/manipulation-demo.py
@@ -21,7 +21,7 @@ import rclpy.qos
 from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from rai import get_llm_model
-from rai.agents.langchain.core import create_conversational_agent
+from rai.agents.langchain.core import create_react_runnable
 from rai.communication.ros2 import wait_for_ros2_services, wait_for_ros2_topics
 from rai.communication.ros2.connectors import ROS2Connector
 from rai.tools.ros2.manipulation import (
@@ -38,7 +38,8 @@ logger = logging.getLogger(__name__)
 
 
 def create_agent():
-    rclpy.init()
+    if not rclpy.ok():
+        rclpy.init()
     connector = ROS2Connector(executor_type="single_threaded")
 
     required_services = ["/grounded_sam_segment", "/grounding_dino_classify"]
@@ -68,7 +69,8 @@ def create_agent():
     embodiment_info = EmbodimentInfo.from_file(
         "examples/embodiments/manipulation_embodiment.json"
     )
-    agent = create_conversational_agent(
+
+    agent = create_react_runnable(
         llm=llm,
         tools=tools,
         system_prompt=embodiment_info.to_langchain(),

--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.6.1"
+version = "2.6.2"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"


### PR DESCRIPTION
## Purpose
- Fix issues with running manipulation demo on current main

## Proposed Changes
- Added missing import to deprecated conversational_agent 
- using new create_react_runnable in manipulation demo instead of deprecated conversational_agent
- fixing defining model in grounding dino

## Issues

-   Links to relevant issues

## Testing
Run manipulation demo
