### PR TITLE
fix(agents): reject non-positive StateBasedConfig interval/workers

### DIFF
--- a/src/rai_core/rai/agents/langchain/state_based_agent.py
+++ b/src/rai_core/rai/agents/langchain/state_based_agent.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.tools import BaseTool
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from rai.agents.langchain.agent import LangChainAgent, newMessageBehaviorType
 from rai.agents.langchain.core import ReActAgentState, create_state_based_runnable
@@ -41,6 +41,20 @@ class StateBasedConfig(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
+
+    @field_validator("time_interval")
+    @classmethod
+    def _time_interval_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(f"time_interval must be positive, got {v!r}")
+        return v
+
+    @field_validator("max_workers")
+    @classmethod
+    def _max_workers_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(f"max_workers must be positive, got {v!r}")
+        return v
 
 
 class BaseStateBasedAgent(LangChainAgent, ABC):

--- a/tests/agents/langchain/test_state_based_config.py
+++ b/tests/agents/langchain/test_state_based_config.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from rai.agents.langchain.state_based_agent import StateBasedConfig
+
+
+def test_time_interval_must_be_positive():
+    for bad in (0, -1.0, 0.0):
+        with pytest.raises(ValidationError):
+            StateBasedConfig(aggregators={}, time_interval=bad)
+
+
+def test_max_workers_must_be_positive():
+    for bad in (0, -1):
+        with pytest.raises(ValidationError):
+            StateBasedConfig(aggregators={}, max_workers=bad)
+
+
+def test_defaults_and_positive_ok():
+    cfg = StateBasedConfig(aggregators={})
+    assert cfg.time_interval == 5.0
+    assert cfg.max_workers == 8
+    cfg2 = StateBasedConfig(aggregators={}, time_interval=0.1, max_workers=1)
+    assert cfg2.time_interval == 0.1
+    assert cfg2.max_workers == 1


### PR DESCRIPTION
### Why
`StateBasedConfig` accepted `time_interval <= 0` (busy-spin in the aggregation loop) and `max_workers <= 0` (invalid for `ThreadPoolExecutor`).

### What
Pydantic `field_validator`s require both fields to be **positive**. Defaults (`5.0` / `8`) unchanged.

### Tests
- [x] `uv run python -m pytest tests/agents/langchain/test_state_based_config.py -q` (3 passed)

Human-reviewed small guard + offline tests.