### PR TITLE
fix(tools): reject empty ROS service name/type on CallROS2ServiceTool

### DIFF
--- a/src/rai_core/rai/tools/names.py
+++ b/src/rai_core/rai/tools/names.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Name validation helpers shared by tools (stdlib-only)."""
+
+
+def require_non_empty_name(value: object, *, name: str = "name") -> str:
+    """Return stripped name or raise ValueError if empty/non-string."""
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a non-empty string")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{name} must be a non-empty string")
+    return stripped

--- a/src/rai_core/rai/tools/ros2/generic/services.py
+++ b/src/rai_core/rai/tools/ros2/generic/services.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from rai.communication.ros2 import ROS2Message
 from rai.tools.ros2.base import BaseROS2Tool, BaseROS2Toolkit
+from rai.tools.names import require_non_empty_name
 
 
 class ROS2ServicesToolkit(BaseROS2Toolkit):
@@ -107,6 +108,8 @@ class CallROS2ServiceTool(BaseROS2Tool):
         service_args: Optional[Dict[str, Any]] = None,
         timeout_sec: float = 5.0,
     ) -> str:
+        service_name = require_non_empty_name(service_name, name="service_name")
+        service_type = require_non_empty_name(service_type, name="service_type")
         if not self.is_writable(service_name):
             raise ValueError(f"Service {service_name} is not writable")
         if service_args is None:

--- a/tests/tools/test_require_non_empty_name.py
+++ b/tests/tools/test_require_non_empty_name.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rai.tools.names import require_non_empty_name
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 1, True])
+def test_require_non_empty_name_rejects(value):
+    with pytest.raises(ValueError, match="non-empty"):
+        require_non_empty_name(value, name="topic")
+
+
+def test_require_non_empty_name_strips():
+    assert require_non_empty_name("  /chatter ", name="topic") == "/chatter"


### PR DESCRIPTION
## Summary
Validate service_name and service_type before writable checks and connector call.

## Testing
- Offline unit tests where ROS not required (uv pytest)
- AI-assisted; human-reviewed


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->