### PR TITLE
fix(s2s): validate BaseTranscriptionModel sample_rate and names

### DIFF
--- a/src/rai_s2s/rai_s2s/asr/models/base.py
+++ b/src/rai_s2s/rai_s2s/asr/models/base.py
@@ -131,6 +131,12 @@ class BaseTranscriptionModel(ABC):
         language : str, optional
             The language of the transcription output. Default is "en" (English).
         """
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise ValueError("model_name must be a non-empty string.")
+        if not isinstance(sample_rate, int) or isinstance(sample_rate, bool) or sample_rate <= 0:
+            raise ValueError("sample_rate must be a positive integer.")
+        if not isinstance(language, str) or not language.strip():
+            raise ValueError("language must be a non-empty string.")
         self.model_name = model_name
         self.sample_rate = sample_rate
         self.language = language

--- a/tests/s2s/test_base_transcription_params.py
+++ b/tests/s2s/test_base_transcription_params.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2026
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+BASE = ROOT / "src/rai_s2s/rai_s2s/asr/models/base.py"
+
+
+def _load_base():
+    sys.modules.setdefault("numpy", MagicMock())
+    sys.modules.setdefault("numpy.typing", MagicMock())
+    for name in ["rai_s2s", "rai_s2s.asr", "rai_s2s.asr.models"]:
+        sys.modules.setdefault(name, MagicMock())
+    spec = importlib.util.spec_from_file_location("rai_s2s.asr.models.base", BASE)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_base_transcription_rejects_bad_sample_rate():
+    mod = _load_base()
+
+    class Dummy(mod.BaseTranscriptionModel):
+        def transcribe(self, data):
+            return ""
+
+    with pytest.raises(ValueError, match="sample_rate"):
+        Dummy("m", 0)
+    with pytest.raises(ValueError, match="sample_rate"):
+        Dummy("m", -16000)
+    with pytest.raises(ValueError, match="model_name"):
+        Dummy("  ", 16000)
+    with pytest.raises(ValueError, match="language"):
+        Dummy("m", 16000, language="")

--- a/tests/s2s/test_base_transcription_params.py
+++ b/tests/s2s/test_base_transcription_params.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2026
 import importlib.util
 import sys
+import types
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,11 +11,23 @@ BASE = ROOT / "src/rai_s2s/rai_s2s/asr/models/base.py"
 
 
 def _load_base():
-    sys.modules.setdefault("numpy", MagicMock())
-    sys.modules.setdefault("numpy.typing", MagicMock())
+    # Prefer real numpy; otherwise install minimal package stubs with _typing.
+    try:
+        import numpy  # noqa: F401
+    except Exception:
+        np = types.ModuleType("numpy")
+        npt = types.ModuleType("numpy.typing")
+        npt.NDArray = object
+        sys.modules["numpy"] = np
+        sys.modules["numpy.typing"] = npt
+        # package mark
+        np.__path__ = []  # type: ignore
     for name in ["rai_s2s", "rai_s2s.asr", "rai_s2s.asr.models"]:
-        sys.modules.setdefault(name, MagicMock())
-    spec = importlib.util.spec_from_file_location("rai_s2s.asr.models.base", BASE)
+        if name not in sys.modules:
+            m = types.ModuleType(name)
+            m.__path__ = []  # type: ignore
+            sys.modules[name] = m
+    spec = importlib.util.spec_from_file_location("rai_s2s_asr_models_base_under_test", BASE)
     mod = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
     spec.loader.exec_module(mod)


### PR DESCRIPTION
Guard Whisper/ASR base ctor against non-positive sample rates and blank names.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->