### PR TITLE
chore: fix seperate → separate typos in bench code

### DIFF
--- a/src/rai_bench/rai_bench/test_models.py
+++ b/src/rai_bench/rai_bench/test_models.py
@@ -121,7 +121,7 @@ def test_models(
         raise ValueError("Number of passed models must match number of passed vendors")
     else:
         for bench_conf in benchmark_configs:
-            # for each bench configuration seperate run folder
+            # for each bench configuration separate run folder
             now = datetime.now()
             run_name = f"run_{now.strftime('%Y-%m-%d_%H-%M-%S')}"
             for i, model_name in enumerate(model_names):

--- a/tests/rai_bench/manipulation_o3de/tasks/test_build_tower_task.py
+++ b/tests/rai_bench/manipulation_o3de/tasks/test_build_tower_task.py
@@ -63,7 +63,7 @@ def test_calculate_single_entity() -> None:
     assert incorrect == 1
 
 
-def test_calculate_seperate_entities() -> None:
+def test_calculate_separate_entities() -> None:
     task = BuildCubeTowerTask(["red_cube"])
     e1 = create_entity("cube1", "red_cube", 0.0, 0.0, 0.0)
     e2 = create_entity("cube2", "red_cube", 0.2, 0.2, 0.0)


### PR DESCRIPTION
## Summary
Fixes the misspelling `seperate` → `separate` in:
- Comment in `rai_bench/test_models.py`
- Unit test name `test_calculate_separate_entities` (was `...seperate...`)

## Motivation
Tiny cleanliness fix; test still calls the same APIs.

## Verification
N/A beyond spelling (pytest discovery rename only).

## Duplicate check
None open for this typo.