### PR TITLE
fix(tool_runner): sanitize exception details in ToolMessage content (CWE-209)

### DIFF
--- a/src/rai_core/rai/agents/langchain/core/tool_runner.py
+++ b/src/rai_core/rai/agents/langchain/core/tool_runner.py
@@ -84,30 +84,32 @@ class ToolRunner(RunnableCallable):
                     f"Tool {call['name']} output: \n\n{str(output.content)}"
                 )
             except ValidationError as e:
-                errors = e.errors()
-                for error in errors:
-                    error.pop(
-                        "url"
-                    )  # get rid of the  https://errors.pydantic.dev/... url
-
-                error_message = f"""
-                                    Validation error in tool {call["name"]}:
-                                    {e.title}
-                                    Number of errors: {e.error_count()}
-                                    Errors:
-                                    {json.dumps(errors, indent=2)}
-                                """
-                self.logger.info(error_message)
+                self.logger.info(
+                    f"Validation error in tool {call['name']}: "
+                    f"{e.title}, {e.error_count()} error(s): "
+                    f"{json.dumps(e.errors(), indent=2)}"
+                )
                 output = ToolMessage(
-                    content=error_message,
+                    content=(
+                        f"Validation error in tool '{call['name']}': "
+                        f"{e.error_count()} validation error(s). "
+                        f"Please check the tool's input arguments and try again."
+                    ),
                     name=call["name"],
                     tool_call_id=call["id"],
                     status="error",
                 )
             except Exception as e:
-                self.logger.info(f'Error in "{call["name"]}", error: {e}')
+                self.logger.info(
+                    f'Error in "{call["name"]}", '
+                    f"error type: {type(e).__name__}, error: {e}"
+                )
                 output = ToolMessage(
-                    content=f"Failed to run tool. Error: {e}",
+                    content=(
+                        f"Failed to run tool '{call['name']}' "
+                        f"({type(e).__name__}). "
+                        f"Please try again or rephrase your request."
+                    ),
                     name=call["name"],
                     tool_call_id=call["id"],
                     status="error",

--- a/tests/agents/langchain/test_tool_runner_exception_leak.py
+++ b/tests/agents/langchain/test_tool_runner_exception_leak.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2024 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CWE-209: Exception detail leakage in ToolRunner error handling.
+
+Verifies that internal exception details (file paths, connection strings,
+stack traces) are NOT leaked in ToolMessage content sent to the LLM/user.
+"""
+
+import logging
+
+from langchain_core.messages import AIMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+from rai.agents.langchain.core import ToolRunner
+
+
+# --- Tools that simulate failures with sensitive information ---
+
+
+@tool
+def tool_with_file_path_error() -> str:
+    """A tool that fails exposing internal file paths."""
+    raise FileNotFoundError(
+        "/home/robot/secrets/config.yaml: No such file or directory"
+    )
+
+
+@tool
+def tool_with_connection_error() -> str:
+    """A tool that fails exposing connection details."""
+    raise ConnectionError(
+        "Failed to connect to database at postgres://admin:s3cret@10.0.0.5:5432/robotdb"
+    )
+
+
+@tool
+def tool_with_runtime_error() -> str:
+    """A tool that fails with a generic runtime error."""
+    raise RuntimeError(
+        "Internal server error in module /opt/rai/src/rai_core/rai/tools/internal.py:42"
+    )
+
+
+class StrictInput(BaseModel):
+    x: float = Field(..., description="Required numeric input")
+
+
+@tool(args_schema=StrictInput)
+def tool_with_validation_schema(x: float) -> str:
+    """A tool with strict validation that will fail on bad input."""
+    return f"Result: {x}"
+
+
+# --- Tests ---
+
+
+def _run_tool_and_get_error_message(tool_fn, tool_call: ToolCall) -> str:
+    """Helper: runs a single tool call and returns the error ToolMessage content."""
+    runner = ToolRunner(tools=[tool_fn], logger=logging.getLogger(__name__))
+    state = {"messages": [AIMessage(content="", tool_calls=[tool_call])]}
+    output = runner.invoke(state)
+    # The error message is the last ToolMessage
+    tool_msgs = [m for m in output["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1, "Expected exactly one ToolMessage"
+    assert tool_msgs[0].status == "error", "Expected error status"
+    return tool_msgs[0].content
+
+
+def test_file_path_not_leaked():
+    """Exception containing file paths must not appear in ToolMessage content."""
+    call = ToolCall(
+        name="tool_with_file_path_error", args={}, id="test-file-path-leak"
+    )
+    content = _run_tool_and_get_error_message(tool_with_file_path_error, call)
+    assert "/home/robot" not in content, (
+        f"Internal file path leaked in error message: {content}"
+    )
+    assert "config.yaml" not in content, (
+        f"Internal file name leaked in error message: {content}"
+    )
+
+
+def test_connection_string_not_leaked():
+    """Exception containing connection strings must not appear in ToolMessage content."""
+    call = ToolCall(
+        name="tool_with_connection_error", args={}, id="test-conn-string-leak"
+    )
+    content = _run_tool_and_get_error_message(tool_with_connection_error, call)
+    assert "postgres://" not in content, (
+        f"Connection string leaked in error message: {content}"
+    )
+    assert "s3cret" not in content, (
+        f"Password leaked in error message: {content}"
+    )
+    assert "10.0.0.5" not in content, (
+        f"Internal IP leaked in error message: {content}"
+    )
+
+
+def test_internal_module_path_not_leaked():
+    """Exception containing internal module paths must not appear in ToolMessage content."""
+    call = ToolCall(
+        name="tool_with_runtime_error", args={}, id="test-module-path-leak"
+    )
+    content = _run_tool_and_get_error_message(tool_with_runtime_error, call)
+    assert "/opt/rai" not in content, (
+        f"Internal module path leaked in error message: {content}"
+    )
+    assert "internal.py" not in content, (
+        f"Internal file name leaked in error message: {content}"
+    )
+
+
+def test_error_message_is_generic():
+    """Error messages should be generic and not contain raw exception details."""
+    call = ToolCall(
+        name="tool_with_file_path_error", args={}, id="test-generic-msg"
+    )
+    content = _run_tool_and_get_error_message(tool_with_file_path_error, call)
+    # Should contain tool name so the LLM knows which tool failed
+    assert "tool_with_file_path_error" in content, (
+        f"Error message should reference the tool name: {content}"
+    )
+
+
+def test_validation_error_no_raw_details():
+    """ValidationError should not leak raw pydantic error details to ToolMessage."""
+    # Pass wrong type to trigger validation error
+    call = ToolCall(
+        name="tool_with_validation_schema",
+        args={"x": "not_a_number"},
+        id="test-validation-leak",
+    )
+    content = _run_tool_and_get_error_message(tool_with_validation_schema, call)
+    # Should not contain internal pydantic error JSON with input values
+    assert "not_a_number" not in content, (
+        f"User input value leaked back in validation error: {content}"
+    )
+
+
+def test_unknown_tool_error_no_raw_exception():
+    """Calling a non-existent tool should not leak raw exception messages."""
+    call = ToolCall(name="nonexistent_tool", args={}, id="test-keyerror")
+    runner = ToolRunner(
+        tools=[tool_with_file_path_error], logger=logging.getLogger(__name__)
+    )
+    state = {"messages": [AIMessage(content="", tool_calls=[call])]}
+    output = runner.invoke(state)
+    tool_msgs = [m for m in output["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].status == "error"
+    content = tool_msgs[0].content
+    # Should mention the tool name
+    assert "nonexistent_tool" in content, (
+        f"Error message should reference the tool name: {content}"
+    )
+    # Should not contain raw str(e) value (for KeyError, str(e) = "'nonexistent_tool'")
+    # The generic message should not embed repr of exception details
+    assert "Traceback" not in content, (
+        f"Stack trace leaked in error message: {content}"
+    )


### PR DESCRIPTION
## Purpose

Sanitize exception details in `ToolRunner` error messages to prevent internal system information from being forwarded to cloud LLM APIs, Streamlit UI, ROS2 topics, and tracing services.

## Proposed Changes

This PR modifies two `except` blocks in `ToolRunner._func()` (`src/rai_core/rai/agents/langchain/core/tool_runner.py`):

1. **`except ValidationError`** — Previously embedded raw pydantic error JSON (including field values, types, and pydantic documentation URLs) into the `ToolMessage.content`. Now returns a generic count-based message while logging full details server-side.

2. **`except Exception`** — Previously embedded `str(e)` directly into the `ToolMessage.content`. Exception messages can contain file paths, connection strings, credentials, IP addresses, and internal module paths. Now returns a generic message with only the exception type name, while logging full details server-side.

In both cases, the full exception information is preserved in `self.logger.info(...)` for debugging — only the `ToolMessage.content` (which flows outward to LLM APIs and UIs) is sanitized.

### Security background (CWE-209)

When a tool raises an exception, the current code constructs a `ToolMessage` with the raw exception string embedded in `content`. This `ToolMessage` then flows through the LangGraph message pipeline to:

- **Cloud LLM APIs** (OpenAI, Anthropic) via `llm.invoke()` in `react_agent.py` and `invocation_helpers.py` — exception details become part of the prompt payload sent to third-party servers
- **Streamlit UI** — displayed directly to the user session
- **ROS2 topics** — published on the robot's message bus
- **Tracing/observability services** configured via LangChain callbacks

This means exception messages containing file paths (e.g., `/home/robot/secrets/config.yaml`), database connection strings (e.g., `postgres://admin:password@10.0.0.5:5432/db`), or internal module paths get transmitted to external services.

The fix scope is intentionally limited to the `ToolRunner` exception handlers. Individual tools that return error details in successful responses (e.g., `nav2_blocking.py:121` returns `f"...exception: {type(e).__name__}: {e}"`) are out of scope for this PR but represent an additional surface worth reviewing.

### Proof of Concept

The data flow from exception to external API:

```
1. Tool raises exception with sensitive data
   e.g., FileNotFoundError("/home/robot/secrets/config.yaml")

2. ToolRunner._func() catches it (tool_runner.py, line 102):
   BEFORE: content=f"Failed to run tool. Error: {e}"
   → ToolMessage.content = "Failed to run tool. Error: /home/robot/secrets/config.yaml: ..."

3. ToolMessage is appended to state["messages"]

4. On next LLM invocation (react_agent.py:84):
   ai_msg = invoke_llm_with_tracing(llm, state["messages"], config)
   → The full message list including the error content is sent to the cloud API

5. The cloud LLM provider now has the internal file path in their logs/training data
```

To reproduce, run the included test suite which simulates this with tools that raise exceptions containing sensitive information:

```bash
pytest tests/agents/langchain/test_tool_runner_exception_leak.py -v
```

The tests verify that file paths, connection strings, internal IPs, module paths, and raw pydantic validation details do not appear in `ToolMessage.content`.

Before submitting, we considered whether this is low-risk given RAI's single-user robotics architecture — the local operator already has full system access, so there is no privilege escalation. However, the cross-boundary concern is real: exception details are transmitted to third-party cloud APIs where the operator does *not* control data retention or access policies. This makes the information disclosure meaningful even without a multi-user threat model.

## Issues

- CWE-209: Generation of Error Message Containing Sensitive Information
- Affected file: `src/rai_core/rai/agents/langchain/core/tool_runner.py`, lines 86–115 (the `ValidationError` and general `Exception` handlers in `ToolRunner._func()`)

## Testing

- Added `tests/agents/langchain/test_tool_runner_exception_leak.py` with 6 test cases:
  - `test_file_path_not_leaked` — verifies internal file paths are not in error content
  - `test_connection_string_not_leaked` — verifies DB connection strings/passwords/IPs are not in error content
  - `test_internal_module_path_not_leaked` — verifies internal Python module paths are not in error content
  - `test_error_message_is_generic` — verifies the error message still contains the tool name for LLM context
  - `test_validation_error_no_raw_details` — verifies pydantic validation errors don't leak input values
  - `test_unknown_tool_error_no_raw_exception` — verifies unknown tool errors don't leak stack traces
- All tests validate that `ToolMessage.content` contains only generic information (tool name + exception type) while sensitive details are only in server-side logs
- The fix preserves existing behavior: error status is still set, tool name and call ID are correct, and the LLM receives enough context to retry or adjust its approach