### PR TITLE
fix(tools): validate configured image/TF tool timeouts

### DIFF
--- a/src/rai_core/rai/tools/ros2/simple.py
+++ b/src/rai_core/rai/tools/ros2/simple.py
@@ -24,6 +24,7 @@ from typing import Any, Literal
 from pydantic import Field
 
 from rai.tools.ros2.base import BaseROS2Tool
+from rai.tools.timeout import require_positive_timeout
 from rai.tools.ros2.generic.topics import (
     GetROS2ImageTool,
     GetROS2TransformTool,
@@ -43,10 +44,11 @@ class GetROS2ImageConfiguredTool(BaseROS2Tool):
             raise ValueError(f"Bad configuration: topic {self.topic} is not readable")
 
     def _run(self) -> Any:
+        timeout_sec = require_positive_timeout(self.timeout_sec)
         tool = GetROS2ImageTool(
             connector=self.connector,
         )
-        return tool._run(topic=self.topic, timeout_sec=self.timeout_sec)
+        return tool._run(topic=self.topic, timeout_sec=timeout_sec)
 
 
 class GetROS2TransformConfiguredTool(BaseROS2Tool):
@@ -58,11 +60,12 @@ class GetROS2TransformConfiguredTool(BaseROS2Tool):
     timeout_sec: float = Field(default=10.0, description="The timeout in seconds")
 
     def _run(self) -> Any:
+        timeout_sec = require_positive_timeout(self.timeout_sec)
         tool = GetROS2TransformTool(
             connector=self.connector,
         )
         return tool._run(
             source_frame=self.source_frame,
             target_frame=self.target_frame,
-            timeout_sec=self.timeout_sec,
+            timeout_sec=timeout_sec,
         )

--- a/src/rai_core/rai/tools/timeout.py
+++ b/src/rai_core/rai/tools/timeout.py
@@ -159,3 +159,23 @@ def timeout_method(
         return wrapper
 
     return decorator
+
+
+def require_positive_timeout(timeout_sec: object, *, name: str = "timeout_sec") -> float:
+    """Validate timeout is a real positive number (bool rejected).
+
+    Returns the value as float. Raises ValueError on invalid input.
+    """
+    if timeout_sec is True or timeout_sec is False:
+        raise ValueError(f"{name} must be a positive number")
+    if isinstance(timeout_sec, int) and not isinstance(timeout_sec, bool):
+        value = float(timeout_sec)
+    elif isinstance(timeout_sec, float):
+        value = float(timeout_sec)
+    else:
+        raise ValueError(f"{name} must be a positive number")
+    if value != value:  # NaN
+        raise ValueError(f"{name} must be a positive number")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value

--- a/tests/tools/test_require_positive_timeout.py
+++ b/tests/tools/test_require_positive_timeout.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+
+from rai.tools.timeout import require_positive_timeout
+
+
+@pytest.mark.parametrize("value", [0, -1, -0.01, True, False, "1", None, math.nan, object()])
+def test_require_positive_timeout_rejects_invalid(value):
+    with pytest.raises(ValueError, match="timeout"):
+        require_positive_timeout(value)
+
+
+@pytest.mark.parametrize("value,expected", [(1, 1.0), (0.5, 0.5), (2, 2.0)])
+def test_require_positive_timeout_accepts_positive(value, expected):
+    assert require_positive_timeout(value) == expected


### PR DESCRIPTION
## Summary
GetROS2ImageConfiguredTool and GetROS2TransformConfiguredTool now validate timeout_sec before delegating.

## Testing
- Offline unit tests where ROS not required (uv pytest)
- AI-assisted; human-reviewed


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->