### PR TITLE
fix(aggregators): avoid KeyError for unknown ROS log levels

### DIFF
--- a/src/rai_core/rai/aggregators/ros2/aggregators.py
+++ b/src/rai_core/rai/aggregators/ros2/aggregators.py
@@ -37,7 +37,7 @@ class ROS2LogsAggregator(BaseAggregator[Log]):
         prev_parsed = None
         counter = 0
         for log in msgs:
-            level = self.levels[log.level]
+            level = self.levels.get(log.level, str(log.level))
             parsed = f"[{log.name}] [{level}] [{log.function}] {log.msg}"
             if parsed == prev_parsed:
                 counter += 1

--- a/tests/aggregators/test_ros2_logs_aggregator.py
+++ b/tests/aggregators/test_ros2_logs_aggregator.py
@@ -193,3 +193,15 @@ def test_ros2_img_vlm_diff_aggregator(ros2_image: Image):
         )
         assert aggregator.get_buffer() == []
         assert aggregator.get() is None
+
+
+def test_ros2_logs_aggregator_unknown_log_level_does_not_keyerror():
+    """ROS log levels outside the fixed map must not crash get()."""
+    aggregator = ROS2LogsAggregator()
+    aggregator(
+        DummyLog(level=25, name="demo_node", function="do_work", msg="custom severity")
+    )
+    summary = aggregator.get()
+    assert isinstance(summary, HumanMessage)
+    assert "custom severity" in summary.content
+    assert "[25]" in summary.content


### PR DESCRIPTION
## Summary
`ROS2LogsAggregator` mapped log severity with `self.levels[log.level]`, which **KeyError**s for values outside `{10,20,30,40,50}` (custom / operator-defined levels). That can crash the agent when очавое summarizing logs.

## Changes
- `levels.get(log.level, str(log.level))`
- Unit test with `DummyLog(level=25, ...)`

## Verification
New unit test (full suite needs ROS env as existing aggregator tests).

## Duplicate check
No open PR for this KeyError path.