### PR TITLE
fix(agents): reject empty AgentRunner agent list

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_core"
-version = "2.12.1"
+version = "2.12.2"
 description = "Core functionality for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_core/rai/agents/runner.py
+++ b/src/rai_core/rai/agents/runner.py
@@ -37,6 +37,8 @@ def wait_for_shutdown(agents: List[BaseAgent]):
     an interrupt signal (SIGINT, e.g., Ctrl+C) or SIGTERM. It installs signal handlers to
     capture these events and invokes the agent's ``stop()`` method as part of the shutdown process.
     """
+    if not agents:
+        raise ValueError("agents must be a non-empty list")
     shutdown_event = Event()
 
     def signal_handler(signum, frame):
@@ -58,6 +60,8 @@ def run_agents(agents: List[BaseAgent]):
     Args:
         agents: List of agent instances
     """
+    if not agents:
+        raise ValueError("agents must be a non-empty list")
     logger.info(
         "run_agents is an experimental function. \
                    If you believe that your agents are not running properly, \
@@ -84,6 +88,8 @@ class AgentRunner:
         agents : List[BaseAgent]
             List of agent instances to be managed by the runner.
         """
+        if not agents:
+            raise ValueError("agents must be a non-empty list")
         self.agents = agents
         self.logger = logging.getLogger(__name__)
 

--- a/tests/agents/test_agent_runner.py
+++ b/tests/agents/test_agent_runner.py
@@ -61,3 +61,26 @@ def test_agent_runner_wait_for_shutdown_stops_agents(monkeypatch):
 
     assert thread.is_alive() is False
     assert all(agent.stop_called for agent in agents)
+
+
+def test_agent_runner_rejects_empty_agents():
+    import pytest
+
+    with pytest.raises(ValueError, match="non-empty"):
+        AgentRunner([])
+
+
+def test_wait_for_shutdown_rejects_empty_agents():
+    import pytest
+    from rai.agents.runner import wait_for_shutdown
+
+    with pytest.raises(ValueError, match="non-empty"):
+        wait_for_shutdown([])
+
+
+def test_run_agents_rejects_empty_agents():
+    import pytest
+    from rai.agents.runner import run_agents
+
+    with pytest.raises(ValueError, match="non-empty"):
+        run_agents([])


### PR DESCRIPTION
## Summary
`AgentRunner([])`, `run_agents([])`, and `wait_for_shutdown([])` previously accepted empty lists. `run` was a no-op and shutdown wait still blocked until signal — surprising for agents/ops scripts.

## Change
Raise `ValueError("agents must be a non-empty list")` when the list is empty at all three agent-list entry points.

## Tests
- [x] Extended `tests/agents/test_agent_runner.py` (4 passed offline)

Existing shutdown-signal unit test unchanged. Human-reviewed micro-diff.
