### PR TITLE
fix(messages): honor db_path in store_artifacts

### DIFF
--- a/src/rai_core/rai/messages/artifacts.py
+++ b/src/rai_core/rai/messages/artifacts.py
@@ -26,18 +26,18 @@ def store_artifacts(
     tool_call_id: str, artifacts: List[Any], db_path="artifact_database.pkl"
 ):
     # TODO(boczekbartek): refactor
-    db_path = Path(db_path)
-    if not db_path.is_file():
-        artifact_database = {}
-        with open("artifact_database.pkl", "wb") as file:
+    path = Path(db_path)
+    if not path.is_file():
+        artifact_database: dict = {}
+        with path.open("wb") as file:
             pickle.dump(artifact_database, file)
-    with open("artifact_database.pkl", "rb") as file:
+    with path.open("rb") as file:
         artifact_database = pickle.load(file)
         if tool_call_id not in artifact_database:
             artifact_database[tool_call_id] = artifacts
         else:
             artifact_database[tool_call_id].extend(artifacts)
-    with open("artifact_database.pkl", "wb") as file:
+    with path.open("wb") as file:
         pickle.dump(artifact_database, file)
 
 

--- a/tests/messages/test_artifacts_db_path.py
+++ b/tests/messages/test_artifacts_db_path.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from rai.messages.artifacts import get_stored_artifacts, store_artifacts
+
+
+def test_store_artifacts_honors_db_path(tmp_path: Path):
+    db = tmp_path / "custom_artifacts.pkl"
+    store_artifacts("tc1", ["a"], db_path=str(db))
+    assert db.is_file()
+    assert get_stored_artifacts("tc1", db_path=str(db)) == ["a"]
+    store_artifacts("tc1", ["b"], db_path=str(db))
+    assert get_stored_artifacts("tc1", db_path=str(db)) == ["a", "b"]
+    assert get_stored_artifacts("missing", db_path=str(db)) == []
+
+
+def test_store_artifacts_creates_file_at_path(tmp_path: Path):
+    db = tmp_path / "nested" / "db.pkl"
+    db.parent.mkdir(parents=True)
+    store_artifacts("x", [1], db_path=str(db))
+    assert get_stored_artifacts("x", db_path=str(db)) == [1]


### PR DESCRIPTION
## Summary
- store_artifacts converted db_path to Path but still hardcoded artifact_database.pkl for I/O
- get_stored_artifacts already used the path; custom db_path could diverge
- Use path.open consistently for create/load/save

## Test plan
- Offline importlib store/get with temp custom path
- New tests/messages/test_artifacts_db_path.py (CI with full deps)

Spec: aerial specs/rai/2026-07-16-1.md
