### PR TITLE
chore(rai_perception): relax dependency version constraints

### DIFF
--- a/src/rai_extensions/rai_perception/pyproject.toml
+++ b/src/rai_extensions/rai_perception/pyproject.toml
@@ -12,11 +12,11 @@ authors = [
 ]
 dependencies = [
     "torch>=2.3.1,<3.0.0",
-    "torchvision>=0.18.1,<0.19.0",
+    "torchvision>=0.18.1",
     "rf-groundingdino>=0.2.0,<0.3.0",
     "rai-gsam2>=1.1.2,<2.0.0",
     "rai_core>=2.0.0a2,<3.0.0",
-    "scikit-learn>=1.0.0,<1.4.0",
+    "scikit-learn>=1.0.0,<2.0.0",
     "transformers<5.0.0",
 ]
 

--- a/src/rai_extensions/rai_perception/pyproject.toml
+++ b/src/rai_extensions/rai_perception/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rai-perception"
 # TODO, update the version once it is published to PyPi
-version = "0.3.0"
+version = "0.3.1"
 description = "Package for object detection, segmentation and gripping point detection."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -4865,7 +4865,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/a3/ec/d16bb3d94ccf45524
 
 [[package]]
 name = "rai-perception"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "src/rai_extensions/rai_perception" }
 dependencies = [
     { name = "rai-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -4882,9 +4882,9 @@ requires-dist = [
     { name = "rai-core", specifier = ">=2.0.0a2,<3.0.0" },
     { name = "rai-gsam2", specifier = ">=1.1.2,<2.0.0" },
     { name = "rf-groundingdino", specifier = ">=0.2.0,<0.3.0" },
-    { name = "scikit-learn", specifier = ">=1.0.0,<1.4.0" },
+    { name = "scikit-learn", specifier = ">=1.0.0,<2.0.0" },
     { name = "torch", specifier = ">=2.3.1,<3.0.0" },
-    { name = "torchvision", specifier = ">=0.18.1,<0.19.0" },
+    { name = "torchvision", specifier = ">=0.18.1" },
     { name = "transformers", specifier = "<5.0.0" },
 ]
 


### PR DESCRIPTION
## Purpose

Dependencies listed in the `rai-perception` package, such as `torchvision`, had overly restrictive version constraints. This made it impossible to install PyTorch with ROCm 7.2 support.
These small adjustments enable the program to run on the latest-generation AMD hardware.

## Proposed Changes

- Relax minor version constraints for dependencies.

## Testing

- CI
- Local tests