### PR TITLE
fix(bench): reject empty MoveObjectsToLeftTask obj_types

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/tasks/move_object_to_left_task.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/tasks/move_object_to_left_task.py
@@ -35,7 +35,11 @@ class MoveObjectsToLeftTask(ManipulationTask):
             A list of object types to be moved.
         """
         super().__init__(logger=logger)
-        self.obj_types = obj_types
+        if not obj_types:
+            raise ValueError("obj_types must be a non-empty list")
+        if not all(isinstance(x, str) and x.strip() for x in obj_types):
+            raise ValueError("obj_types must contain non-empty strings")
+        self.obj_types = list(obj_types)
 
     @property
     def task_prompt(self) -> str:

--- a/tests/rai_bench/manipulation_o3de/tasks/test_move_to_left_task.py
+++ b/tests/rai_bench/manipulation_o3de/tasks/test_move_to_left_task.py
@@ -43,3 +43,15 @@ def test_calculate_other_types() -> None:
     correct, incorrect = task.calculate_correct([e1, e2])
     assert correct == 1
     assert incorrect == 0
+
+import pytest
+
+
+def test_reject_empty_obj_types() -> None:
+    with pytest.raises(ValueError):
+        MoveObjectsToLeftTask([])
+
+
+def test_reject_blank_obj_type() -> None:
+    with pytest.raises(ValueError):
+        MoveObjectsToLeftTask(["red_cube", "  "])


### PR DESCRIPTION
Reject empty/blank obj_types lists for MoveObjectsToLeftTask at construction.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
