### PR TITLE
fix(hri): pass base64_audios for AI multimodal to_langchain

### DIFF
--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -92,7 +92,7 @@ class HRIMessage(BaseMessage):
                 if self.images == [] and self.audios == []:
                     return AIMessage(content=self.text)
                 return AIMultimodalMessage(
-                    content=self.text, images=base64_images, audios=base64_images
+                    content=self.text, images=base64_images, audios=base64_audios
                 )
             case _:
                 raise ValueError(

--- a/tests/communication/test_hri_message.py
+++ b/tests/communication/test_hri_message.py
@@ -82,7 +82,27 @@ def test_to_langchain_human():
     assert langchain_message.content == "Hi there"
 
 
-def test_to_langchain_ai_multimodal(image, audio):
+def test_to_langchain_ai_images_only(image):
+    """AI messages with images (no audio) must map audios correctly and succeed."""
+    from rai.messages.multimodal import AIMultimodalMessage
+
+    message = HRIMessage(
+        text="Response",
+        images=[image],
+        audios=[],
+        message_author="ai",
+        communication_id=HRIMessage.generate_communication_id(),
+        seq_no=0,
+        seq_end=True,
+    )
+    langchain_message = message.to_langchain()
+    assert isinstance(langchain_message, AIMultimodalMessage)
+    assert langchain_message.images is not None
+    assert len(langchain_message.images) == 1
+
+
+def test_to_langchain_ai_with_audio_still_unsupported(image, audio):
+    """Audio on MultimodalMessage remains unsupported until issue #370."""
     message = HRIMessage(
         text="Response",
         images=[image],
@@ -92,16 +112,10 @@ def test_to_langchain_ai_multimodal(image, audio):
         seq_no=0,
         seq_end=True,
     )
-
-    with pytest.raises(
-        ValueError
-    ):  # NOTE: update when https://github.com/RobotecAI/rai/issues/370 is resolved
+    with pytest.raises(ValueError, match="Audio is not yet supported"):
         _ = message.to_langchain()
 
-    # assert isinstance(langchain_message, AIMultimodalMessage)
-    # assert langchain_message.content == "Response"
-    # assert langchain_message.images == ["img"]
-    # assert langchain_message.audios == ["audio"]
+
 
 
 def test_from_langchain_human():


### PR DESCRIPTION
Image-only AI `HRIMessage.to_langchain()` failed because the AI branch set `audios=base64_images` instead of `base64_audios`, tripping MultimodalMessage's audio gate. Human branch already correct.

Tests cover images-only success and image+audio still unsupported until #370.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->