### PR TITLE
fix: @Bartok9 contributions (batch 2)

### DIFF
--- a/src/rai_core/pyproject.toml
+++ b/src/rai_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_core"
-version = "2.12.2"
+version = "2.12.3"
 description = "Core functionality for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_core/rai/agents/langchain/core/tool_runner.py
+++ b/src/rai_core/rai/agents/langchain/core/tool_runner.py
@@ -73,9 +73,20 @@ class ToolRunner(RunnableCallable):
             self.logger.info(f"Running tool: {call['name']}, args: {call['args']}")
             artifact = None
 
+            tool = self.tools_by_name.get(call["name"])
+            if tool is None:
+                error_message = f'Unknown tool: "{call["name"]}"'
+                self.logger.info(error_message)
+                return ToolMessage(
+                    content=error_message,
+                    name=call["name"],
+                    tool_call_id=call["id"],
+                    status="error",
+                )
+
             try:
                 ts = time.perf_counter()
-                output = self.tools_by_name[call["name"]].invoke(call, config)  # type: ignore
+                output = tool.invoke(call, config)  # type: ignore
                 te = time.perf_counter() - ts
                 self.logger.info(
                     f"Tool {call['name']} completed in {te:.2f} seconds. Tool output: {str(output.content)[:100]}{'...' if len(str(output.content)) > 100 else ''}"

--- a/src/rai_core/rai/communication/hri_connector.py
+++ b/src/rai_core/rai/communication/hri_connector.py
@@ -92,7 +92,7 @@ class HRIMessage(BaseMessage):
                 if self.images == [] and self.audios == []:
                     return AIMessage(content=self.text)
                 return AIMultimodalMessage(
-                    content=self.text, images=base64_images, audios=base64_images
+                    content=self.text, images=base64_images, audios=base64_audios
                 )
             case _:
                 raise ValueError(

--- a/src/rai_core/rai/frontend/configurator.py
+++ b/src/rai_core/rai/frontend/configurator.py
@@ -467,7 +467,7 @@ def asr():
 
     # Get the current vendor from config and convert to display name
     current_vendor = st.session_state.config.get("asr", {}).get(
-        "transciption_model", TRANSCRIBE_MODELS[0]
+        "transcription_model", TRANSCRIBE_MODELS[0]
     )
 
     asr_vendor = st.selectbox(

--- a/src/rai_core/rai/messages/artifacts.py
+++ b/src/rai_core/rai/messages/artifacts.py
@@ -28,6 +28,7 @@ def store_artifacts(
     # TODO(boczekbartek): refactor
     path = Path(db_path)
     if not path.is_file():
+        path.parent.mkdir(parents=True, exist_ok=True)
         artifact_database: dict = {}
         with path.open("wb") as file:
             pickle.dump(artifact_database, file)

--- a/src/rai_core/rai/tools/ros2/generic/actions.py
+++ b/src/rai_core/rai/tools/ros2/generic/actions.py
@@ -150,8 +150,10 @@ class GetROS2ActionsNamesAndTypesTool(BaseROS2Tool):
 
 
 class StartROS2ActionToolInput(BaseModel):
-    action_name: str = Field(..., description="The name of the action to start")
-    action_type: str = Field(..., description="The type of the action")
+    action_name: str = Field(
+        ..., min_length=1, description="The name of the action to start"
+    )
+    action_type: str = Field(..., min_length=1, description="The type of the action")
     action_args: Dict[str, Any] = Field(
         ..., description="The arguments to pass to the action"
     )

--- a/src/rai_core/rai/tools/ros2/generic/services.py
+++ b/src/rai_core/rai/tools/ros2/generic/services.py
@@ -83,14 +83,15 @@ class GetROS2ServicesNamesAndTypesTool(BaseROS2Tool):
 
 
 class CallROS2ServiceToolInput(BaseModel):
-    service_name: str = Field(description="The service to call")
-    service_type: str = Field(description="The type of the service")
+    service_name: str = Field(min_length=1, description="The service to call")
+    service_type: str = Field(min_length=1, description="The type of the service")
     service_args: Optional[Dict[str, Any]] = Field(
         default={},
         description="A dictionary mapping each field name of the service request message to its value. For example, for std_srvs/srv/SetBool use {'data': True}.",
     )
     timeout_sec: float = Field(
         default=5.0,
+        gt=0,
         description="The timeout for the service call in seconds",
     )
 

--- a/src/rai_core/rai/tools/ros2/generic/topics.py
+++ b/src/rai_core/rai/tools/ros2/generic/topics.py
@@ -77,9 +77,11 @@ class ROS2TopicsToolkit(BaseROS2Toolkit):
 
 
 class PublishROS2MessageToolInput(BaseModel):
-    topic: str = Field(..., description="The topic to publish the message to")
+    topic: str = Field(
+        ..., min_length=1, description="The topic to publish the message to"
+    )
     message: Dict[str, Any] = Field(..., description="The message to publish")
-    message_type: str = Field(..., description="The type of the message")
+    message_type: str = Field(..., min_length=1, description="The type of the message")
 
 
 class PublishROS2MessageTool(BaseROS2Tool):
@@ -99,8 +101,10 @@ class PublishROS2MessageTool(BaseROS2Tool):
 
 
 class ReceiveROS2MessageToolInput(BaseModel):
-    topic: str = Field(..., description="The topic to receive the message from")
-    timeout_sec: float = Field(1.0, description="The timeout in seconds")
+    topic: str = Field(
+        ..., min_length=1, description="The topic to receive the message from"
+    )
+    timeout_sec: float = Field(1.0, gt=0, description="The timeout in seconds")
 
 
 class ReceiveROS2MessageTool(BaseROS2Tool):
@@ -117,8 +121,10 @@ class ReceiveROS2MessageTool(BaseROS2Tool):
 
 
 class GetROS2ImageToolInput(BaseModel):
-    topic: str = Field(..., description="The topic to receive the image from")
-    timeout_sec: float = Field(1.0, description="The timeout in seconds")
+    topic: str = Field(
+        ..., min_length=1, description="The topic to receive the image from"
+    )
+    timeout_sec: float = Field(1.0, gt=0, description="The timeout in seconds")
 
 
 class GetROS2ImageTool(BaseROS2Tool):
@@ -249,9 +255,9 @@ class GetROS2MessageInterfaceTool(BaseROS2Tool):
 
 
 class GetROS2TransformToolInput(BaseModel):
-    target_frame: str = Field(..., description="The target frame")
-    source_frame: str = Field(..., description="The source frame")
-    timeout_sec: float = Field(default=10.0, description="The timeout in seconds")
+    target_frame: str = Field(..., min_length=1, description="The target frame")
+    source_frame: str = Field(..., min_length=1, description="The source frame")
+    timeout_sec: float = Field(default=10.0, gt=0, description="The timeout in seconds")
 
 
 class GetROS2TransformTool(BaseROS2Tool):

--- a/src/rai_core/rai/tools/ros2/navigation/nav2.py
+++ b/src/rai_core/rai/tools/ros2/navigation/nav2.py
@@ -58,10 +58,18 @@ class Nav2Toolkit(BaseROS2Toolkit):
 
 
 class NavigateToPoseToolInput(BaseModel):
-    x: float = Field(..., description="The x coordinate of the pose")
-    y: float = Field(..., description="The y coordinate of the pose")
-    z: float = Field(..., description="The z coordinate of the pose")
-    yaw: float = Field(..., description="The yaw angle of the pose")
+    x: float = Field(
+        ..., allow_inf_nan=False, description="The x coordinate of the pose"
+    )
+    y: float = Field(
+        ..., allow_inf_nan=False, description="The y coordinate of the pose"
+    )
+    z: float = Field(
+        ..., allow_inf_nan=False, description="The z coordinate of the pose"
+    )
+    yaw: float = Field(
+        ..., allow_inf_nan=False, description="The yaw angle of the pose"
+    )
 
 
 class NavigateToPoseTool(BaseROS2Tool):

--- a/src/rai_core/rai/tools/ros2/simple.py
+++ b/src/rai_core/rai/tools/ros2/simple.py
@@ -35,8 +35,8 @@ class GetROS2ImageConfiguredTool(BaseROS2Tool):
     description: str = "Get the current image from the camera"
     response_format: Literal["content", "content_and_artifact"] = "content_and_artifact"
 
-    topic: str = Field(..., description="The topic to get the image from")
-    timeout_sec: float = Field(default=5.0, description="The timeout in seconds")
+    topic: str = Field(..., min_length=1, description="The topic to get the image from")
+    timeout_sec: float = Field(default=5.0, gt=0, description="The timeout in seconds")
 
     def model_post_init(self, __context: Any) -> None:
         if not self.is_readable(topic=self.topic):
@@ -53,9 +53,9 @@ class GetROS2TransformConfiguredTool(BaseROS2Tool):
     name: str = "get_ros2_robot_position"
     description: str = "Get the robot's position"
 
-    source_frame: str = Field(..., description="The source frame")
-    target_frame: str = Field(..., description="The target frame")
-    timeout_sec: float = Field(default=10.0, description="The timeout in seconds")
+    source_frame: str = Field(..., min_length=1, description="The source frame")
+    target_frame: str = Field(..., min_length=1, description="The target frame")
+    timeout_sec: float = Field(default=10.0, gt=0, description="The timeout in seconds")
 
     def _run(self) -> Any:
         tool = GetROS2TransformTool(

--- a/src/rai_s2s/pyproject.toml
+++ b/src/rai_s2s/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_s2s"
-version = "1.0.0"
+version = "1.0.1"
 description = "Speech-to-Speech module for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_s2s/rai_s2s/asr/agents/initialization.py
+++ b/src/rai_s2s/rai_s2s/asr/agents/initialization.py
@@ -24,6 +24,14 @@ class VADConfig:
     threshold: float = 0.5
     silence_grace_period: float = 0.3
 
+    def __post_init__(self):
+        if not 0.0 < self.threshold <= 1.0:
+            raise ValueError(f"threshold must be in (0, 1], got {self.threshold}")
+        if self.silence_grace_period < 0:
+            raise ValueError(
+                f"silence_grace_period must not be negative, got {self.silence_grace_period}"
+            )
+
 
 @dataclass
 class WWConfig:
@@ -31,6 +39,10 @@ class WWConfig:
     model_type: Literal["OpenWakeWord"] = "OpenWakeWord"
     threshold: float = 0.01
     is_used: bool = False
+
+    def __post_init__(self):
+        if not 0.0 < self.threshold <= 1.0:
+            raise ValueError(f"threshold must be in (0, 1], got {self.threshold}")
 
 
 TRANSCRIBE_MODELS = ["LocalWhisper", "FasterWhisper", "OpenAI"]

--- a/tests/agents/langchain/test_tool_runner.py
+++ b/tests/agents/langchain/test_tool_runner.py
@@ -41,6 +41,7 @@ def test_tool_runner_invalid_call():
         "Tool output is not a tool message"
     )
     assert output["messages"][1].status == "error"
+    assert "Unknown tool" in output["messages"][1].content
 
 
 def test_tool_runner():

--- a/tests/communication/test_hri_message.py
+++ b/tests/communication/test_hri_message.py
@@ -98,10 +98,23 @@ def test_to_langchain_ai_multimodal(image, audio):
     ):  # NOTE: update when https://github.com/RobotecAI/rai/issues/370 is resolved
         _ = message.to_langchain()
 
-    # assert isinstance(langchain_message, AIMultimodalMessage)
-    # assert langchain_message.content == "Response"
-    # assert langchain_message.images == ["img"]
-    # assert langchain_message.audios == ["audio"]
+
+def test_to_langchain_ai_images_only(image):
+    message = HRIMessage(
+        text="Response",
+        images=[image],
+        audios=[],
+        message_author="ai",
+        communication_id=HRIMessage.generate_communication_id(),
+        seq_no=0,
+        seq_end=True,
+    )
+
+    langchain_message = message.to_langchain()
+
+    assert isinstance(langchain_message, RAIMultimodalMessage)
+    assert len(langchain_message.images) == 1
+    assert langchain_message.audios == []
 
 
 def test_from_langchain_human():

--- a/tests/messages/test_artifacts_db_path.py
+++ b/tests/messages/test_artifacts_db_path.py
@@ -28,7 +28,6 @@ def test_store_artifacts_honors_db_path(tmp_path: Path):
 
 
 def test_store_artifacts_creates_file_at_path(tmp_path: Path):
-    db = tmp_path / "nested" / "db.pkl"
-    db.parent.mkdir(parents=True)
+    db = tmp_path / "nested" / "dir" / "db.pkl"
     store_artifacts("x", [1], db_path=str(db))
     assert get_stored_artifacts("x", db_path=str(db)) == [1]

--- a/tests/s2s/test_asr_config.py
+++ b/tests/s2s/test_asr_config.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VAD and wake word thresholds come from config.toml, where an out-of-range
+value silently turns detection permanently on or permanently off."""
+
+import pytest
+
+from rai_s2s.asr.agents.initialization import VADConfig, WWConfig
+
+
+@pytest.mark.parametrize("config_cls", [VADConfig, WWConfig])
+@pytest.mark.parametrize("threshold", [0.0, -0.1, 1.5])
+def test_threshold_out_of_range_rejected(config_cls, threshold):
+    with pytest.raises(ValueError, match="threshold"):
+        config_cls(threshold=threshold)
+
+
+def test_negative_silence_grace_period_rejected():
+    with pytest.raises(ValueError, match="silence_grace_period"):
+        VADConfig(silence_grace_period=-1.0)
+
+
+def test_defaults_are_valid():
+    assert VADConfig().threshold == 0.5
+    assert WWConfig().threshold == 0.01

--- a/tests/tools/ros2/test_input_validation.py
+++ b/tests/tools/ros2/test_input_validation.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool argument constraints are declared on the args_schema, so a model that
+sends an empty topic name, a non-positive timeout or a NaN coordinate gets a
+ValidationError that ToolRunner reports back to it instead of a live call."""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+from rai.tools.ros2.generic.actions import StartROS2ActionToolInput
+from rai.tools.ros2.generic.services import CallROS2ServiceToolInput
+from rai.tools.ros2.generic.topics import (
+    GetROS2ImageToolInput,
+    GetROS2TransformToolInput,
+    PublishROS2MessageToolInput,
+    ReceiveROS2MessageToolInput,
+)
+from rai.tools.ros2.navigation.nav2 import NavigateToPoseToolInput
+
+VALID = {
+    PublishROS2MessageToolInput: dict(
+        topic="/chatter", message={}, message_type="std_msgs/msg/String"
+    ),
+    ReceiveROS2MessageToolInput: dict(topic="/chatter", timeout_sec=1.0),
+    GetROS2ImageToolInput: dict(topic="/camera/image_raw", timeout_sec=1.0),
+    GetROS2TransformToolInput: dict(
+        target_frame="map", source_frame="base_link", timeout_sec=1.0
+    ),
+    CallROS2ServiceToolInput: dict(
+        service_name="/set_bool", service_type="std_srvs/srv/SetBool", timeout_sec=1.0
+    ),
+    StartROS2ActionToolInput: dict(
+        action_name="/navigate",
+        action_type="nav2_msgs/action/NavigateToPose",
+        action_args={},
+    ),
+    NavigateToPoseToolInput: dict(x=1.0, y=2.0, z=0.0, yaw=0.0),
+}
+
+EMPTY_NAME_FIELDS = [
+    (PublishROS2MessageToolInput, "topic"),
+    (PublishROS2MessageToolInput, "message_type"),
+    (ReceiveROS2MessageToolInput, "topic"),
+    (GetROS2ImageToolInput, "topic"),
+    (GetROS2TransformToolInput, "target_frame"),
+    (GetROS2TransformToolInput, "source_frame"),
+    (CallROS2ServiceToolInput, "service_name"),
+    (CallROS2ServiceToolInput, "service_type"),
+    (StartROS2ActionToolInput, "action_name"),
+    (StartROS2ActionToolInput, "action_type"),
+]
+
+TIMEOUT_MODELS = [
+    ReceiveROS2MessageToolInput,
+    GetROS2ImageToolInput,
+    GetROS2TransformToolInput,
+    CallROS2ServiceToolInput,
+]
+
+
+@pytest.mark.parametrize("model", VALID)
+def test_valid_args_accepted(model):
+    model(**VALID[model])
+
+
+@pytest.mark.parametrize("model,field", EMPTY_NAME_FIELDS)
+def test_empty_names_rejected(model, field):
+    with pytest.raises(ValidationError):
+        model(**{**VALID[model], field: ""})
+
+
+@pytest.mark.parametrize("model", TIMEOUT_MODELS)
+@pytest.mark.parametrize("timeout_sec", [0, -1.0])
+def test_non_positive_timeout_rejected(model, timeout_sec):
+    with pytest.raises(ValidationError):
+        model(**{**VALID[model], "timeout_sec": timeout_sec})
+
+
+@pytest.mark.parametrize("field", ["x", "y", "z", "yaw"])
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_non_finite_pose_rejected(field, value):
+    with pytest.raises(ValidationError):
+        NavigateToPoseToolInput(**{**VALID[NavigateToPoseToolInput], field: value})

--- a/uv.lock
+++ b/uv.lock
@@ -4714,7 +4714,7 @@ requires-dist = [
 
 [[package]]
 name = "rai-core"
-version = "2.12.2"
+version = "2.12.3"
 source = { editable = "src/rai_core" }
 dependencies = [
     { name = "coloredlogs" },
@@ -4890,7 +4890,7 @@ requires-dist = [
 
 [[package]]
 name = "rai-s2s"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "src/rai_s2s" }
 dependencies = [
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'x86_64'" },


### PR DESCRIPTION
## Purpose

-   Salvage the second round of open PRs from @Bartok9 (#827 to #869) into one change. Most of them add an imperative guard plus a helper module plus a test file each, around 1400 added lines in total, with five PRs shipping a byte-identical copy of the same helper.

## Proposed Changes

-   Tool argument validation moves to the existing pydantic `args_schema` as `Field(min_length=1)`, `Field(gt=0)` and `Field(allow_inf_nan=False)`. Enforced before `_run`, visible in the schema the model sees, and `ToolRunner` already turns `ValidationError` into a `ToolMessage`. Replaces #827, #828, #829, #831, #832, #833, #834, #835, #836 in ~15 lines with no new modules.
-   `hri_connector.py`: AI multimodal messages passed `base64_images` as `audios`, so images-only messages raised (#847).
-   `configurator.py`: ASR selectbox read `transciption_model` while the handler writes `transcription_model` (#859).
-   `artifacts.py`: `store_artifacts` creates the parent directory for a new `db_path` (#848).
-   `tool_runner.py`: unknown tool names report `Unknown tool` instead of a bare KeyError repr (#853).
-   `VADConfig` and `WWConfig` validate thresholds in `__post_init__`, matching `TranscribeConfig` (#854, #856, #866).
-   Not taken: #855 (our own tests pass `time_interval=0` with `time.sleep` patched), the `rai_bench` task guards (#860, #861, #863, #864, #865, #867, #868, #869) and the remaining `rai_s2s` model guards (#857, #858, #862), which validate parameters only we set, and the `AGENTS.md` hunk in #863.
-   `rai_core` 2.12.3, `rai_s2s` 1.0.1, `uv.lock` regenerated.

## Issues

-   Supersedes #827, #828, #829, #831, #832, #833, #834, #835, #836, #847, #848, #853, #854, #856, #859, #866
-   Closes as already on main via #824: #830, #849, #850, #852
-   Declined: #855, #857, #858, #860, #861, #862, #863, #864, #865, #867, #868, #869
-   #814 touches the same `except` block in `tool_runner.py` and needs a rebase after this lands

## Testing

-   `tests/tools/ros2/test_input_validation.py` covers every schema constraint, `tests/s2s/test_asr_config.py` covers the config guards, and the bug fixes are asserted in the existing test files.
-   `pytest tests/tools tests/agents tests/messages tests/communication tests/s2s`: 343 passed, 4 skipped, 11 xfailed.

Co-authored-by: Bartok <danielrpike9@gmail.com>