### PR TITLE
fix(agents): reject non-positive HRICallbackHandler max_buffer_size

### DIFF
--- a/src/rai_core/rai/agents/langchain/callback.py
+++ b/src/rai_core/rai/agents/langchain/callback.py
@@ -34,6 +34,14 @@ class HRICallbackHandler(BaseCallbackHandler):
         logger: Optional[logging.Logger] = None,
         stream_response: bool = True,
     ):
+        if isinstance(max_buffer_size, bool) or not isinstance(max_buffer_size, int):
+            raise TypeError(
+                f"max_buffer_size must be a positive int, got {type(max_buffer_size).__name__}"
+            )
+        if max_buffer_size <= 0:
+            raise ValueError(
+                f"max_buffer_size must be positive, got {max_buffer_size!r}"
+            )
         self.connectors = connectors
         self.aggregate_chunks = aggregate_chunks
         self.stream_response = stream_response

--- a/tests/agents/langchain/test_hri_callback_handler.py
+++ b/tests/agents/langchain/test_hri_callback_handler.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from rai.agents.langchain.callback import HRICallbackHandler
+
+
+def test_hri_callback_handler_rejects_nonpositive_max_buffer_size():
+    with pytest.raises(ValueError, match="max_buffer_size must be positive"):
+        HRICallbackHandler(connectors={}, max_buffer_size=0)
+    with pytest.raises(ValueError, match="max_buffer_size must be positive"):
+        HRICallbackHandler(connectors={}, max_buffer_size=-1)
+
+
+def test_hri_callback_handler_rejects_non_int_max_buffer_size():
+    with pytest.raises(TypeError, match="max_buffer_size must be a positive int"):
+        HRICallbackHandler(connectors={}, max_buffer_size=False)
+    with pytest.raises(TypeError, match="max_buffer_size must be a positive int"):
+        HRICallbackHandler(connectors={}, max_buffer_size=1.5)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="max_buffer_size must be a positive int"):
+        HRICallbackHandler(connectors={}, max_buffer_size="200")  # type: ignore[arg-type]
+
+
+def test_hri_callback_handler_accepts_positive_max_buffer_size():
+    handler = HRICallbackHandler(connectors={}, max_buffer_size=1)
+    assert handler.max_buffer_size == 1
+    default_handler = HRICallbackHandler(connectors={})
+    assert default_handler.max_buffer_size == 200


### PR DESCRIPTION
## Summary

- Fail closed when `HRICallbackHandler.max_buffer_size` is non-positive or not an `int` (including `bool`).
- Prevents a zero/negative aggregate buffer that never flushes on size during streamed HRI responses.

## Motivation

`max_buffer_size` gates when aggregated token chunks are flushed to HRI connectors. A non-positive value breaks that size path; `bool` is an `int` subclass in Python so `False` would otherwise look like `0`.

## Verification

```text
PYTHONPATH=src/rai_core python -m pytest tests/agents/langchain/test_hri_callback_handler.py -q
# 3 passed
```

- Did NOT change: default `max_buffer_size=200`, chunk split characters, stream_response path.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h