### PR TITLE
fix(tools): reject empty ROS topic names on publish/receive/image

### DIFF
--- a/src/rai_core/rai/tools/names.py
+++ b/src/rai_core/rai/tools/names.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ROS name validation helpers shared by tools (stdlib-only)."""
+
+
+def require_non_empty_name(value: object, *, name: str = "name") -> str:
+    """Return stripped name or raise ValueError if empty/non-string."""
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a non-empty string")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{name} must be a non-empty string")
+    return stripped

--- a/src/rai_core/rai/tools/ros2/generic/topics.py
+++ b/src/rai_core/rai/tools/ros2/generic/topics.py
@@ -28,6 +28,7 @@ from rai.communication.ros2 import ROS2Connector, ROS2Message
 from rai.communication.ros2.api.conversion import ros2_message_to_dict
 from rai.messages import MultimodalArtifact, preprocess_image
 from rai.tools.ros2.base import BaseROS2Tool, BaseROS2Toolkit
+from rai.tools.names import require_non_empty_name
 from rai.tools.ros2.generic.interface_parser import render_interface_string
 
 
@@ -88,6 +89,7 @@ class PublishROS2MessageTool(BaseROS2Tool):
     args_schema: Type[PublishROS2MessageToolInput] = PublishROS2MessageToolInput
 
     def _run(self, topic: str, message: Dict[str, Any], message_type: str) -> str:
+        topic = require_non_empty_name(topic, name="topic")
         if not self.is_writable(topic):
             raise ValueError(f"Topic {topic} is not writable")
         ros_message = ROS2Message(
@@ -110,6 +112,7 @@ class ReceiveROS2MessageTool(BaseROS2Tool):
     args_schema: Type[ReceiveROS2MessageToolInput] = ReceiveROS2MessageToolInput
 
     def _run(self, topic: str, timeout_sec: float = 1.0) -> str:
+        topic = require_non_empty_name(topic, name="topic")
         if not self.is_readable(topic):
             raise ValueError(f"Topic {topic} is not readable")
         message = self.connector.receive_message(topic, timeout_sec=timeout_sec)
@@ -131,6 +134,7 @@ class GetROS2ImageTool(BaseROS2Tool):
     def _run(
         self, topic: str, timeout_sec: float = 1.0
     ) -> Tuple[str, MultimodalArtifact]:
+        topic = require_non_empty_name(topic, name="topic")
         if not self.is_readable(topic):
             raise ValueError(f"Topic {topic} is not readable")
         message = self.connector.receive_message(topic, timeout_sec=timeout_sec)

--- a/tests/tools/test_require_non_empty_name.py
+++ b/tests/tools/test_require_non_empty_name.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rai.tools.names import require_non_empty_name
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 1, True])
+def test_require_non_empty_name_rejects(value):
+    with pytest.raises(ValueError, match="non-empty"):
+        require_non_empty_name(value, name="topic")
+
+
+def test_require_non_empty_name_strips():
+    assert require_non_empty_name("  /chatter ", name="topic") == "/chatter"


### PR DESCRIPTION
## Summary
Blank topic strings from agents are rejected via require_non_empty_name on publish/receive/image tools.

## Testing
- Offline unit tests where ROS not required (uv pytest)
- AI-assisted; human-reviewed


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->