### PR TITLE
chore(mani_bench): Simplify toolset

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/benchmark.py
@@ -39,10 +39,9 @@ from rai.communication.ros2.connectors import ROS2Connector
 from rai.messages import HumanMultimodalMessage
 from rai.tools.ros2 import (
     GetObjectPositionsTool,
-    GetROS2ImageTool,
-    GetROS2TopicsNamesAndTypesTool,
     MoveToPointTool,
 )
+from rai.tools.ros2.simple import GetROS2ImageConfiguredTool
 from rai_perception.tools import GetGrabbingPointTool
 
 from rai_bench.base_benchmark import BaseBenchmark, RunSummary, TimeoutException
@@ -395,8 +394,7 @@ def _setup_benchmark_environment(
             get_grabbing_point_tool=GetGrabbingPointTool(connector=connector),
         ),
         MoveToPointTool(connector=connector, manipulator_frame="panda_link0"),
-        GetROS2ImageTool(connector=connector),
-        GetROS2TopicsNamesAndTypesTool(connector=connector),
+        GetROS2ImageConfiguredTool(connector=connector, topic="/color_image5"),
     ]
 
     # define o3de bridge


### PR DESCRIPTION
## Purpose

The o3de manipulation benchmark should evaluate manipulation skills through reasoning, without requiring additional tool calls to retrieve a topic list or fetch an image.

The image tool should be preconfigured so the model can focus on the task itself.

While this removes part of the benchmark (i.e., fewer steps to reason about), it better aligns the evaluation with what is actually being tested.

## Proposed Changes

Update the available tools in the o3de manipulation benchmark.

## Testing

-   Running benchmark