### PR TITLE
fix: O3DE manipulation benchmark determinism enhancements

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_core"
-version = "2.12.0"
+version = "2.12.1"
 description = "Core functionality for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_core/rai/tools/ros2/manipulation/custom.py
+++ b/src/rai_core/rai/tools/ros2/manipulation/custom.py
@@ -362,7 +362,7 @@ class GetObjectPositionsTool(BaseROS2Tool):
 
     @staticmethod
     def format_pose(pose: Pose):
-        return f"Centroid(x={pose.position.x:.2f}, y={pose.position.y:2f}, z={pose.position.z:2f})"
+        return f"Centroid(x={pose.position.x:.2f}, y={pose.position.y:.2f}, z={pose.position.z:.2f})"
 
     def _run(self, object_name: str):
         transform = self.connector.get_transform(

--- a/src/rai_core/rai/tools/ros2/manipulation/custom.py
+++ b/src/rai_core/rai/tools/ros2/manipulation/custom.py
@@ -388,6 +388,15 @@ class GetObjectPositionsTool(BaseROS2Tool):
             mani_frame_pose = do_transform_pose(pose, transform)
             mani_frame_poses.append(mani_frame_pose)
 
+        # Sort by rounded position for a stable, deterministic ordering across runs.
+        mani_frame_poses.sort(
+            key=lambda p: (
+                round(p.position.x, 2),
+                round(p.position.y, 2),
+                round(p.position.z, 2),
+            )
+        )
+
         if len(mani_frame_poses) == 0:
             return f"No {object_name}s detected."
         else:

--- a/uv.lock
+++ b/uv.lock
@@ -4717,7 +4717,7 @@ requires-dist = [
 
 [[package]]
 name = "rai-core"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "src/rai_core" }
 dependencies = [
     { name = "coloredlogs" },


### PR DESCRIPTION
## Purpose

This PR addresses 2 sources of non-deterministic behavior in the benchmark:
- y and z centroids with 2f specifier fall back to the default f precision of 6 decimals. This leaks floating point noise from GPU kernels to the LLM and results in slightly different inputs to the LLM run-to-run, sometimes causing different actions to be taken.
- detected object centroids were returned in perception-arrival order, which is non-deterministic across runs. When more than one object of a type is detected, the agent picks "the first" - so it could act on a different physical object run-to-run. Sorting the centroids by rounded (x, y, z) gives a stable, position-deterministic ordering.

## Testing

Re-ran o3de manipulation benchmark, verified that centroids are showing up at the same precision for each axis and on multi-object scenes detections are returned in a sorted order.

Note: if you run the benchmark multiple times using GPT-5.x models you will still get some non-determinism because OpenAI doesn't guarantee determinism even with random seed fixed, but with this patch the delta gets reduced significantly.