### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+RAI is a Python monorepo for an Embodied AI agent framework integrating LLMs with ROS 2. It uses `uv` for dependency management and `colcon` for ROS 2 workspace builds.
+
+### Environment prerequisites
+
+-   **ROS 2 Jazzy** must be installed and sourced (`source /opt/ros/jazzy/setup.bash`) before any build or run step.
+-   **`uv`** is the Python package manager (lockfile: `uv.lock`).
+-   A C++ toolchain (`g++-14`, `libstdc++-14-dev`) is required for `colcon build` of `rai_interfaces`.
+
+### Shell setup
+
+Before running anything (tests, Python scripts, imports), always source the environment:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+export SHELL=/bin/bash
+source ./setup_shell.sh
+```
+
+This activates the `.venv`, sources the colcon `install/` overlay, and sets `PYTHONPATH` correctly.
+
+### Building
+
+```bash
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+```
+
+The `rai_interfaces` package (cloned via `vcs import src < ros_deps.repos`) must be present in `src/src/rai_interfaces` before building.
+
+### Linting
+
+Ruff is configured via `.pre-commit-config.yaml`. Run with:
+
+```bash
+pre-commit run ruff --all-files
+pre-commit run ruff-format --all-files
+```
+
+Ruff uses `--fix` by default through pre-commit, so it auto-fixes import ordering issues.
+
+### Testing
+
+```bash
+python -m pytest tests/ --timeout=60 -m "not billable and not ci_only and not manual" --ignore=src
+```
+
+The `pyproject.toml` already sets these default markers and `--ignore=src`.
+
+**Sound device tests**: Tests under `tests/communication/sounds_device/` require virtual audio input/output devices. In headless environments without audio hardware, these tests will error during collection. Either skip them (`--ignore=tests/communication/sounds_device`) or create virtual PulseAudio/ALSA devices before running.
+
+### Key gotchas
+
+-   The `config.toml` in the repo root is the working config file; `rai-config-init` is only for pip-installed users, not developers using the repo.
+-   The Streamlit configurator (`rai/frontend/configurator.py`) is an optional GUI; all configuration can be done by editing `config.toml` directly.
+-   Many test modules import ROS 2 packages (`rclpy`, `geometry_msgs`, etc.) at module level, so ROS 2 must be sourced even to collect tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

- Add `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents working in this repo.

## Proposed Changes

Adds `AGENTS.md` documenting:
- Environment prerequisites (ROS 2 Jazzy, uv, C++ toolchain)
- Shell setup sequence (`source /opt/ros/jazzy/setup.bash` then `source ./setup_shell.sh`)
- Build, lint, and test commands
- Key gotchas (sound device tests require virtual audio devices, `config.toml` is pre-existing in the repo, ROS 2 must be sourced for test collection)

## Issues

- N/A (environment setup task)

## Testing

Environment verified end-to-end:

- `uv sync --all-groups` - all dependency groups installed
- `colcon build --symlink-install` - ROS 2 workspace built (rai_interfaces, rai_nomad, rai_bringup)
- `ruff check` - linting functional
- `pytest tests/` - **765 passed**, 4 skipped, 11 xfailed, 0 errors (sound device tests skipped)
- Core module imports verified: rai_core, rai_whoami, rai_sim, rai_bench, rai_interfaces, rclpy
- ROS 2 node lifecycle test passed

[hello_world_output.log](https://cursor.com/agents/bc-a2e7ae5e-c40d-4210-bdb1-70848acd4696/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_output.log)
[pytest_output.log](https://cursor.com/agents/bc-a2e7ae5e-c40d-4210-bdb1-70848acd4696/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpytest_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2e7ae5e-c40d-4210-bdb1-70848acd4696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2e7ae5e-c40d-4210-bdb1-70848acd4696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

