### PR TITLE
fix(agents): reject non-positive LangChainAgent max_size

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_core"
-version = "2.12.1"
+version = "2.12.2"
 description = "Core functionality for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_core/rai/agents/langchain/agent.py
+++ b/src/rai_core/rai/agents/langchain/agent.py
@@ -115,6 +115,8 @@ class LangChainAgent(BaseAgent):
         max_size: int = 100,
     ):
         super().__init__()
+        if max_size <= 0:
+            raise ValueError(f"max_size must be positive, got {max_size!r}")
         self.logger = logging.getLogger(__name__)
         self.agent = runnable
         self.stream_response = stream_response

--- a/tests/agents/langchain/test_langchain_agent_max_size.py
+++ b/tests/agents/langchain/test_langchain_agent_max_size.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rai.agents.langchain.agent import LangChainAgent
+
+
+def _make_agent(max_size: int) -> LangChainAgent:
+    return LangChainAgent(
+        target_connectors={},
+        runnable=MagicMock(),
+        max_size=max_size,
+    )
+
+
+def test_max_size_must_be_positive():
+    for bad in (0, -1, False):
+        with pytest.raises(ValueError, match="max_size must be positive"):
+            _make_agent(bad)  # type: ignore[arg-type]
+
+
+def test_max_size_accepts_positive():
+    agent = _make_agent(1)
+    assert agent.max_size == 1

--- a/tests/agents/langchain/test_langchain_agent_max_size.py
+++ b/tests/agents/langchain/test_langchain_agent_max_size.py
@@ -15,7 +15,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from rai.agents.langchain.agent import LangChainAgent
 
 


### PR DESCRIPTION
### Summary
`LangChainAgent` treated any `max_size` as valid. With `max_size <= 0`, the queue is always considered full on the first enqueue path (`len >= max_size`), so the agent either drops/poplefts incorrectly or never buffers usefully.

### Change
- Raise `ValueError` when `max_size <= 0` at construction.
- Offline unit tests with mocked runnable/connectors.

### Test plan
- [x] `uv run python -m pytest tests/agents/langchain/test_langchain_agent_max_size.py -q`

AI-assisted; human-reviewed.