### PR TITLE
fix(bench): validate BuildCubeTowerTask obj_types and displacement

### DIFF
--- a/src/rai_bench/rai_bench/manipulation_o3de/tasks/build_tower_task.py
+++ b/src/rai_bench/rai_bench/manipulation_o3de/tasks/build_tower_task.py
@@ -63,6 +63,12 @@ class BuildCubeTowerTask(ManipulationTask):
         # we could check the z distance between entities
         # or trust user with this
         super().__init__(logger)
+        if not obj_types:
+            raise ValueError("obj_types must be a non-empty list")
+        if allowable_displacement <= 0:
+            raise ValueError(
+                f"allowable_displacement must be positive, got {allowable_displacement}"
+            )
         if not set(obj_types).issubset(self.ALLOWED_OBJECTS):
             raise TypeError(
                 f"Invalid obj_types provided: {obj_types}. Allowed objects: {self.ALLOWED_OBJECTS}"

--- a/tests/rai_bench/manipulation_o3de/tasks/test_build_tower_task.py
+++ b/tests/rai_bench/manipulation_o3de/tasks/test_build_tower_task.py
@@ -79,6 +79,18 @@ def test_too_big_displacement() -> None:
         BuildCubeTowerTask(["red_cube"], allowable_displacement=0.1)
 
 
+def test_empty_obj_types_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        BuildCubeTowerTask([])
+
+
+def test_non_positive_allowable_displacement_raises() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        BuildCubeTowerTask(["red_cube"], allowable_displacement=0.0)
+    with pytest.raises(ValueError, match="positive"):
+        BuildCubeTowerTask(["red_cube"], allowable_displacement=-0.01)
+
+
 def test_not_allowable_type() -> None:
     with pytest.raises(TypeError):
         BuildCubeTowerTask(["red_cube", "apple"], allowable_displacement=0.1)


### PR DESCRIPTION
Reject empty obj_types and non-positive allowable_displacement on BuildCubeTowerTask; add unit tests.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->