### PR TITLE
fix(tools): reject empty ROS action name/type on StartROS2ActionTool

### DIFF
--- a/src/rai_core/rai/tools/names.py
+++ b/src/rai_core/rai/tools/names.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ROS name validation helpers shared by tools (stdlib-only)."""
+
+
+def require_non_empty_name(value: object, *, name: str = "name") -> str:
+    """Return stripped name or raise ValueError if empty/non-string."""
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a non-empty string")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{name} must be a non-empty string")
+    return stripped

--- a/src/rai_core/rai/tools/ros2/generic/actions.py
+++ b/src/rai_core/rai/tools/ros2/generic/actions.py
@@ -25,6 +25,7 @@ from rclpy.action import CancelResponse
 
 from rai.communication.ros2 import ROS2Message
 from rai.tools.ros2.base import BaseROS2Tool, BaseROS2Toolkit
+from rai.tools.names import require_non_empty_name
 
 internal_action_id_mapping: Dict[str, str] = {}
 action_results_store: Dict[str, Any] = {}
@@ -170,6 +171,8 @@ class StartROS2ActionTool(BaseROS2Tool):
     def _run(
         self, action_name: str, action_type: str, action_args: Dict[str, Any]
     ) -> str:
+        action_name = require_non_empty_name(action_name, name="action_name")
+        action_type = require_non_empty_name(action_type, name="action_type")
         if not self.is_writable(action_name):
             raise ValueError(f"Action {action_name} is not writable")
         message = ROS2Message(payload=action_args)

--- a/tests/tools/test_require_non_empty_name.py
+++ b/tests/tools/test_require_non_empty_name.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rai.tools.names import require_non_empty_name
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 1, True])
+def test_require_non_empty_name_rejects(value):
+    with pytest.raises(ValueError, match="non-empty"):
+        require_non_empty_name(value, name="topic")
+
+
+def test_require_non_empty_name_strips():
+    assert require_non_empty_name("  /chatter ", name="topic") == "/chatter"


### PR DESCRIPTION
## Summary
Validate action_name and action_type before start_action.

## Testing
- Offline unit tests where ROS not required (uv pytest)
- AI-assisted; human-reviewed


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->