### PR TITLE
fix(ros2): slash-normalize available names in entity waiters

### DIFF
--- a/src/rai_core/rai/communication/ros2/waiters.py
+++ b/src/rai_core/rai/communication/ros2/waiters.py
@@ -30,8 +30,8 @@ def get_missing_entities(
     callable_get_entities: Callable[[], List[str]],
     requested_entities: List[str],
 ) -> set[str]:
-    requested_set = set(requested_entities)
-    available_set = set(callable_get_entities())
+    requested_set = {ensure_slash(name) for name in requested_entities}
+    available_set = {ensure_slash(name) for name in callable_get_entities()}
     return requested_set - available_set
 
 

--- a/tests/communication/ros2/test_waiters.py
+++ b/tests/communication/ros2/test_waiters.py
@@ -126,3 +126,43 @@ def test_wait_for_ros2_negative_timeout(
 
     with pytest.raises(ValueError):
         wait_func(connector, [name], time_interval=0.001, timeout=-0.01)
+
+
+def test_wait_for_ros2_services_available_without_slash(monkeypatch):
+    """Discovery may omit leading slash; required names should still match."""
+    connector = DummyConnector(
+        services_seq=[
+            [("target_service", ["srv/Type"])],
+        ]
+    )
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+    waiters.wait_for_ros2_services(connector, ["target_service"], time_interval=0, timeout=1.0)
+
+
+def test_wait_for_ros2_topics_available_without_slash(monkeypatch):
+    connector = DummyConnector(
+        topics_seq=[
+            [("topic_a", ["msg/A"])],
+        ]
+    )
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+    waiters.wait_for_ros2_topics(connector, ["topic_a"], time_interval=0, timeout=1.0)
+
+
+def test_wait_for_ros2_actions_available_without_slash(monkeypatch):
+    connector = DummyConnector(
+        actions_seq=[
+            [("action_a", ["action/A"])],
+        ]
+    )
+    monkeypatch.setattr(waiters.time, "sleep", lambda *_: None)
+    waiters.wait_for_ros2_actions(connector, ["action_a"], time_interval=0, timeout=1.0)
+
+
+def test_wait_for_ros2_entities_negative_timeout():
+    with pytest.raises(ValueError):
+        waiters.wait_for_ros2_entities(
+            requested=["/a"],
+            get_entities=lambda: [],
+            timeout=-1,
+        )


### PR DESCRIPTION
## Purpose
`wait_for_ros2_*` helpers slash-normalize requested names but compared them to raw discovery names. If the graph lists services/topics/actions without a leading `/`, waiters treat them as missing and can false-timeout when `timeout > 0`.

## Proposed Changes
- In `get_missing_entities`, normalize both requested and available with `ensure_slash`.
- Tests for services/topics/actions discovered without slash, and negative timeout `ValueError`.

## Testing
- `tests/communication/ros2/test_waiters.py` extensions (monkeypatched DummyConnector; no live ROS).
- Spec: `specs/rai/2026-07-14-2.md`.

## Duplicate check
No open PR for waiter slash normalization of available entities.