### PR TITLE
fix(ros2): reject non-positive waiters time_interval

### DIFF
--- a/src/rai_core/rai/communication/ros2/waiters.py
+++ b/src/rai_core/rai/communication/ros2/waiters.py
@@ -46,6 +46,8 @@ def wait_for_ros2_entities(
 
     if timeout < 0:
         raise ValueError("Timeout must be 0 (wait forever) or a positive value.")
+    if time_interval <= 0:
+        raise ValueError("time_interval must be positive.")
     start_time = time.time()
 
     while timeout == 0 or time.time() - start_time < timeout:

--- a/tests/communication/ros2/test_waiters.py
+++ b/tests/communication/ros2/test_waiters.py
@@ -168,3 +168,17 @@ def test_wait_for_ros2_entities_negative_timeout():
             get_entities=lambda: [],
             timeout=-1,
         )
+
+
+def test_wait_for_entities_rejects_non_positive_time_interval():
+    import pytest
+    from rai.communication.ros2 import waiters
+
+    with pytest.raises(ValueError, match="time_interval"):
+        waiters.wait_for_ros2_entities(
+            ["/x"], lambda: [], time_interval=0, timeout=1.0
+        )
+    with pytest.raises(ValueError, match="time_interval"):
+        waiters.wait_for_ros2_entities(
+            ["/x"], lambda: [], time_interval=-0.5, timeout=1.0
+        )


### PR DESCRIPTION
Poll interval must be > 0. Timeout may still be 0 for wait-forever.

`pytest tests/communication/ros2/test_waiters.py`

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->