### PR TITLE
perf: parallelize perception service initialization

### DIFF
--- a/src/rai_extensions/rai_perception/rai_perception/scripts/run_perception_services.py
+++ b/src/rai_extensions/rai_perception/rai_perception/scripts/run_perception_services.py
@@ -14,6 +14,7 @@
 
 
 import os
+import threading
 
 import rclpy
 from rai.agents import wait_for_shutdown
@@ -46,12 +47,31 @@ def main():
         "enable_legacy_service_names", enable_legacy
     )
 
-    # Services read model_name from ROS2 params (defaults: "grounding_dino", "grounded_sam")
-    detection_service = DetectionService(ros2_connector=detection_connector)
-    segmentation_service = SegmentationService(ros2_connector=segmentation_connector)
+    # Use threading to initialize and download weights concurrently
+    detection_service = None
+    segmentation_service = None
 
-    detection_service.run()
-    segmentation_service.run()
+    def init_detection():
+        nonlocal detection_service
+        detection_service = DetectionService(ros2_connector=detection_connector)
+
+    def init_segmentation():
+        nonlocal segmentation_service
+        segmentation_service = SegmentationService(ros2_connector=segmentation_connector)
+
+    t1 = threading.Thread(target=init_detection)
+    t2 = threading.Thread(target=init_segmentation)
+
+    t1.start()
+    t2.start()
+    
+    t1.join()
+    t2.join()
+
+    if detection_service is not None:
+        detection_service.run()
+    if segmentation_service is not None:
+        segmentation_service.run()
 
     wait_for_shutdown([detection_service, segmentation_service])
     rclpy.shutdown()

--- a/src/rai_sim/rai_sim/o3de/o3de_bridge.py
+++ b/src/rai_sim/rai_sim/o3de/o3de_bridge.py
@@ -314,26 +314,26 @@ class O3DExROS2Bridge(SimulationBridge):
                 if action not in available_actions_names
             ]
 
-            if missing_services:
-                self.logger.warning(
-                    f"Waiting for missing services {missing_services} out of required services: {required_services}"
-                )
-
-            if missing_topics:
-                self.logger.warning(
-                    f"Waiting for missing topics: {missing_topics} out of required topics: {required_topics}"
-                )
-
-            if missing_actions:
-                self.logger.warning(
-                    f"Waiting for missing actions: {missing_actions} out of required actions: {required_actions}"
-                )
-
-            if not (missing_services or missing_topics or missing_actions):
-                self.logger.info("All required ROS2 stack components are available.")
-                return True
-
-            time.sleep(0.5)
+            if missing_services or missing_topics or missing_actions:
+                missing_info = []
+                if missing_services:
+                    missing_info.append(f"services: {missing_services}")
+                if missing_topics:
+                    missing_info.append(f"topics: {missing_topics}")
+                if missing_actions:
+                    missing_info.append(f"actions: {missing_actions}")
+                
+                # Only log every 10th retry (5 seconds) to avoid spam, or on the first try
+                if i % 10 == 0:
+                    self.logger.warning(
+                        f"Still waiting for ROS2 components to initialize. Missing {', '.join(missing_info)}. "
+                        "Note: perception services like detection and segmentation may take several minutes to download weights on their first run."
+                    )
+                time.sleep(0.5)
+                continue
+            
+            self.logger.info("All required ROS2 stack components are available.")
+            return True
 
         self.logger.error(
             "Maximum number of retries reached. Required ROS2 stack components are not fully available."


### PR DESCRIPTION
## Purpose

Reduce startup time for perception services and minimize log spam during initialization.

## Proposed Changes

- Uses threading to load GroundingDINO and Grounded SAM models concurrently, significantly reducing startup time.
- Refines readiness logging in  to only log missing components every 5 seconds (instead of 0.5s) to avoid log spam, while adding a note about initial weight download delays.
- Removes hardcoded weight size estimation from warning messages.

## Issues

- None

## Testing

- Manually verified perception services start correctly and concurrently
- Verified log output is cleaner during initialization