### PR TITLE
fix: vision model is not initialzed when use_cuda is true

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.6.0"
+version = "2.6.1"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/src/rai_extensions/rai_perception/rai_perception/vision_markup/boxer.py
+++ b/src/rai_extensions/rai_perception/rai_perception/vision_markup/boxer.py
@@ -80,15 +80,13 @@ class GDBoxer:
             "vision_markup/boxer.py", "configs/gdino_config.py"
         )
         self.weight_path = str(weight_path)
-        if use_cuda:
-            if torch.cuda.is_available():
-                self.device = "cuda"
-            else:
-                self.logger.warning("CUDA is not available but requested, using CPU")
-                self.device = "cpu"
+        if use_cuda and torch.cuda.is_available():
+            self.device = "cuda"
         else:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
-            self.model = Model(self.cfg_path, self.weight_path, device=device)
+            if use_cuda:
+                self.logger.warning("CUDA is not available but requested, using CPU")
+            self.device = "cpu"
+        self.model = Model(self.cfg_path, self.weight_path, device=self.device)
         self.bridge = CvBridge()
 
     def get_boxes(


### PR DESCRIPTION
## Purpose

-   Fix regression introduced from [PR #721](https://github.com/RobotecAI/rai/pull/721)

## Proposed Changes

- Move the model init outside the if/else block. Small refactoring of the condition logic to make it more readable.
- Add unit tests.

## Testing

-  Unit tests were run. 
-  Manipulation demo was run. 
