### PR TITLE
fix(agents): require positive HRICallbackHandler max_buffer_size

### DIFF
--- a/src/rai_core/rai/agents/langchain/callback.py
+++ b/src/rai_core/rai/agents/langchain/callback.py
@@ -39,6 +39,10 @@ class HRICallbackHandler(BaseCallbackHandler):
         self.stream_response = stream_response
         self.splitting_chars = splitting_chars or ["\n", ".", "!", "?"]
         self.chunks_buffer = ""
+        if not isinstance(max_buffer_size, int) or isinstance(max_buffer_size, bool):
+            raise ValueError("max_buffer_size must be a positive int")
+        if max_buffer_size <= 0:
+            raise ValueError("max_buffer_size must be a positive int")
         self.max_buffer_size = max_buffer_size
         self._buffer_lock = threading.Lock()
         self.logger = logger or logging.getLogger(__name__)

--- a/tests/agents/langchain/test_hri_callback_max_buffer.py
+++ b/tests/agents/langchain/test_hri_callback_max_buffer.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Robotec.AI
+import pytest
+
+from rai.agents.langchain.callback import HRICallbackHandler
+
+
+def test_hri_callback_rejects_non_positive_max_buffer_size():
+    with pytest.raises(ValueError, match="max_buffer_size"):
+        HRICallbackHandler(connectors={}, max_buffer_size=0)
+    with pytest.raises(ValueError, match="max_buffer_size"):
+        HRICallbackHandler(connectors={}, max_buffer_size=-5)
+    with pytest.raises(ValueError, match="max_buffer_size"):
+        HRICallbackHandler(connectors={}, max_buffer_size=True)  # type: ignore[arg-type]
+
+
+def test_hri_callback_accepts_positive_max_buffer_size():
+    h = HRICallbackHandler(connectors={}, max_buffer_size=16)
+    assert h.max_buffer_size == 16


### PR DESCRIPTION
Chunk aggregation buffer length must be a positive int so streaming never uses a dead zero/negative cap.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->