### PR TITLE
fix: missing upperbound version of transformers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2831,18 +2831,21 @@ files = [
     {file = "imagecodecs-2025.3.30-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:44dc270d78b7cda29e2d430acbd8dab66322766412e596f450871e2831148aa2"},
     {file = "imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cee56331d9a700e9ec518caeba6d9813ffd7c042f1fae47d2dafcdfc259d2a5"},
     {file = "imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e354fa2046bb7029d0a1ff15a8bb31487ca0d479cd42fdb5c312bcd9408ce3fc"},
+    {file = "imagecodecs-2025.3.30-cp311-cp311-win32.whl", hash = "sha256:4ce5c1eb14716bfa733516a69f3b8b77f05cf0541558cc4e8f8991e57d40cc82"},
     {file = "imagecodecs-2025.3.30-cp311-cp311-win_amd64.whl", hash = "sha256:7debc7231780d8e44ffcd13aee2178644d93115c19ff73c96cf3068b219ac3a2"},
     {file = "imagecodecs-2025.3.30-cp311-cp311-win_arm64.whl", hash = "sha256:2b5c1c02c70da9561da9b728b97599b3ed0ef7d5399979017ce90029f522587b"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:dad3f0fc39eb9a88cecb2ccfe0e13eac35b21da36c0171285e4b289b12085235"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2806b6e605e674d7e3d21099779a88cb30b9da4807a88e0f02da3ea249085e5f"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abfb2231f4741262c91f3e77af85ce1f35b7d44f71414c5d1ba6008cfc3e5672"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6583fdcac9a4cd75a7701ed7fac7e74d3836807eb9f8aee22f60f519b748ff56"},
+    {file = "imagecodecs-2025.3.30-cp312-cp312-win32.whl", hash = "sha256:ed187770804cbf322b60e24dfc14b8a1e2c321a1b93afb3a7e4948fbb9e99bf0"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-win_amd64.whl", hash = "sha256:0b0f6e0f118674c76982e5a25bfeec5e6fc4fc4fc102c0d356e370f473e7b512"},
     {file = "imagecodecs-2025.3.30-cp312-cp312-win_arm64.whl", hash = "sha256:bde3bd80cdf65afddb64af4c433549e882a5aa15d300e3781acab8d4df1c94a9"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:0bf7248a7949525848f3e2c7d09e837e8333d52c7ac0436c6eed36235da8227b"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3e598b6ec77df2517a8d4af6b66393250ba4a8764fccda5dbe6546236df5d11c"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:212ae6ba7c656ddf24e8aabefc56c5e2300335ed1305838508c57de202e6dbe4"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa7b1c7d7af449c8153a040f7782d4296350245f8809e49dd4fb5bef4d740e6"},
+    {file = "imagecodecs-2025.3.30-cp313-cp313-win32.whl", hash = "sha256:66b614488d85d91f456b949fde4ad678dbe95cde38861043122237de086308c1"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-win_amd64.whl", hash = "sha256:1c51fef75fec66b4ea5e98b4ab47889942049389278749e1f96329c38f31c377"},
     {file = "imagecodecs-2025.3.30-cp313-cp313-win_arm64.whl", hash = "sha256:eda70c0b9d2bcf225f7ae12dbefd0e3ab92ea7db30cdb56b292517fb61357ad7"},
     {file = "imagecodecs-2025.3.30.tar.gz", hash = "sha256:29256f44a7fcfb8f235a3e9b3bae72b06ea2112e63bcc892267a8c01b7097f90"},
@@ -7352,7 +7355,7 @@ url = "src/rai_bench"
 
 [[package]]
 name = "rai-core"
-version = "2.8.0"
+version = "2.8.3"
 description = "Core functionality for RAI framework"
 optional = false
 python-versions = "^3.10, <3.13"
@@ -7414,7 +7417,7 @@ transformers = "*"
 
 [[package]]
 name = "rai-perception"
-version = "0.2.0"
+version = "0.2.1"
 description = "Package for object detection, segmentation and gripping point detection."
 optional = false
 python-versions = "^3.8"
@@ -7429,6 +7432,7 @@ rf-groundingdino = "^0.2.0"
 scikit-learn = ">=1.0.0,<1.4.0"
 torch = "^2.3.1"
 torchvision = "^0.18.1"
+transformers = "<5.0.0"
 
 [package.source]
 type = "directory"

--- a/src/rai_extensions/rai_perception/pyproject.toml
+++ b/src/rai_extensions/rai_perception/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rai-perception"
 # TODO, update the version once it is published to PyPi
-version = "0.2.0"
+version = "0.2.1"
 description = "Package for object detection, segmentation and gripping point detection."
 authors = ["Maciej Majek <maciej.majek@robotec.ai>", "Julia Jia <juliajster@gmail.com>", "Kajetan Rachwał <kajetan.rachwal@robotec.ai>"]
 readme = "README.md"
@@ -17,6 +17,7 @@ rf-groundingdino = "^0.2.0"
 rai-gsam2 = "^1.1.2"
 rai_core = ">=2.0.0.a2,<3.0.0"
 scikit-learn = ">=1.0.0,<1.4.0"
+transformers = "<5.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Purpose

Fixes runtime error

## Proposed Changes

Setting a constraint for transformers lib

Todo, perhaps in another PR, find the lower bound version.

## Issues

-   Links to relevant issues

## Testing

happy path
```
poetry install --with perception
poetry run python -m rai_perception.scripts.run_perception_services
```

error mode
```
poetry install --with perception
poetry run pip install transformers==5.0.0
poetry run python -m rai_perception.scripts.run_perception_services
```