### PR TITLE
fix(ci): license header + align zero-timeout test with #808

### DIFF
--- a/tests/communication/__init__.py
+++ b/tests/communication/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/communication/ros2/test_ros2_async.py
+++ b/tests/communication/ros2/test_ros2_async.py
@@ -125,10 +125,10 @@ def test_get_future_result_cancelled_during_wait():
 
 # Edge case timeout tests
 def test_get_future_result_zero_timeout():
-    """Test with zero timeout."""
+    """Test that a zero timeout is rejected as non-positive."""
     future = Future()
-    result = get_future_result(future, timeout_sec=0.0)
-    assert result is None
+    with pytest.raises(ValueError, match="timeout_sec must be positive"):
+        get_future_result(future, timeout_sec=0.0)
 
 
 def test_get_future_result_very_short_timeout():


### PR DESCRIPTION
Follow-up to #824 as requested by @maciejmajek — the two CI fixes for the salvage batch.

## Changes
1. **check-license-lines**: add the standard Apache header to `tests/communication/__init__.py` (was empty).
2. **build-and-test-ros2 (humble + jazzy)**: align `test_get_future_result_zero_timeout` with the intended behavior from #808 — `get_future_result` now rejects non-positive `timeout_sec` with `ValueError`, so the stale `assert None` becomes `pytest.raises(ValueError)`.

Based on `bartok9/fixes` so the #808 rejection change is present. Happy to retarget to `main` or fold in however is easiest. 🎻