### PR TITLE
fix(s2s): validate SoundDeviceConfig block_size and channels

### DIFF
--- a/src/rai_s2s/rai_s2s/sound_device/api.py
+++ b/src/rai_s2s/rai_s2s/sound_device/api.py
@@ -79,6 +79,18 @@ class SoundDeviceConfig:
             raise ValueError("Either 'device_number' or 'device_name' must be set.")
         if not self.is_input and not self.is_output:
             raise ValueError("Either 'is_input' or 'is_output' must be True.")
+        if not isinstance(self.block_size, int) or isinstance(self.block_size, bool) or self.block_size <= 0:
+            raise ValueError("block_size must be a positive integer.")
+        if self.channels is not None:
+            if not isinstance(self.channels, int) or isinstance(self.channels, bool) or self.channels <= 0:
+                raise ValueError("channels must be a positive integer when set.")
+        if self.consumer_sampling_rate is not None:
+            if (
+                not isinstance(self.consumer_sampling_rate, int)
+                or isinstance(self.consumer_sampling_rate, bool)
+                or self.consumer_sampling_rate <= 0
+            ):
+                raise ValueError("consumer_sampling_rate must be a positive integer when set.")
 
 
 class SoundDeviceAPI:

--- a/tests/communication/sounds_device/test_api.py
+++ b/tests/communication/sounds_device/test_api.py
@@ -299,3 +299,21 @@ def test_close_read_stream(input_device_id, mock_sd, has_stream):
         assert api.in_stream is None
     else:
         api.close_read_stream()  # Should not raise an error
+
+
+def test_config_rejects_non_positive_block_size():
+    from rai_s2s.sound_device.api import SoundDeviceConfig
+    import pytest
+
+    with pytest.raises(ValueError, match="block_size"):
+        SoundDeviceConfig(device_number=0, is_input=True, block_size=0)
+    with pytest.raises(ValueError, match="block_size"):
+        SoundDeviceConfig(device_number=0, is_input=True, block_size=-8)
+
+
+def test_config_rejects_non_positive_channels():
+    from rai_s2s.sound_device.api import SoundDeviceConfig
+    import pytest
+
+    with pytest.raises(ValueError, match="channels"):
+        SoundDeviceConfig(device_number=0, is_input=True, channels=0)


### PR DESCRIPTION
Positive ints for block_size; channels and consumer_sampling_rate when set.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->