### PR TITLE
fix(bench): validate GroupObjectsTask threshold and obj_types

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/tasks/group_objects_task.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/tasks/group_objects_task.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 from typing import List, Sequence, Tuple, Union
 
 from rclpy.impl.rcutils_logger import RcutilsLogger
@@ -44,6 +45,13 @@ class GroupObjectsTask(ManipulationTask):
             when building the neighbourhood list. Defaults to 0.15.
         """
         super().__init__(logger)
+        if not obj_types:
+            raise ValueError("obj_types must be a non-empty list")
+        if not math.isfinite(threshold_distance) or threshold_distance <= 0:
+            raise ValueError(
+                "threshold_distance must be a finite number greater than 0, "
+                f"got {threshold_distance!r}"
+            )
         self.obj_types = obj_types
         self.threshold_distance = threshold_distance
 

--- a/tests/rai_bench/manipulation_o3de/tasks/test_group_objects_task.py
+++ b/tests/rai_bench/manipulation_o3de/tasks/test_group_objects_task.py
@@ -115,3 +115,17 @@ def test_calculate_no_specified_objects() -> None:
 
     assert correct == 0
     assert misclustered == 0
+
+
+import pytest
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, float("nan"), float("inf")])
+def test_group_objects_rejects_bad_threshold(bad):
+    with pytest.raises(ValueError, match="threshold_distance"):
+        GroupObjectsTask(obj_types=["red_cube"], threshold_distance=bad)
+
+
+def test_group_objects_rejects_empty_obj_types():
+    with pytest.raises(ValueError, match="obj_types"):
+        GroupObjectsTask(obj_types=[], threshold_distance=0.15)


### PR DESCRIPTION
Reject empty `obj_types` and non-positive/non-finite `threshold_distance` in GroupObjectsTask before clustering.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
