### PR TITLE
feat: Enable dark mode for RAI docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,13 @@
 site_name: RAI documentation
 theme:
   name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
   features:
     - navigation.sections
     - navigation.expand


### PR DESCRIPTION
## Purpose

-   Enable the dark mode support for RAI docs

## Proposed Changes

- Simple fix

## Issues

-   Links to relevant issues

## Testing

```
# install all dependencies
poetry install --with docs
poetry run pip install src/rai_core src/rai_sim src/rai_bench src/rai_s2s --no-deps

# build & serve
poetry run mkdocs serve

# open http://127.0.0.1:8000/ in brower 
```
