### PR TITLE
fix(s2s): reject non-positive TTSModel sample_rate and channels

### DIFF
--- a/src/rai_s2s/rai_s2s/tts/models/base.py
+++ b/src/rai_s2s/rai_s2s/tts/models/base.py
@@ -35,6 +35,12 @@ class TTSModel(ABC):
         pass
 
     def set_tts_params(self, target_sample_rate: int, channels: int):
+        if not isinstance(target_sample_rate, int) or isinstance(target_sample_rate, bool) or target_sample_rate <= 0:
+            raise ValueError(
+                f"target_sample_rate must be a positive int, got {target_sample_rate!r}"
+            )
+        if not isinstance(channels, int) or isinstance(channels, bool) or channels <= 0:
+            raise ValueError(f"channels must be a positive int, got {channels!r}")
         self.sample_rate = target_sample_rate
         self.channels = channels
 

--- a/tests/s2s/test_tts_set_params.py
+++ b/tests/s2s/test_tts_set_params.py
@@ -1,0 +1,32 @@
+import pytest
+from typing import Tuple
+
+from rai_s2s.tts.models.base import TTSModel
+
+
+class _DummyTTS(TTSModel):
+    def get_speech(self, text: str):
+        raise NotImplementedError
+
+    def get_tts_params(self) -> Tuple[int, int]:
+        return self.sample_rate, self.channels
+
+
+def test_set_tts_params_accepts_positive():
+    m = _DummyTTS()
+    m.set_tts_params(16000, 1)
+    assert m.get_tts_params() == (16000, 1)
+
+
+@pytest.mark.parametrize("rate", [0, -1])
+def test_set_tts_params_rejects_bad_rate(rate):
+    m = _DummyTTS()
+    with pytest.raises(ValueError, match="target_sample_rate"):
+        m.set_tts_params(rate, 1)
+
+
+@pytest.mark.parametrize("channels", [0, -2])
+def test_set_tts_params_rejects_bad_channels(channels):
+    m = _DummyTTS()
+    with pytest.raises(ValueError, match="channels"):
+        m.set_tts_params(16000, channels)


### PR DESCRIPTION
Validate `TTSModel.set_tts_params` so sample_rate and channels must be positive ints before resampling.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
