### PR TITLE
fix(communication): reject non-positive callback_max_workers

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_core"
-version = "2.12.1"
+version = "2.12.2"
 description = "Core functionality for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_core/rai/communication/base_connector.py
+++ b/src/rai_core/rai/communication/base_connector.py
@@ -74,8 +74,7 @@ class BaseConnector(Generic[T]):
     def __init__(self, callback_max_workers: int = 4):
         if callback_max_workers <= 0:
             raise ValueError(
-                "callback_max_workers must be positive, got "
-                f"{callback_max_workers!r}"
+                f"callback_max_workers must be positive, got {callback_max_workers!r}"
             )
         self.callback_max_workers = callback_max_workers
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/src/rai_core/rai/communication/base_connector.py
+++ b/src/rai_core/rai/communication/base_connector.py
@@ -72,6 +72,11 @@ class ParametrizedCallback(BaseModel, Generic[T]):
 
 class BaseConnector(Generic[T]):
     def __init__(self, callback_max_workers: int = 4):
+        if callback_max_workers <= 0:
+            raise ValueError(
+                "callback_max_workers must be positive, got "
+                f"{callback_max_workers!r}"
+            )
         self.callback_max_workers = callback_max_workers
         self.logger = logging.getLogger(self.__class__.__name__)
         self.registered_callbacks: Dict[str, Dict[str, ParametrizedCallback[T]]] = (

--- a/tests/communication/test_base_connector.py
+++ b/tests/communication/test_base_connector.py
@@ -138,3 +138,15 @@ def test_base_connector_msg_class_obj_type():
 
     connector = InternalDerivedConnector()
     assert connector.T_class == DerivedMessage
+
+
+@pytest.mark.parametrize("bad", [0, -1, -4])
+def test_base_connector_rejects_nonpositive_callback_max_workers(bad):
+    with pytest.raises(ValueError, match="callback_max_workers must be positive"):
+        DummyConnector(callback_max_workers=bad)
+
+
+def test_base_connector_accepts_positive_callback_max_workers():
+    connector = DummyConnector(callback_max_workers=1)
+    assert connector.callback_max_workers == 1
+    connector.shutdown()


### PR DESCRIPTION
## Summary
`BaseConnector` forwarded `callback_max_workers` straight into `ThreadPoolExecutor`. Non-positive values fail deep in concurrent.futures (or are invalid). This PR checks **`callback_max_workers > 0`** up front and raises `ValueError` with a clear message. Default stays `4`.

## Motivation
Agent connectors should fail closed with a readable error when misconfigured.

## Changes
- Guard in `BaseConnector.__init__`
- Unit tests for `0` / negative / positive paths

## Verification
```bash
.venv/bin/python -m pytest tests/communication/test_base_connector.py -q
# 7 passed
```

Human-reviewed micro-diff.