### PR TITLE
fix(s2s): dispatch on the transcription model names the config uses

### DIFF
--- a/src/rai_s2s/pyproject.toml
+++ b/src/rai_s2s/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rai_s2s"
-version = "1.0.1"
+version = "1.0.2"
 description = "Speech-to-Speech module for RAI framework"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/rai_s2s/rai_s2s/asr/agents/asr_agent.py
+++ b/src/rai_s2s/rai_s2s/asr/agents/asr_agent.py
@@ -30,7 +30,7 @@ from rai.communication.ros2 import (
 )
 from typing_extensions import Self
 
-from rai_s2s.asr.agents.initialization import load_config
+from rai_s2s.asr.agents.initialization import TRANSCRIBE_MODELS, load_config
 from rai_s2s.asr.models import BaseTranscriptionModel, BaseVoiceDetectionModel
 from rai_s2s.sound_device import (
     SoundDeviceConfig,
@@ -121,32 +121,39 @@ class SpeechRecognitionAgent(BaseAgent):
             is_output=False,
         )
         match cfg.transcribe.model_type:
-            case "LocalWhisper (Free)":
+            case "LocalWhisper":
                 from rai_s2s.asr.models import LocalWhisper
 
                 model = LocalWhisper(
                     cfg.transcribe.model_name, 16000, language=cfg.transcribe.language
                 )
-            case "FasterWhisper (Free)":
+            case "FasterWhisper":
                 from rai_s2s.asr.models import FasterWhisper
 
                 model = FasterWhisper(
                     cfg.transcribe.model_name, 16000, language=cfg.transcribe.language
                 )
-            case "OpenAI (Cloud)":
+            case "OpenAI":
                 from rai_s2s.asr.models import OpenAIWhisper
 
                 model = OpenAIWhisper(
                     cfg.transcribe.model_name, 16000, language=cfg.transcribe.language
                 )
             case _:
-                raise ValueError(f"Unknown model name f{cfg.transcribe.model_name}")
+                raise ValueError(
+                    f"Unknown transcription model: {cfg.transcribe.model_type}. "
+                    f"Must be one of {TRANSCRIBE_MODELS}"
+                )
 
         match cfg.voice_activity_detection.model_name:
             case "SileroVAD":
                 from rai_s2s.asr.models import SileroVAD
 
                 vad = SileroVAD(16000, cfg.voice_activity_detection.threshold)
+            case _:
+                raise ValueError(
+                    f"Unknown VAD model: {cfg.voice_activity_detection.model_name}"
+                )
 
         agent = cls(microphone_configuration, "rai_auto_asr_agent", model, vad)
         if cfg.wakeword.is_used:

--- a/tests/s2s/test_asr_agent_from_config.py
+++ b/tests/s2s/test_asr_agent_from_config.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""from_config dispatches on config strings, so the values TRANSCRIBE_MODELS
+advertises and the configurator writes have to be the ones it matches on."""
+
+from pathlib import Path
+
+import pytest
+
+from rai_s2s.asr import models
+from rai_s2s.asr.agents.asr_agent import SpeechRecognitionAgent
+from rai_s2s.asr.agents.initialization import TRANSCRIBE_MODELS
+
+CONFIG = """
+[asr]
+recording_device_name = "default"
+transcription_model = "{transcription_model}"
+transcription_model_name = "tiny"
+language = "en"
+vad_model = "{vad_model}"
+vad_threshold = 0.3
+silence_grace_period = 0.3
+use_wake_word = false
+wake_word_model = ""
+wake_word_model_name = ""
+wake_word_threshold = 0.5
+"""
+
+
+@pytest.fixture
+def config(tmp_path: Path):
+    def write(transcription_model: str, vad_model: str = "SileroVAD") -> str:
+        path = tmp_path / "config.toml"
+        path.write_text(
+            CONFIG.format(transcription_model=transcription_model, vad_model=vad_model)
+        )
+        return str(path)
+
+    return write
+
+
+@pytest.fixture(autouse=True)
+def stub_models(monkeypatch):
+    """The dispatch is under test, not the models it reaches for."""
+    for name in ("LocalWhisper", "FasterWhisper", "OpenAIWhisper", "SileroVAD"):
+        monkeypatch.setattr(models, name, lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        SpeechRecognitionAgent, "__init__", lambda self, *args, **kwargs: None
+    )
+
+
+@pytest.mark.parametrize("transcription_model", TRANSCRIBE_MODELS)
+def test_every_advertised_model_is_dispatchable(config, transcription_model):
+    assert isinstance(
+        SpeechRecognitionAgent.from_config(config(transcription_model)),
+        SpeechRecognitionAgent,
+    )
+
+
+def test_unknown_transcription_model_lists_the_valid_ones(config):
+    # the old suffixed spelling is now rejected at config load, not silently
+    # accepted and then dropped by the dispatch below
+    with pytest.raises(ValueError, match="unknown model_type"):
+        SpeechRecognitionAgent.from_config(config("LocalWhisper (Free)"))
+
+
+def test_unknown_vad_model_is_reported(config):
+    with pytest.raises(ValueError, match="Unknown VAD model"):
+        SpeechRecognitionAgent.from_config(
+            config(TRANSCRIBE_MODELS[0], vad_model="NotAVAD")
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4890,7 +4890,7 @@ requires-dist = [
 
 [[package]]
 name = "rai-s2s"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "src/rai_s2s" }
 dependencies = [
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'x86_64'" },


### PR DESCRIPTION
## Purpose

-   `SpeechRecognitionAgent.from_config` cannot load any valid config. It raises for every accepted value of `transcription_model`.

## Proposed Changes

-   The match arms in `asr_agent.py` expected `"LocalWhisper (Free)"`, `"FasterWhisper (Free)"` and `"OpenAI (Cloud)"`, while `TRANSCRIBE_MODELS`, the shipped `config.toml` and the configurator all use the bare names. Anything valid fell through to `case _` and raised. Now matches the bare names, with the error message naming `model_type` and the valid options instead of `model_name` (and without the stray `f` inside the string).
-   Gave the VAD match a default arm. It had none, so an unrecognised `vad_model` left `vad` unbound and came out as an `UnboundLocalError` at construction.
-   `rai_s2s` 1.0.2.

## Issues

-   None filed, found while going through the @Bartok9 PRs in #872.

## Testing

-   `tests/s2s/test_asr_agent_from_config.py` walks `TRANSCRIBE_MODELS` and asserts every advertised value reaches a model, with the models and the agent constructor stubbed so nothing is downloaded or opens a device. Also covers the old suffixed spelling and an unknown `vad_model`.
-   `pytest tests/s2s tests/communication/sounds_device`: 37 passed.