### PR TITLE
fix(tools): reject non-positive ROS2 CLI command timeout

### DIFF
--- a/src/rai_core/rai/tools/ros2/cli.py
+++ b/src/rai_core/rai/tools/ros2/cli.py
@@ -22,6 +22,12 @@ FORBIDDEN_CHARACTERS = ["&", ";", "|", "&&", "||", "(", ")", "<", ">", ">>", "<<
 
 
 def run_with_timeout(cmd: List[str], timeout_sec: int):
+    if isinstance(timeout_sec, bool) or not isinstance(timeout_sec, (int, float)):
+        raise TypeError(
+            f"timeout_sec must be a positive number, got {type(timeout_sec).__name__}"
+        )
+    if timeout_sec <= 0:
+        raise ValueError(f"timeout_sec must be positive, got {timeout_sec!r}")
     proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
     timer = Timer(timeout_sec, proc.kill)
     try:

--- a/tests/tools/test_ros2_cli_timeout.py
+++ b/tests/tools/test_ros2_cli_timeout.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for ROS2 CLI timeout guards (no ROS_DISTRO required)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_CLI_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "rai_core"
+    / "rai"
+    / "tools"
+    / "ros2"
+    / "cli.py"
+)
+
+
+def _load_cli_module():
+    """Load cli.py without package __init__ (which requires ROS2 sourced)."""
+    name = "_rai_cli_timeout_ut"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _CLI_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except ModuleNotFoundError:
+        del sys.modules[name]
+        # langchain_core missing: still load pure helpers with lightweight stubs
+        from subprocess import PIPE, Popen
+        from threading import Timer
+        from typing import List, Literal, Optional
+
+        src = _CLI_PATH.read_text(encoding="utf-8")
+        ns = {
+            "__name__": name,
+            "PIPE": PIPE,
+            "Popen": Popen,
+            "Timer": Timer,
+            "List": List,
+            "Literal": Literal,
+            "Optional": Optional,
+            "BaseTool": object,
+            "BaseToolkit": type("BaseToolkit", (), {"get_tools": lambda self: []}),
+            "tool": lambda f=None, **_k: (f if f is not None else (lambda x: x)),
+        }
+        exec(compile(src, str(_CLI_PATH), "exec"), ns)
+        mod = type(sys)(name)
+        mod.__dict__.update(ns)
+        sys.modules[name] = mod
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _load_cli_module()
+
+
+def test_run_with_timeout_rejects_zero(cli):
+    with pytest.raises(ValueError, match="positive"):
+        cli.run_with_timeout(["echo", "x"], 0)
+
+
+def test_run_with_timeout_rejects_negative(cli):
+    with pytest.raises(ValueError, match="positive"):
+        cli.run_with_timeout(["echo", "x"], -1)
+
+
+def test_run_with_timeout_rejects_bool(cli):
+    with pytest.raises(TypeError, match="positive number"):
+        cli.run_with_timeout(["echo", "x"], False)  # type: ignore[arg-type]
+
+
+def test_run_command_rejects_nonpositive(cli):
+    with pytest.raises(ValueError, match="positive"):
+        cli.run_command(["echo", "ok"], timeout=0)
+
+
+def test_run_with_timeout_happy_path(cli, monkeypatch):
+    proc = MagicMock()
+    proc.communicate.return_value = (b"out\n", b"")
+    monkeypatch.setattr(cli, "Popen", lambda *a, **k: proc)
+    monkeypatch.setattr(cli, "Timer", lambda *a, **k: MagicMock())
+    stdout, stderr = cli.run_with_timeout(["echo", "ok"], 1.0)
+    assert stdout == b"out\n"
+    assert stderr == b""

--- a/tests/tools/test_ros2_cli_timeout.py
+++ b/tests/tools/test_ros2_cli_timeout.py
@@ -16,7 +16,6 @@
 
 import importlib.util
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -34,23 +33,11 @@ _CLI_PATH = (
 
 
 def _load_cli_module():
-    """Load cli.py directly, bypassing the package __init__ (which requires
-    ROS2 sourced) and stubbing langchain_core.tools if it is not installed."""
+    """Load cli.py directly, bypassing the package __init__ which requires ROS2
+    sourced. langchain_core is a core rai dependency and is always installed."""
     name = "_rai_cli_timeout_ut"
     if name in sys.modules:
         return sys.modules[name]
-
-    # Provide a minimal langchain_core.tools stub only when the real package is
-    # unavailable, so the offline import of cli.py succeeds without ROS2/langchain.
-    if importlib.util.find_spec("langchain_core") is None:
-        lc = types.ModuleType("langchain_core")
-        lc_tools = types.ModuleType("langchain_core.tools")
-        lc_tools.BaseTool = object
-        lc_tools.BaseToolkit = type("BaseToolkit", (), {"get_tools": lambda self: []})
-        lc_tools.tool = lambda f=None, **_k: (f if f is not None else (lambda x: x))
-        lc.tools = lc_tools
-        sys.modules.setdefault("langchain_core", lc)
-        sys.modules.setdefault("langchain_core.tools", lc_tools)
 
     spec = importlib.util.spec_from_file_location(name, _CLI_PATH)
     assert spec is not None and spec.loader is not None

--- a/tests/tools/test_ros2_cli_timeout.py
+++ b/tests/tools/test_ros2_cli_timeout.py
@@ -16,6 +16,7 @@
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -33,40 +34,29 @@ _CLI_PATH = (
 
 
 def _load_cli_module():
-    """Load cli.py without package __init__ (which requires ROS2 sourced)."""
+    """Load cli.py directly, bypassing the package __init__ (which requires
+    ROS2 sourced) and stubbing langchain_core.tools if it is not installed."""
     name = "_rai_cli_timeout_ut"
     if name in sys.modules:
         return sys.modules[name]
+
+    # Provide a minimal langchain_core.tools stub only when the real package is
+    # unavailable, so the offline import of cli.py succeeds without ROS2/langchain.
+    if importlib.util.find_spec("langchain_core") is None:
+        lc = types.ModuleType("langchain_core")
+        lc_tools = types.ModuleType("langchain_core.tools")
+        lc_tools.BaseTool = object
+        lc_tools.BaseToolkit = type("BaseToolkit", (), {"get_tools": lambda self: []})
+        lc_tools.tool = lambda f=None, **_k: (f if f is not None else (lambda x: x))
+        lc.tools = lc_tools
+        sys.modules.setdefault("langchain_core", lc)
+        sys.modules.setdefault("langchain_core.tools", lc_tools)
+
     spec = importlib.util.spec_from_file_location(name, _CLI_PATH)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[name] = mod
-    try:
-        spec.loader.exec_module(mod)
-    except ModuleNotFoundError:
-        del sys.modules[name]
-        # langchain_core missing: still load pure helpers with lightweight stubs
-        from subprocess import PIPE, Popen
-        from threading import Timer
-        from typing import List, Literal, Optional
-
-        src = _CLI_PATH.read_text(encoding="utf-8")
-        ns = {
-            "__name__": name,
-            "PIPE": PIPE,
-            "Popen": Popen,
-            "Timer": Timer,
-            "List": List,
-            "Literal": Literal,
-            "Optional": Optional,
-            "BaseTool": object,
-            "BaseToolkit": type("BaseToolkit", (), {"get_tools": lambda self: []}),
-            "tool": lambda f=None, **_k: (f if f is not None else (lambda x: x)),
-        }
-        exec(compile(src, str(_CLI_PATH), "exec"), ns)
-        mod = type(sys)(name)
-        mod.__dict__.update(ns)
-        sys.modules[name] = mod
+    spec.loader.exec_module(mod)
     return mod
 
 


### PR DESCRIPTION
### Why
`run_with_timeout` forwarded any `timeout_sec` into `threading.Timer`. Values `<= 0` give a meaningless or immediate kill race; `bool` subclasses `int` so `False` was quietly treated as 0.

### What
- Reject non-numeric/`bool` timeouts with `TypeError`
- Reject `timeout_sec <= 0` with `ValueError`
- Offline unit tests load `cli.py` without requiring ROS2 sourced (package `__init__` gates on ROS_DISTRO)

### Tests
- [x] `PYTHONPATH=src/rai_core .venv/bin/python -m pytest tests/tools/test_ros2_cli_timeout.py -q` (5 passed)

Shell forbidden-character safety unchanged. Human-reviewed micro-diff.