### PR TITLE
fix(aggregators): report original keyframe buffer size in VLM diff summary

### DIFF
--- a/src/rai_core/rai/aggregators/ros2/aggregators.py
+++ b/src/rai_core/rai/aggregators/ros2/aggregators.py
@@ -112,7 +112,7 @@ class ROS2ImgVLMDescriptionAggregator(BaseAggregator[Image | CompressedImage]):
 class ROS2ImgVLMDiffAggregator(BaseAggregator[Image | CompressedImage]):
     """
     Returns the LLM analysis of the differences between 3 images in the
-    aggregation buffer: 1st, midden, last
+    aggregation buffer: 1st, middle, last
     """
 
     SYSTEM_PROMPT = "You are an expert in image analysis and your speciality is the comparison of 3 images"
@@ -142,6 +142,7 @@ class ROS2ImgVLMDiffAggregator(BaseAggregator[Image | CompressedImage]):
             return None
 
         b64_images = [convert_ros_img_to_base64(msg) for msg in msgs]
+        original_count = len(b64_images)
 
         self.clear_buffer()
 
@@ -165,5 +166,8 @@ class ROS2ImgVLMDiffAggregator(BaseAggregator[Image | CompressedImage]):
         llm = self.llm.with_structured_output(ROS2ImgDiffOutput)
         response = cast(ROS2ImgDiffOutput, llm.invoke(task))
         return HumanMessage(
-            content=f"Result of the analysis of the {len(b64_images)} keyframes selected from {len(b64_images)} last images:\n{response}"
+            content=(
+                f"Result of the analysis of the {len(b64_images)} keyframes "
+                f"selected from {original_count} last images:\n{response}"
+            )
         )

--- a/tests/aggregators/test_ros2_logs_aggregator.py
+++ b/tests/aggregators/test_ros2_logs_aggregator.py
@@ -205,3 +205,42 @@ def test_ros2_logs_aggregator_unknown_log_level_does_not_keyerror():
     assert isinstance(summary, HumanMessage)
     assert "custom severity" in summary.content
     assert "[25]" in summary.content
+
+
+def test_ros2_img_vlm_diff_get_key_elements():
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([]) == []
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([1]) == [1]
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([1, 2]) == [1, 2]
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([1, 2, 3]) == [1, 2, 3]
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([1, 2, 3, 4, 5]) == [1, 3, 5]
+    assert ROS2ImgVLMDiffAggregator.get_key_elements([1, 2, 3, 4, 5, 6]) == [1, 4, 6]
+
+
+def test_ros2_img_vlm_diff_aggregator_original_count(ros2_image: Image):
+    """When buffer has >3 images, message must report original_count, not selected len."""
+
+    class ROS2ImgDiffOutput(BaseModel):
+        are_different: bool = Field(..., description="Whether the images are different")
+        differences: List[str] = Field(..., description="Description of the difference")
+
+    class DummyModel(FakeChatModel):
+        def invoke(self, *args, **kwargs):
+            return ROS2ImgDiffOutput(
+                are_different=True,
+                differences=["moved"],
+            )
+
+        def with_structured_output(self, *args, **kwargs):
+            return self
+
+    with patch(
+        "rai.aggregators.ros2.aggregators.get_llm_model",
+        side_effect=lambda *args, **kwargs: DummyModel(),
+    ):
+        aggregator = ROS2ImgVLMDiffAggregator()
+        for _ in range(5):
+            aggregator(ros2_image)
+        result = aggregator.get()
+        assert result is not None
+        assert "selected from 5 last images" in result.content
+        assert "analysis of the 3 keyframes" in result.content


### PR DESCRIPTION
## Purpose
`ROS2ImgVLMDiffAggregator.get()` reported keyframes as selected from `len(selected)` twice, so when the buffer had more than 3 images the status text wrongly claimed e.g. "3 keyframes selected from 3 last images".

## Proposed Changes
- Capture original buffer length before first/middle/last selection.
- Docstring typo: midden → middle.
- Unit tests for `get_key_elements` and the five-image summary string.

## Testing
- New unit tests in `tests/aggregators/test_ros2_logs_aggregator.py` (ROS env / existing aggregator fixture conventions).
- Spec: aerial dual-agent `specs/rai/2026-07-14-1.md` (Composer 2.5 Standard posture; Grok-spec + review micro-diff).

## Duplicate check
No open PR for this summary-string fix.