### PR TITLE
fix(bench): reject non-positive PlaceCubesTask threshold_distance

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/tasks/place_cubes_task.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/tasks/place_cubes_task.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 from typing import Sequence, Tuple, Union
 
 from rclpy.impl.rcutils_logger import RcutilsLogger
@@ -43,6 +44,11 @@ class PlaceCubesTask(ManipulationTask):
             Defaults to 0.15.
         """
         super().__init__(logger)
+        if not math.isfinite(threshold_distance) or threshold_distance <= 0:
+            raise ValueError(
+                "threshold_distance must be a finite number greater than 0, "
+                f"got {threshold_distance!r}"
+            )
         self.threshold_distance = threshold_distance
 
     @property

--- a/tests/rai_bench/manipulation_o3de/tasks/test_place_cubes_task.py
+++ b/tests/rai_bench/manipulation_o3de/tasks/test_place_cubes_task.py
@@ -59,3 +59,15 @@ def test_calculate_2_clusters_adjacent() -> None:
     correct, incorrect = task.calculate_correct([e1, e2, e3, e4])
     assert correct == 4
     assert incorrect == 0
+
+import math
+import pytest
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [0, -0.1, float("nan"), float("inf"), float("-inf")],
+)
+def test_place_cubes_task_rejects_non_positive_threshold(bad):
+    with pytest.raises(ValueError, match="threshold_distance"):
+        PlaceCubesTask(threshold_distance=bad)


### PR DESCRIPTION
Require finite `threshold_distance` > 0 in PlaceCubesTask so adjacency scoring cannot run with zero/NaN distance.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
