### PR TITLE
fix(frontend): read transcription_model key consistently in ASR config UI

### DIFF
--- a/src/rai_core/rai/frontend/configurator.py
+++ b/src/rai_core/rai/frontend/configurator.py
@@ -467,7 +467,7 @@ def asr():
 
     # Get the current vendor from config and convert to display name
     current_vendor = st.session_state.config.get("asr", {}).get(
-        "transciption_model", TRANSCRIBE_MODELS[0]
+        "transcription_model", TRANSCRIBE_MODELS[0]
     )
 
     asr_vendor = st.selectbox(

--- a/tests/frontend/test_configurator_asr_key.py
+++ b/tests/frontend/test_configurator_asr_key.py
@@ -1,0 +1,8 @@
+"""Regression: ASR vendor select must read the same config key the on_change writer uses."""
+from pathlib import Path
+
+def test_configurator_reads_transcription_model_key():
+    text = Path("src/rai_core/rai/frontend/configurator.py").read_text()
+    assert "\"transciption_model\"" not in text
+    assert "config[\"asr\"][\"transcription_model\"]" in text
+    assert "\"transcription_model\", TRANSCRIBE_MODELS[0]" in text


### PR DESCRIPTION
The ASR vendor selectbox read typo key `transciption_model` while `on_asr_vendor_change` writes `transcription_model`, so a saved vendor could be ignored on reload.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
