### PR TITLE
fix: NavigateToPose.Result has no attribute error_code and log error msg

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rai_core"
-version = "2.8.1"
+version = "2.8.2"
 description = "Core functionality for RAI framework"
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Bartłomiej Boczek <bartlomiej.boczek@robotec.ai>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"

--- a/tests/tools/ros2/test_nav2_tools.py
+++ b/tests/tools/ros2/test_nav2_tools.py
@@ -34,6 +34,7 @@ from rai.tools.ros2.navigation.nav2_blocking import (
 )
 
 from tests.communication.ros2.helpers import (
+    create_mock_connector_with_clock,
     ros_setup,
 )
 
@@ -85,23 +86,11 @@ def test_get_error_message() -> None:
     assert "Error message: Planner failed to find path" in error_msg
 
 
-def _create_mock_connector() -> MagicMock:
-    """Helper to create a mock connector with node and clock."""
-    connector = MagicMock(spec=ROS2Connector)
-    mock_node = MagicMock()
-    mock_clock = MagicMock()
-    mock_time = MagicMock()
-    mock_clock.now.return_value.to_msg.return_value = mock_time
-    connector.node = mock_node
-    mock_node.get_clock.return_value = mock_clock
-    return connector
-
-
 def test_navigate_to_pose_blocking_tool(
     ros_setup: None, request: pytest.FixtureRequest
 ) -> None:
     """Test navigation tool success, error, and None result scenarios."""
-    connector = _create_mock_connector()
+    connector = create_mock_connector_with_clock()
     tool = NavigateToPoseBlockingTool(connector=connector)
 
     with patch(

--- a/tests/tools/ros2/test_nav2_tools.py
+++ b/tests/tools/ros2/test_nav2_tools.py
@@ -25,7 +25,6 @@ except ImportError:
 from unittest.mock import MagicMock, patch
 
 from geometry_msgs.msg import TransformStamped
-from nav2_msgs.action import NavigateToPose
 from rai.communication.ros2.connectors import ROS2Connector
 from rai.tools.ros2.navigation.nav2_blocking import (
     GetCurrentPoseTool,
@@ -72,7 +71,7 @@ def test_get_error_code_string() -> None:
 def test_get_error_message() -> None:
     """Test error message extraction with error code and optional message."""
     # Test with error code only
-    result = NavigateToPose.Result()
+    result = MagicMock()
     result.error_code = 2
     error_msg = _get_error_message(result)
     assert "(TIMEOUT)" in error_msg
@@ -112,14 +111,14 @@ def test_navigate_to_pose_blocking_tool(
         mock_action_client_class.return_value = mock_action_client
 
         # Test success
-        success_result = NavigateToPose.Result()
+        success_result = MagicMock()
         success_result.error_code = 0
         mock_action_client.send_goal.return_value = success_result
         result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
         assert result == "Navigate to pose successful."
 
         # Test error with error code
-        error_result = NavigateToPose.Result()
+        error_result = MagicMock()
         error_result.error_code = 2
         mock_action_client.send_goal.return_value = error_result
         result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)

--- a/tests/tools/ros2/test_nav2_tools.py
+++ b/tests/tools/ros2/test_nav2_tools.py
@@ -29,8 +29,8 @@ from rai.communication.ros2.connectors import ROS2Connector
 from rai.tools.ros2.navigation.nav2_blocking import (
     GetCurrentPoseTool,
     NavigateToPoseBlockingTool,
-    _get_error_code_string,
     _get_error_message,
+    _get_status_string,
 )
 
 from tests.communication.ros2.helpers import (
@@ -61,35 +61,52 @@ def test_get_current_pose_tool(ros_setup: None, request: pytest.FixtureRequest) 
     assert result == str(transform)
 
 
-def test_get_error_code_string() -> None:
-    """Test error code to string conversion."""
-    assert _get_error_code_string(0) == "NONE"
-    assert _get_error_code_string(2) == "TIMEOUT"
-    assert _get_error_code_string(6) == "PLANNER_FAILED"
-    assert _get_error_code_string(99) == "UNKNOWN_ERROR_CODE_99"
+def test_get_status_string() -> None:
+    """Test GoalStatus to string conversion."""
+    from action_msgs.msg import GoalStatus
+
+    assert _get_status_string(GoalStatus.STATUS_UNKNOWN) == "UNKNOWN"
+    assert _get_status_string(GoalStatus.STATUS_SUCCEEDED) == "SUCCEEDED"
+    assert _get_status_string(GoalStatus.STATUS_ABORTED) == "ABORTED"
+    assert _get_status_string(GoalStatus.STATUS_CANCELED) == "CANCELED"
+    assert _get_status_string(999) == "UNKNOWN_STATUS_999"
 
 
 def test_get_error_message() -> None:
-    """Test error message extraction with error code and optional message."""
-    # Test with error code only
-    result = MagicMock()
-    result.error_code = 2
-    error_msg = _get_error_message(result)
-    assert "(TIMEOUT)" in error_msg
+    """Test error message extraction with status and error_msg."""
+    from action_msgs.msg import GoalStatus
 
-    # Test with error message field
+    # Test with ABORTED status and no error message
+    result_response = MagicMock()
+    result_response.status = GoalStatus.STATUS_ABORTED
+    result_response.result = MagicMock()
+    result_response.result.error_msg = ""
+    error_msg = _get_error_message(result_response)
+    assert error_msg == "Status: ABORTED"
+
+    # Test with ABORTED status and error message
     result_with_msg = MagicMock()
-    result_with_msg.error_code = 6
-    result_with_msg.error_message = "Planner failed to find path"
+    result_with_msg.status = GoalStatus.STATUS_ABORTED
+    result_with_msg.result = MagicMock()
+    result_with_msg.result.error_msg = "Planner failed to find path"
     error_msg = _get_error_message(result_with_msg)
-    assert "(PLANNER_FAILED)" in error_msg
-    assert "Error message: Planner failed to find path" in error_msg
+    assert error_msg == "Status: ABORTED. Planner failed to find path"
+
+    # Test with CANCELED status
+    canceled_response = MagicMock()
+    canceled_response.status = GoalStatus.STATUS_CANCELED
+    canceled_response.result = MagicMock()
+    canceled_response.result.error_msg = ""
+    error_msg = _get_error_message(canceled_response)
+    assert error_msg == "Status: CANCELED"
 
 
 def test_navigate_to_pose_blocking_tool(
     ros_setup: None, request: pytest.FixtureRequest
 ) -> None:
     """Test navigation tool success, error, and None result scenarios."""
+    from action_msgs.msg import GoalStatus
+
     connector = create_mock_connector_with_clock()
     tool = NavigateToPoseBlockingTool(connector=connector)
 
@@ -101,29 +118,32 @@ def test_navigate_to_pose_blocking_tool(
 
         # Test success
         success_result = MagicMock()
-        success_result.error_code = 0
+        success_result.status = GoalStatus.STATUS_SUCCEEDED
+        success_result.result = MagicMock()
+        success_result.result.error_msg = ""
         mock_action_client.send_goal.return_value = success_result
         result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
         assert result == "Navigate to pose successful."
 
-        # Test error with error code
+        # Test error without message
         error_result = MagicMock()
-        error_result.error_code = 2
+        error_result.status = GoalStatus.STATUS_ABORTED
+        error_result.result = MagicMock()
+        error_result.result.error_msg = ""
         mock_action_client.send_goal.return_value = error_result
         result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
-        assert "Navigate to pose action failed" in result
-        assert "Error code: 2" in result
-        assert "(TIMEOUT)" in result
+        assert result == "Navigate to pose action failed. Status: ABORTED"
 
         # Test error with message
         error_result_with_msg = MagicMock()
-        error_result_with_msg.error_code = 6
-        error_result_with_msg.error_message = "Planner failed"
+        error_result_with_msg.status = GoalStatus.STATUS_ABORTED
+        error_result_with_msg.result = MagicMock()
+        error_result_with_msg.result.error_msg = "Planner failed"
         mock_action_client.send_goal.return_value = error_result_with_msg
         result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
-        assert "Error code: 6" in result
-        assert "(PLANNER_FAILED)" in result
-        assert "Error message: Planner failed" in result
+        assert (
+            result == "Navigate to pose action failed. Status: ABORTED. Planner failed"
+        )
 
         # Test None result
         mock_action_client.send_goal.return_value = None

--- a/tests/tools/ros2/test_nav2_tools.py
+++ b/tests/tools/ros2/test_nav2_tools.py
@@ -22,12 +22,16 @@ except ImportError:
     pytest.skip("ROS2 is not installed", allow_module_level=True)
 
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from geometry_msgs.msg import TransformStamped
+from nav2_msgs.action import NavigateToPose
 from rai.communication.ros2.connectors import ROS2Connector
 from rai.tools.ros2.navigation.nav2_blocking import (
     GetCurrentPoseTool,
+    NavigateToPoseBlockingTool,
+    _get_error_code_string,
+    _get_error_message,
 )
 
 from tests.communication.ros2.helpers import (
@@ -55,3 +59,87 @@ def test_get_current_pose_tool(ros_setup: None, request: pytest.FixtureRequest) 
 
     connector.get_transform.assert_called_once_with("map", "base_link")
     assert result == str(transform)
+
+
+def test_get_error_code_string() -> None:
+    """Test error code to string conversion."""
+    assert _get_error_code_string(0) == "NONE"
+    assert _get_error_code_string(2) == "TIMEOUT"
+    assert _get_error_code_string(6) == "PLANNER_FAILED"
+    assert _get_error_code_string(99) == "UNKNOWN_ERROR_CODE_99"
+
+
+def test_get_error_message() -> None:
+    """Test error message extraction with error code and optional message."""
+    # Test with error code only
+    result = NavigateToPose.Result()
+    result.error_code = 2
+    error_msg = _get_error_message(result)
+    assert "(TIMEOUT)" in error_msg
+
+    # Test with error message field
+    result_with_msg = MagicMock()
+    result_with_msg.error_code = 6
+    result_with_msg.error_message = "Planner failed to find path"
+    error_msg = _get_error_message(result_with_msg)
+    assert "(PLANNER_FAILED)" in error_msg
+    assert "Error message: Planner failed to find path" in error_msg
+
+
+def _create_mock_connector() -> MagicMock:
+    """Helper to create a mock connector with node and clock."""
+    connector = MagicMock(spec=ROS2Connector)
+    mock_node = MagicMock()
+    mock_clock = MagicMock()
+    mock_time = MagicMock()
+    mock_clock.now.return_value.to_msg.return_value = mock_time
+    connector.node = mock_node
+    mock_node.get_clock.return_value = mock_clock
+    return connector
+
+
+def test_navigate_to_pose_blocking_tool(
+    ros_setup: None, request: pytest.FixtureRequest
+) -> None:
+    """Test navigation tool success, error, and None result scenarios."""
+    connector = _create_mock_connector()
+    tool = NavigateToPoseBlockingTool(connector=connector)
+
+    with patch(
+        "rai.tools.ros2.navigation.nav2_blocking.ActionClient"
+    ) as mock_action_client_class:
+        mock_action_client = MagicMock()
+        mock_action_client_class.return_value = mock_action_client
+
+        # Test success
+        success_result = NavigateToPose.Result()
+        success_result.error_code = 0
+        mock_action_client.send_goal.return_value = success_result
+        result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
+        assert result == "Navigate to pose successful."
+
+        # Test error with error code
+        error_result = NavigateToPose.Result()
+        error_result.error_code = 2
+        mock_action_client.send_goal.return_value = error_result
+        result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
+        assert "Navigate to pose action failed" in result
+        assert "Error code: 2" in result
+        assert "(TIMEOUT)" in result
+
+        # Test error with message
+        error_result_with_msg = MagicMock()
+        error_result_with_msg.error_code = 6
+        error_result_with_msg.error_message = "Planner failed"
+        mock_action_client.send_goal.return_value = error_result_with_msg
+        result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
+        assert "Error code: 6" in result
+        assert "(PLANNER_FAILED)" in result
+        assert "Error message: Planner failed" in result
+
+        # Test None result
+        mock_action_client.send_goal.return_value = None
+        result = tool._run(x=1.0, y=2.0, z=0.0, yaw=0.5)
+        assert result == "Navigate to pose action failed. Please try again."
+
+        assert mock_action_client.send_goal.call_count == 4


### PR DESCRIPTION
## Purpose

Fix  
- https://github.com/RobotecAI/rai/issues/753#issuecomment-3792135950
```
"navigate_to_pose_blocking", error: 'NavigateToPose_Result' object has no attribute 'error_code'
```
- https://discord.com/channels/1309212732578336808/1309212733039841304/1465025297203204279
```
"navigate_to_pose_blocking", error: 'NavigateToPose_Result' object has no attribute 'error_message'
```
## Proposed Changes

- `send_goal()` returns `GetResultService.Response` instead of `NavigateToPose.Result`.  It is not clear on why during runtime, it would report the attribute error of `error_code`. Added debug logging to investigate further.
- To get additional error info, checking status and then error message may be more descriptive. The nav2 has limited support for error_code. `_get_error_message` is to support this. 
- In addition to the new tests, the changes in tests are to address https://github.com/RobotecAI/rai/issues/759 and time to msg handling for humble.

## Issues

-   Links to relevant issues

## Testing

-   Unit test added. 